### PR TITLE
fix #1072

### DIFF
--- a/src/style/comment/comment.scss
+++ b/src/style/comment/comment.scss
@@ -176,7 +176,7 @@
           @include icon();
           @include spot-icon();
           @include invert-on-dark();
-          :hover {
+          &:hover {
             opacity: 0.6;
           }
         }

--- a/src/style/comment/comment.scss
+++ b/src/style/comment/comment.scss
@@ -171,13 +171,18 @@
             }
           }
         }
-        .operation .spot {
-          @include transition();
-          @include icon();
-          @include spot-icon();
-          @include invert-on-dark();
-          &:hover {
-            opacity: 0.6;
+        .operation{
+          &:hover{
+            background: transparent !important;
+          }
+          .spot {
+            @include transition();
+            @include icon();
+            @include spot-icon();
+            @include invert-on-dark();
+            &:hover {
+              opacity: 0.6;
+            }
           }
         }
       }

--- a/src/style/dark/dark-slice-1.css
+++ b/src/style/dark/dark-slice-1.css
@@ -479,6 +479,7 @@ body,
 font>span,
 .list-item .close .close-icon,
 .bb-comment,
+.bb-comment .comment-list .list-item .info .operation,
 #app,
 .back-top
 {


### PR DESCRIPTION
<!-- 可以参考下代码贡献指南: https://github.com/the1812/Bilibili-Evolved/blob/preview/CONTRIBUTING.md -->

- 现在鼠标挪动到评论的 spot 上会有透明度过渡效果（嗯，貌似是手滑写漏一个 & 导致的）
- 现在评论区的 operation 类的元素背景颜色被设为透明（虽然有点偷懒，但是能用，而且和官方的效果比要和谐一些）
