### PR TITLE
记忆自定义标题栏收藏列表所选项

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -25,6 +25,7 @@
         "Swiper",
         "Violentmonkey",
         "Vuex",
+        "Watchlater",
         "afterbegin",
         "afterend",
         "bili",

--- a/@types/global/index.d.ts
+++ b/@types/global/index.d.ts
@@ -504,6 +504,7 @@ declare global {
     downloadPackageEmitMode: '打包下载' | '分别下载',
     latestVersionLink: string,
     currentVersion: string,
+    favoritesListCurrentSelect: string,
   }
   const GM_info: MonkeyInfo
   function GM_xmlhttpRequest(details: MonkeyXhrDetails): { abort: () => void }

--- a/src/client/settings.js
+++ b/src/client/settings.js
@@ -250,6 +250,7 @@ export const settings = {
   columnImageExporter: false,
   downloadPackageEmitMode: '打包下载',
   cache: {},
+  favoritesListCurrentSelect: ''
 }
 const fixedSettings = {
   useDefaultVideoQuality: false,

--- a/src/style/custom-navbar/favorites-list/custom-navbar-favorites-list.ts
+++ b/src/style/custom-navbar/favorites-list/custom-navbar-favorites-list.ts
@@ -118,6 +118,9 @@ export class FavoritesList extends NavbarComponent {
           })
           this.searchAllList()
         },
+        selectedListName(name: string) {
+          settings.favoritesListCurrentSelect = name
+        },
       },
       computed: {
         listNames() {
@@ -232,7 +235,11 @@ export class FavoritesList extends NavbarComponent {
             } as ListInfo
           })
           if (this.list.length > 0) {
-            this.selectedListName = this.list[0].name
+            if (settings.favoritesListCurrentSelect && this.list.some((item: ListInfo) => item.name === settings.favoritesListCurrentSelect)) {
+              this.selectedListName = settings.favoritesListCurrentSelect
+            } else {
+              this.selectedListName = this.list[0].name
+            }
             this.changeList()
           }
         } catch (error) {


### PR DESCRIPTION
<!-- 可以参考下代码贡献指南: https://github.com/the1812/Bilibili-Evolved/blob/preview/CONTRIBUTING.md -->

以前一直想吐槽的一点，这个收藏列表所选项在跨页面时是不记忆的，如果在收藏列表里打开了某个收藏夹里的视频，又想要在那个视频页面打开同一收藏夹下的其它视频就又得翻一次收藏夹列表，十分不便

这个 pr 改进了这一点，把相关项存储在设置中，这样哪怕关闭浏览器在打开也会直接显示上次所选的收藏夹