### PR TITLE
「默认播放速度」功能改进

### DIFF
--- a/src/client/resource-manifest.js
+++ b/src/client/resource-manifest.js
@@ -681,12 +681,7 @@ Resource.manifest = {
   useDefaultVideoSpeed: {
     path: 'default-video-speed.min.js',
     displayNames: {
-      useDefaultVideoSpeed: '记忆播放速度',
-      defaultVideoSpeed: '默认播放速度',
-    },
-    dropdown: {
-      key: 'defaultVideoSpeed',
-      items: ['0.5', '0.75', '1.0', '1.25', '1.5', '2.0'],
+      useDefaultVideoSpeed: '记忆上次播放速度',
     }
   },
   seedsToCoins: {

--- a/src/client/resource-manifest.js
+++ b/src/client/resource-manifest.js
@@ -681,7 +681,7 @@ Resource.manifest = {
   useDefaultVideoSpeed: {
     path: 'default-video-speed.min.js',
     displayNames: {
-      useDefaultVideoSpeed: '使用默认播放速度',
+      useDefaultVideoSpeed: '记忆播放速度',
       defaultVideoSpeed: '默认播放速度',
     },
     dropdown: {

--- a/src/client/settings.js
+++ b/src/client/settings.js
@@ -249,6 +249,8 @@ export const settings = {
   cache: {},
   favoritesListCurrentSelect: '',
   defaultVideoSpeedList: {},
+  rememberVideoSpeed: false,
+  latestVideoSpeed: 1,
 }
 const fixedSettings = {
   useDefaultDanmakuSettings: false,

--- a/src/client/settings.js
+++ b/src/client/settings.js
@@ -247,7 +247,17 @@ export const settings = {
   homeHidden: false,
   homeHiddenItems: [],
   cache: {},
-  favoritesListCurrentSelect: ''
+  favoritesListCurrentSelect: '',
+  defaultVideoSpeedList: {
+    [0.5]: [],
+    [0.75]: [],
+    [1.0]: [],
+    [1.25]: [],
+    [1.5]: [],
+    [2.0]: [],
+    [2.5]: [],
+    [3.0]: [],
+  },
 }
 const fixedSettings = {
   useDefaultDanmakuSettings: false,

--- a/src/client/settings.js
+++ b/src/client/settings.js
@@ -251,6 +251,7 @@ export const settings = {
   defaultVideoSpeedList: {},
   rememberVideoSpeed: false,
   latestVideoSpeed: 1,
+  extendVideoSpeed: false,
 }
 const fixedSettings = {
   useDefaultDanmakuSettings: false,

--- a/src/client/settings.js
+++ b/src/client/settings.js
@@ -247,8 +247,7 @@ export const settings = {
   homeHidden: false,
   homeHiddenItems: [],
   cache: {},
-  favoritesListCurrentSelect: '',
-  defaultVideoSpeedBlacklist: [],
+  favoritesListCurrentSelect: ''
 }
 const fixedSettings = {
   useDefaultDanmakuSettings: false,

--- a/src/client/settings.js
+++ b/src/client/settings.js
@@ -247,7 +247,8 @@ export const settings = {
   homeHidden: false,
   homeHiddenItems: [],
   cache: {},
-  favoritesListCurrentSelect: ''
+  favoritesListCurrentSelect: '',
+  defaultVideoSpeedBlacklist: [],
 }
 const fixedSettings = {
   useDefaultDanmakuSettings: false,

--- a/src/client/settings.js
+++ b/src/client/settings.js
@@ -248,7 +248,7 @@ export const settings = {
   homeHiddenItems: [],
   cache: {},
   favoritesListCurrentSelect: '',
-  defaultVideoSpeedList: {},
+  rememberVideoSpeedList: {},
   rememberVideoSpeed: false,
   extendVideoSpeed: false,
 }

--- a/src/client/settings.js
+++ b/src/client/settings.js
@@ -250,7 +250,6 @@ export const settings = {
   favoritesListCurrentSelect: '',
   defaultVideoSpeedList: {},
   rememberVideoSpeed: false,
-  latestVideoSpeed: 1,
   extendVideoSpeed: false,
 }
 const fixedSettings = {

--- a/src/client/settings.js
+++ b/src/client/settings.js
@@ -248,16 +248,7 @@ export const settings = {
   homeHiddenItems: [],
   cache: {},
   favoritesListCurrentSelect: '',
-  defaultVideoSpeedList: {
-    [0.5]: [],
-    [0.75]: [],
-    [1.0]: [],
-    [1.25]: [],
-    [1.5]: [],
-    [2.0]: [],
-    [2.5]: [],
-    [3.0]: [],
-  },
+  defaultVideoSpeedList: {},
 }
 const fixedSettings = {
   useDefaultDanmakuSettings: false,

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -520,7 +520,7 @@ declare global {
     favoritesListCurrentSelect: string,
     homeHidden: boolean,
     homeHiddenItems: string[],
-    defaultVideoSpeedList: {
+    rememberVideoSpeedList: {
       [index: string]: string[]
     },
     rememberVideoSpeed: boolean,

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -520,6 +520,16 @@ declare global {
     favoritesListCurrentSelect: string,
     homeHidden: boolean,
     homeHiddenItems: string[],
+    defaultVideoSpeedList: {
+      [0.5]: string[],
+      [0.75]: string[],
+      [1.0]: string[],
+      [1.25]: string[],
+      [1.5]: string[],
+      [2.0]: string[],
+      [2.5]: string[],
+      [3.0]: string[],
+    },
   }
   const GM_info: MonkeyInfo
   function GM_xmlhttpRequest(details: MonkeyXhrDetails): { abort: () => void }

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -521,14 +521,7 @@ declare global {
     homeHidden: boolean,
     homeHiddenItems: string[],
     defaultVideoSpeedList: {
-      [0.5]: string[],
-      [0.75]: string[],
-      [1.0]: string[],
-      [1.25]: string[],
-      [1.5]: string[],
-      [2.0]: string[],
-      [2.5]: string[],
-      [3.0]: string[],
+      [index: string]: string[]
     },
   }
   const GM_info: MonkeyInfo

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -524,7 +524,6 @@ declare global {
       [index: string]: string[]
     },
     rememberVideoSpeed: boolean,
-    latestVideoSpeed: number,
     extendVideoSpeed: boolean,
   }
   const GM_info: MonkeyInfo

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -523,6 +523,8 @@ declare global {
     defaultVideoSpeedList: {
       [index: string]: string[]
     },
+    rememberVideoSpeed: boolean,
+    latestVideoSpeed: number,
   }
   const GM_info: MonkeyInfo
   function GM_xmlhttpRequest(details: MonkeyXhrDetails): { abort: () => void }

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -520,6 +520,7 @@ declare global {
     favoritesListCurrentSelect: string,
     homeHidden: boolean,
     homeHiddenItems: string[],
+    defaultVideoSpeedBlacklist: string[],
   }
   const GM_info: MonkeyInfo
   function GM_xmlhttpRequest(details: MonkeyXhrDetails): { abort: () => void }

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -520,7 +520,6 @@ declare global {
     favoritesListCurrentSelect: string,
     homeHidden: boolean,
     homeHiddenItems: string[],
-    defaultVideoSpeedBlacklist: string[],
   }
   const GM_info: MonkeyInfo
   function GM_xmlhttpRequest(details: MonkeyXhrDetails): { abort: () => void }

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -525,6 +525,7 @@ declare global {
     },
     rememberVideoSpeed: boolean,
     latestVideoSpeed: number,
+    extendVideoSpeed: boolean,
   }
   const GM_info: MonkeyInfo
   function GM_xmlhttpRequest(details: MonkeyXhrDetails): { abort: () => void }

--- a/src/utils/gui-settings/gui-settings.html
+++ b/src/utils/gui-settings/gui-settings.html
@@ -54,7 +54,6 @@
       <!-- <checkbox indent="0" key="useDefaultVideoQuality" dependencies=""></checkbox>
       <dropdown indent="1" key="defaultVideoQuality" dependencies="useDefaultVideoQuality"></dropdown> -->
       <checkbox indent="0" key="useDefaultVideoSpeed" dependencies=""></checkbox>
-      <dropdown indent="1" key="defaultVideoSpeed" dependencies="useDefaultVideoSpeed"></dropdown>
       <!-- <checkbox indent="0" key="useDefaultDanmakuSettings" dependencies=""></checkbox>
       <checkbox indent="1" key="enableDanmaku" dependencies="useDefaultDanmakuSettings"></checkbox>
       <checkbox indent="1" key="rememberDanmakuSettings" dependencies="useDefaultDanmakuSettings enableDanmaku">

--- a/src/utils/gui-settings/icons.css
+++ b/src/utils/gui-settings/icons.css
@@ -113,3 +113,12 @@
 .icons-enabled .icon-cc-subtitles::after {
   background-image: url('data:image/svg+xml,%3Csvg width="24" height="24" viewBox="0 0 22 22" xmlns="http://www.w3.org/2000/svg"%3E%3Cpath d="M4 4h14a2 2 0 012 2v10a2 2 0 01-2 2H4a2 2 0 01-2-2V6a2 2 0 012-2zm5 5.5a1 1 0 100-2H6a2 2 0 00-2 2v3a2 2 0 002 2h3a1 1 0 000-2H7a1 1 0 01-1-1v-1a1 1 0 011-1h2zm8 0a1 1 0 000-2h-3a2 2 0 00-2 2v3a2 2 0 002 2h3a1 1 0 000-2h-2a1 1 0 01-1-1v-1a1 1 0 011-1h2z" fill="black" fill-rule="evenodd"%3E%3C/path%3E%3C/svg%3E');
 }
+.icons-enabled .icon-speed-down::after {
+  background-image: url('data:image/svg+xml;utf-8,<svg height="24" width="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><path d="M18.41,7.41L17,6L11,12L17,18L18.41,16.59L13.83,12L18.41,7.41M12.41,7.41L11,6L5,12L11,18L12.41,16.59L7.83,12L12.41,7.41Z" /></svg>');
+}
+.icons-enabled .icon-speed-up::after {
+  background-image: url('data:image/svg+xml;utf-8,<svg height="24" width="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><path d="M5.59,7.41L7,6L13,12L7,18L5.59,16.59L10.17,12L5.59,7.41M11.59,7.41L13,6L19,12L13,18L11.59,16.59L16.17,12L11.59,7.41Z" /></svg>');
+}
+.icons-enabled .icon-play::after {
+  background-image: url('data:image/svg+xml;utf-8,<svg height="24" width="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><path d="M8,5.14V19.14L19,12.14L8,5.14Z" /></svg>');
+}

--- a/src/utils/gui-settings/icons.css
+++ b/src/utils/gui-settings/icons.css
@@ -113,12 +113,3 @@
 .icons-enabled .icon-cc-subtitles::after {
   background-image: url('data:image/svg+xml,%3Csvg width="24" height="24" viewBox="0 0 22 22" xmlns="http://www.w3.org/2000/svg"%3E%3Cpath d="M4 4h14a2 2 0 012 2v10a2 2 0 01-2 2H4a2 2 0 01-2-2V6a2 2 0 012-2zm5 5.5a1 1 0 100-2H6a2 2 0 00-2 2v3a2 2 0 002 2h3a1 1 0 000-2H7a1 1 0 01-1-1v-1a1 1 0 011-1h2zm8 0a1 1 0 000-2h-3a2 2 0 00-2 2v3a2 2 0 002 2h3a1 1 0 000-2h-2a1 1 0 01-1-1v-1a1 1 0 011-1h2z" fill="black" fill-rule="evenodd"%3E%3C/path%3E%3C/svg%3E');
 }
-.icons-enabled .icon-speed-down::after {
-  background-image: url('data:image/svg+xml;utf-8,<svg height="24" width="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><path d="M18.41,7.41L17,6L11,12L17,18L18.41,16.59L13.83,12L18.41,7.41M12.41,7.41L11,6L5,12L11,18L12.41,16.59L7.83,12L12.41,7.41Z" /></svg>');
-}
-.icons-enabled .icon-speed-up::after {
-  background-image: url('data:image/svg+xml;utf-8,<svg height="24" width="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><path d="M5.59,7.41L7,6L13,12L7,18L5.59,16.59L10.17,12L5.59,7.41M11.59,7.41L13,6L19,12L13,18L11.59,16.59L16.17,12L11.59,7.41Z" /></svg>');
-}
-.icons-enabled .icon-play::after {
-  background-image: url('data:image/svg+xml;utf-8,<svg height="24" width="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><path d="M8,5.14V19.14L19,12.14L8,5.14Z" /></svg>');
-}

--- a/src/utils/gui-settings/tooltip/settings-tooltip.zh-CN.ts
+++ b/src/utils/gui-settings/tooltip/settings-tooltip.zh-CN.ts
@@ -139,8 +139,8 @@ export const toolTips = new Map<keyof BilibiliEvolvedSettings, string>([
   ['sideBarOffset', /*html*/`设定侧栏的垂直偏移量, 单位为百分比, 允许的范围为 -40% ~ 40%.`],
   ['hideCategory', /*html*/`隐藏主站的分区栏, 分区仍然可以从顶栏的主站菜单中进入.`],
   ['foldComment', /*html*/`动态里查看评论区时, 在底部添加一个<span>收起评论</span>按钮, 这样就不用再回到上面收起了.`],
-  ['useDefaultVideoSpeed', /*html*/`设置是否使用默认视频播放速度.`],
-  ['defaultVideoSpeed', /*html*/`设置默认的视频播放速度.`],
+  ['useDefaultVideoSpeed', /*html*/`设置是否记忆视频播放速度.`],
+  ['defaultVideoSpeed', /*html*/`设置全局默认的视频播放速度，将优先使用用户对特定视频指定的倍数.`],
   ['seedsToCoins', /*html*/`在附加功能中添加<span>瓜子换硬币</span>的按钮, 点击可以将700银瓜子换成1个硬币, 每天限1次.`],
   ['autoDraw', /*html*/`在当前直播间有抽奖活动时, 自动点击抽奖按钮. 注意只适用于少量抽奖, 那种99+限量抽奖可能跟不上其他人的手速(`],
   ['keymap', /*html*/`为视频播放器启用更多的快捷键:

--- a/src/utils/gui-settings/tooltip/settings-tooltip.zh-CN.ts
+++ b/src/utils/gui-settings/tooltip/settings-tooltip.zh-CN.ts
@@ -139,8 +139,7 @@ export const toolTips = new Map<keyof BilibiliEvolvedSettings, string>([
   ['sideBarOffset', /*html*/`设定侧栏的垂直偏移量, 单位为百分比, 允许的范围为 -40% ~ 40%.`],
   ['hideCategory', /*html*/`隐藏主站的分区栏, 分区仍然可以从顶栏的主站菜单中进入.`],
   ['foldComment', /*html*/`动态里查看评论区时, 在底部添加一个<span>收起评论</span>按钮, 这样就不用再回到上面收起了.`],
-  ['useDefaultVideoSpeed', /*html*/`设置是否记忆视频播放速度.`],
-  ['defaultVideoSpeed', /*html*/`设置全局默认的视频播放速度，将优先使用用户对特定视频指定的倍数.`],
+  ['useDefaultVideoSpeed', /*html*/`设置是否记忆上次选择的视频播放速度.`],
   ['seedsToCoins', /*html*/`在附加功能中添加<span>瓜子换硬币</span>的按钮, 点击可以将700银瓜子换成1个硬币, 每天限1次.`],
   ['autoDraw', /*html*/`在当前直播间有抽奖活动时, 自动点击抽奖按钮. 注意只适用于少量抽奖, 那种99+限量抽奖可能跟不上其他人的手速(`],
   ['keymap', /*html*/`为视频播放器启用更多的快捷键:

--- a/src/video/default-video-speed.ts
+++ b/src/video/default-video-speed.ts
@@ -1,21 +1,15 @@
 const indexOfCurrentAid = () => settings.defaultVideoSpeedBlacklist.indexOf(unsafeWindow.aid as string)
 
-const getNativeDefaultPlaySpeed = () => {
+const nativeDefaultPlaySpeed = (() => {
   try {
     return parseFloat(JSON.parse(sessionStorage.getItem("bilibili_player_settings") as string).video_status.videospeed || 1)
   } catch {
     return 1
   }
-}
+})()
 
 const setPlaybackRate = async (speed: number) => {
-  const video = await SpinQuery.select('.bilibili-player-video video') as HTMLVideoElement
-  video.playbackRate = speed
-  SpinQuery.condition(
-    () => video,
-    () => video.playbackRate !== speed,
-    () => video.playbackRate = speed
-  )
+  (await SpinQuery.select(`.bilibili-player-video-btn-speed-menu .bilibili-player-video-btn-speed-menu-list[data-value="${speed}"]`))?.click()
 }
 
 const updateWidget = (button: HTMLButtonElement, icon: HTMLElement, label: HTMLSpanElement, state: boolean) => {
@@ -76,7 +70,7 @@ export default {
             await setPlaybackRate(parseFloat(settings.defaultVideoSpeed))
           } else {
             settings.defaultVideoSpeedBlacklist.push(unsafeWindow.aid)
-            await setPlaybackRate(getNativeDefaultPlaySpeed())
+            await setPlaybackRate(nativeDefaultPlaySpeed)
           }
           settings.defaultVideoSpeedBlacklist = settings.defaultVideoSpeedBlacklist
           updateWidget(button, icon, label, !state)

--- a/src/video/default-video-speed.ts
+++ b/src/video/default-video-speed.ts
@@ -1,8 +1,6 @@
-type supportedVideoPlayRates = keyof typeof settings.defaultVideoSpeedList
-
 const getDefaultVideoSpeed = () => parseFloat(settings.defaultVideoSpeed)
 
-const setVideoSpeed = async (speed: supportedVideoPlayRates) => {
+const setVideoSpeed = async (speed: number) => {
   (await SpinQuery.select(`.bilibili-player-video-btn-speed-menu .bilibili-player-video-btn-speed-menu-list[data-value="${speed}"]`))?.click()
 }
 
@@ -14,7 +12,7 @@ const getSpeedFromSetting = () => {
   }
 }
 
-const addSpeedToSetting = (speed: supportedVideoPlayRates, aid: string, force = false) => {
+const addSpeedToSetting = (speed: number, aid: string, force = false) => {
   let aidOldIndex = -1;
   // 如果原来设置中记忆了有关的 aid，就需要先移除它
   for (const aids of Object.values(settings.defaultVideoSpeedList)) {
@@ -28,7 +26,7 @@ const addSpeedToSetting = (speed: supportedVideoPlayRates, aid: string, force = 
   if (aidOldIndex === -1 && !force) {
     return
   }
-  // 防止以后 B 站自己加上了别的倍数，有必要的话就重新初始化个数组
+  // 为新的速度值初始化相应的 aid 数组
   if (!settings.defaultVideoSpeedList[speed]) {
     settings.defaultVideoSpeedList[speed] = []
   }
@@ -56,7 +54,7 @@ const setup = _.once(async () => {
         if (!unsafeWindow.aid) {
           throw "aid is undefined"
         }
-        addSpeedToSetting(currentSpeed as supportedVideoPlayRates, unsafeWindow.aid, currentSpeed !== getDefaultVideoSpeed())
+        addSpeedToSetting(currentSpeed, unsafeWindow.aid, currentSpeed !== getDefaultVideoSpeed())
       }
     })
   })
@@ -65,6 +63,6 @@ const setup = _.once(async () => {
 Observer.videoChange(async () => {
   await setup()
   if (settings.useDefaultVideoSpeed) {
-    await setVideoSpeed((getSpeedFromSetting() || getDefaultVideoSpeed()) as supportedVideoPlayRates)
+    await setVideoSpeed((getSpeedFromSetting() || getDefaultVideoSpeed()))
   }
 })

--- a/src/video/default-video-speed.ts
+++ b/src/video/default-video-speed.ts
@@ -1,3 +1,27 @@
+const inBlacklist = () => settings.defaultVideoSpeedBlacklist.some(val => val === unsafeWindow.aid)
+
+const changeState = (button: HTMLButtonElement, icon: HTMLElement, label: HTMLSpanElement, state: boolean) => {
+  if (state) {
+    icon.className = "icon-play"
+  } else {
+    const defaultVideoSpeed = parseFloat(settings.defaultVideoSpeed)
+    if (defaultVideoSpeed < 1) {
+      icon.className = "icon-speed-down"
+    } else if (defaultVideoSpeed > 1) {
+      icon.className = "icon-speed-up"
+    } else {
+      icon.className = "icon-play"
+    }
+  }
+  if (state) {
+    label.innerText = "使用"
+    button.title = "标记当前视频使用默认播放速度（适用于实况类、学习类等视频），刷新后生效。"
+  } else {
+    label.innerText = "排除"
+    button.title = "标记当前视频不使用默认播放速度（适用于音乐类、鬼畜类等视频），刷新后生效。"
+  }
+}
+
 const setPlaybackRate = (video: HTMLVideoElement) => {
   const speed = parseFloat(settings.defaultVideoSpeed)
   video.playbackRate = speed
@@ -7,7 +31,54 @@ const setPlaybackRate = (video: HTMLVideoElement) => {
     () => video.playbackRate = speed
   )
 }
+
 Observer.videoChange(async () => {
+  if (inBlacklist()) {
+    return
+  }
   const video = await SpinQuery.select('.bilibili-player-video video') as HTMLVideoElement
   setPlaybackRate(video)
 })
+
+export default {
+  widget: {
+    content: /*html*/`
+      <button class="gui-settings-flat-button" style="position: relative; z-index: 100;" id="toggle-default-video-speed">
+        <i class="icon-play"></i>
+        <span class="toggle-text"></span>
+        <span>默认播放速度</span>
+      </button>`,
+    condition: async () => {
+      return await videoCondition() && settings.useDefaultVideoSpeed
+    },
+    success: () => {
+      const button = dq('#toggle-default-video-speed') as HTMLButtonElement
+      const icon = dq("#toggle-default-video-speed i") as HTMLElement
+      const label = dq("#toggle-default-video-speed .toggle-text") as HTMLSpanElement
+
+      changeState(button, icon, label, inBlacklist())
+
+      button.addEventListener('click', async () => {
+        try {
+          button.disabled = true
+          if (!unsafeWindow.aid) {
+            throw "aid is undefined"
+          }
+          let state = inBlacklist()
+          if (state) {
+            settings.defaultVideoSpeedBlacklist.splice(settings.defaultVideoSpeedBlacklist.indexOf(unsafeWindow.aid), 1)
+          } else {
+            settings.defaultVideoSpeedBlacklist.push(unsafeWindow.aid)
+          }
+          settings.defaultVideoSpeedBlacklist = settings.defaultVideoSpeedBlacklist
+          state = !state
+          changeState(button, icon, label, state)
+        } catch (error) {
+          logError(error)
+        } finally {
+          button.disabled = false
+        }
+      })
+    },
+  }
+}

--- a/src/video/default-video-speed.ts
+++ b/src/video/default-video-speed.ts
@@ -1,85 +1,13 @@
-const indexOfCurrentAid = () => settings.defaultVideoSpeedBlacklist.indexOf(unsafeWindow.aid as string)
-
-const nativeDefaultPlaySpeed = (() => {
-  try {
-    return parseFloat(JSON.parse(sessionStorage.getItem("bilibili_player_settings") as string).video_status.videospeed || 1)
-  } catch {
-    return 1
-  }
-})()
-
-const setPlaybackRate = async (speed: number) => {
-  (await SpinQuery.select(`.bilibili-player-video-btn-speed-menu .bilibili-player-video-btn-speed-menu-list[data-value="${speed}"]`))?.click()
+const setPlaybackRate = (video: HTMLVideoElement) => {
+  const speed = parseFloat(settings.defaultVideoSpeed)
+  video.playbackRate = speed
+  SpinQuery.condition(
+    () => video,
+    () => video.playbackRate !== speed,
+    () => video.playbackRate = speed
+  )
 }
-
-const updateWidget = (button: HTMLButtonElement, icon: HTMLElement, label: HTMLSpanElement, state: boolean) => {
-  if (state) {
-    icon.className = "icon-play"
-    label.innerText = "原生"
-    button.title = "当前视频使用 B 站原生默认播放速度（适用于音乐类、鬼畜类等视频）"
-  } else {
-    label.innerText = "自定义"
-    button.title = "当前视频使用脚本自定义的默认播放速度（适用于实况类、学习类等视频）"
-
-    const defaultVideoSpeed = parseFloat(settings.defaultVideoSpeed)
-
-    if (defaultVideoSpeed < 1) {
-      icon.className = "icon-speed-down"
-    } else if (defaultVideoSpeed > 1) {
-      icon.className = "icon-speed-up"
-    } else {
-      icon.className = "icon-play"
-    }
-  }
-}
-
 Observer.videoChange(async () => {
-  if (indexOfCurrentAid() === -1) {
-    await setPlaybackRate(parseFloat(settings.defaultVideoSpeed))
-  }
+  const video = await SpinQuery.select('.bilibili-player-video video') as HTMLVideoElement
+  setPlaybackRate(video)
 })
-
-export default {
-  widget: {
-    content: /*html*/`
-      <button class="gui-settings-flat-button" style="position: relative; z-index: 100;" id="toggle-default-video-speed">
-        <i class="icon-play"></i>
-        <span class="toggle-text"></span>
-        <span>默认播放速度</span>
-      </button>`,
-    condition: async () => {
-      return await videoCondition() && settings.useDefaultVideoSpeed
-    },
-    success: async () => {
-      const button = dq('#toggle-default-video-speed') as HTMLButtonElement
-      const icon = dq("#toggle-default-video-speed i") as HTMLElement
-      const label = dq("#toggle-default-video-speed .toggle-text") as HTMLSpanElement
-
-      updateWidget(button, icon, label, indexOfCurrentAid() !== -1)
-
-      button.addEventListener('click', async () => {
-        try {
-          button.disabled = true
-          if (!unsafeWindow.aid) {
-            throw "aid is undefined"
-          }
-          const index = indexOfCurrentAid()
-          const state = index !== -1
-          if (state) {
-            settings.defaultVideoSpeedBlacklist.splice(index, 1)
-            await setPlaybackRate(parseFloat(settings.defaultVideoSpeed))
-          } else {
-            settings.defaultVideoSpeedBlacklist.push(unsafeWindow.aid)
-            await setPlaybackRate(nativeDefaultPlaySpeed)
-          }
-          settings.defaultVideoSpeedBlacklist = settings.defaultVideoSpeedBlacklist
-          updateWidget(button, icon, label, !state)
-        } catch (error) {
-          logError(error)
-        } finally {
-          button.disabled = false
-        }
-      })
-    },
-  }
-}

--- a/src/video/default-video-speed.ts
+++ b/src/video/default-video-speed.ts
@@ -38,22 +38,19 @@ const addSpeedToSetting = (speed: supportedVideoPlayRates, aid: string, force = 
   settings.defaultVideoSpeedList = settings.defaultVideoSpeedList
 }
 
-Observer.videoChange(async () => {
-  if (settings.useDefaultVideoSpeed) {
-    await setVideoSpeed((getSpeedFromSetting() || getDefaultVideoSpeed()) as supportedVideoPlayRates)
-  }
-})
+const setup = _.once(async () => {
+  const menu = await SpinQuery.select(".bilibili-player-video-btn-speed-menu")
 
-SpinQuery.select(".bilibili-player-video-btn-speed-menu").then(value => {
-  if (!value) {
+  if (!menu) {
     throw "speed menu not found!"
   }
-  Observer.all(value, (mutations) => {
+
+  Observer.all(menu, (mutations) => {
     if (!settings.useDefaultVideoSpeed) {
       return
     }
     mutations.forEach(mutation => {
-      const selectedSpeedOption = mutation.target as HTMLLIElement;
+      const selectedSpeedOption = mutation.target as HTMLLIElement
       if (selectedSpeedOption.classList.contains("bilibili-player-active")) {
         const currentSpeed = parseFloat(selectedSpeedOption.dataset.value || '1')
         if (!unsafeWindow.aid) {
@@ -63,4 +60,11 @@ SpinQuery.select(".bilibili-player-video-btn-speed-menu").then(value => {
       }
     })
   })
+})
+
+Observer.videoChange(async () => {
+  await setup()
+  if (settings.useDefaultVideoSpeed) {
+    await setVideoSpeed((getSpeedFromSetting() || getDefaultVideoSpeed()) as supportedVideoPlayRates)
+  }
 })

--- a/src/video/default-video-speed.ts
+++ b/src/video/default-video-speed.ts
@@ -1,13 +1,66 @@
-const setPlaybackRate = (video: HTMLVideoElement) => {
-  const speed = parseFloat(settings.defaultVideoSpeed)
-  video.playbackRate = speed
-  SpinQuery.condition(
-    () => video,
-    () => video.playbackRate !== speed,
-    () => video.playbackRate = speed
-  )
+type supportedVideoPlayRates = keyof typeof settings.defaultVideoSpeedList
+
+const getDefaultVideoSpeed = () => parseFloat(settings.defaultVideoSpeed)
+
+const setVideoSpeed = async (speed: supportedVideoPlayRates) => {
+  (await SpinQuery.select(`.bilibili-player-video-btn-speed-menu .bilibili-player-video-btn-speed-menu-list[data-value="${speed}"]`))?.click()
 }
+
+const getSpeedFromSetting = () => {
+  for (const [level, aids] of Object.entries(settings.defaultVideoSpeedList)) {
+    if (aids.some(aid => aid === unsafeWindow.aid)) {
+      return parseFloat(level)
+    }
+  }
+}
+
+const addSpeedToSetting = (speed: supportedVideoPlayRates, aid: string, force = false) => {
+  let aidOldIndex = -1;
+  // 如果原来设置中记忆了有关的 aid，就需要先移除它
+  for (const aids of Object.values(settings.defaultVideoSpeedList)) {
+    aidOldIndex = aids.indexOf(aid)
+    if (aidOldIndex !== -1) {
+      aids.splice(aidOldIndex, 1)
+      break
+    }
+  }
+  // 对于没有被记忆的 aid，并且 force 参数为假就直接返回
+  if (aidOldIndex === -1 && !force) {
+    return
+  }
+  // 防止以后 B 站自己加上了别的倍数，有必要的话就重新初始化个数组
+  if (!settings.defaultVideoSpeedList[speed]) {
+    settings.defaultVideoSpeedList[speed] = []
+  }
+  // 追加记忆值
+  settings.defaultVideoSpeedList[speed].push(aid)
+  // 持久化
+  settings.defaultVideoSpeedList = settings.defaultVideoSpeedList
+}
+
 Observer.videoChange(async () => {
-  const video = await SpinQuery.select('.bilibili-player-video video') as HTMLVideoElement
-  setPlaybackRate(video)
+  if (settings.useDefaultVideoSpeed) {
+    await setVideoSpeed((getSpeedFromSetting() || getDefaultVideoSpeed()) as supportedVideoPlayRates)
+  }
+})
+
+SpinQuery.select(".bilibili-player-video-btn-speed-menu").then(value => {
+  if (!value) {
+    throw "speed menu not found!"
+  }
+  Observer.all(value, (mutations) => {
+    if (!settings.useDefaultVideoSpeed) {
+      return
+    }
+    mutations.forEach(mutation => {
+      const selectedSpeedOption = mutation.target as HTMLLIElement;
+      if (selectedSpeedOption.classList.contains("bilibili-player-active")) {
+        const currentSpeed = parseFloat(selectedSpeedOption.dataset.value || '1')
+        if (!unsafeWindow.aid) {
+          throw "aid is undefined"
+        }
+        addSpeedToSetting(currentSpeed as supportedVideoPlayRates, unsafeWindow.aid, currentSpeed !== getDefaultVideoSpeed())
+      }
+    })
+  })
 })

--- a/src/video/default-video-speed.ts
+++ b/src/video/default-video-speed.ts
@@ -25,7 +25,7 @@ export class VideoSpeedController {
   }
 
   static getSpeedFromSetting() {
-    for (const [level, aids] of Object.entries(settings.defaultVideoSpeedList)) {
+    for (const [level, aids] of Object.entries(settings.rememberVideoSpeedList)) {
       if (aids.some(aid => aid === unsafeWindow.aid)) {
         return parseFloat(level)
       }
@@ -35,7 +35,7 @@ export class VideoSpeedController {
   static rememberSpeed(speed: number, aid: string, force = false) {
     let aidOldIndex = -1;
     // 如果原来设置中记忆了有关的 aid，就需要先移除它
-    for (const aids of Object.values(settings.defaultVideoSpeedList)) {
+    for (const aids of Object.values(settings.rememberVideoSpeedList)) {
       aidOldIndex = aids.indexOf(aid)
       if (aidOldIndex !== -1) {
         aids.splice(aidOldIndex, 1)
@@ -47,13 +47,13 @@ export class VideoSpeedController {
       return
     }
     // 为新的速度值初始化相应的 aid 数组
-    if (!settings.defaultVideoSpeedList[speed]) {
-      settings.defaultVideoSpeedList[speed] = []
+    if (!settings.rememberVideoSpeedList[speed]) {
+      settings.rememberVideoSpeedList[speed] = []
     }
     // 追加记忆值
-    settings.defaultVideoSpeedList[speed].push(aid)
+    settings.rememberVideoSpeedList[speed].push(aid)
     // 持久化
-    settings.defaultVideoSpeedList = settings.defaultVideoSpeedList
+    settings.rememberVideoSpeedList = settings.rememberVideoSpeedList
   }
 
   private _containerElement: HTMLElement

--- a/src/video/default-video-speed.ts
+++ b/src/video/default-video-speed.ts
@@ -1,74 +1,214 @@
-const getDefaultVideoSpeed = () => parseFloat(settings.defaultVideoSpeed)
+export class VideoSpeedController {
+  static readonly classNameMap = {
+    speedMenuList: "bilibili-player-video-btn-speed-menu",
+    speedMenuItem: "bilibili-player-video-btn-speed-menu-list",
+    speedNameBtn: "bilibili-player-video-btn-speed-name",
+    speedContainer: "bilibili-player-video-btn-speed",
+    active: "bilibili-player-active",
+    show: "bilibili-player-speed-show",
+    video: "bilibili-player-video"
+  }
+  static readonly nativeSupportedRates = [0.5, 0.75, 1.0, 1.25, 1.5, 2.0]
+  static readonly extendedSupportedRates = [2.5, 3]
+  // 扩展倍数不支持热重载
+  static readonly supportedRates = (settings.extendVideoSpeed) ? [...VideoSpeedController.nativeSupportedRates, ...VideoSpeedController.extendedSupportedRates] : VideoSpeedController.nativeSupportedRates
 
-const setVideoSpeed = async (speed: number) => {
-  (await SpinQuery.select(`.bilibili-player-video-btn-speed-menu .bilibili-player-video-btn-speed-menu-list[data-value="${speed}"]`))?.click()
-}
+  static getDefaultVideoSpeed() {
+    return parseFloat(settings.defaultVideoSpeed)
+  }
 
-const getSpeedFromSetting = () => {
-  for (const [level, aids] of Object.entries(settings.defaultVideoSpeedList)) {
-    if (aids.some(aid => aid === unsafeWindow.aid)) {
-      return parseFloat(level)
+  static formatSpeedText(speed: number) {
+    if (speed === 1) {
+      return "倍数"
+    }
+    return Math.trunc(speed) === speed ? `${speed}.0x` : `${speed}x`
+  }
+
+  static getSpeedFromSetting() {
+    for (const [level, aids] of Object.entries(settings.defaultVideoSpeedList)) {
+      if (aids.some(aid => aid === unsafeWindow.aid)) {
+        return parseFloat(level)
+      }
     }
   }
-}
 
-const addSpeedToSetting = (speed: number, aid: string, force = false) => {
-  let aidOldIndex = -1;
-  // 如果原来设置中记忆了有关的 aid，就需要先移除它
-  for (const aids of Object.values(settings.defaultVideoSpeedList)) {
-    aidOldIndex = aids.indexOf(aid)
-    if (aidOldIndex !== -1) {
-      aids.splice(aidOldIndex, 1)
-      break
+  static rememberSpeed(speed: number, aid: string, force = false) {
+    let aidOldIndex = -1;
+    // 如果原来设置中记忆了有关的 aid，就需要先移除它
+    for (const aids of Object.values(settings.defaultVideoSpeedList)) {
+      aidOldIndex = aids.indexOf(aid)
+      if (aidOldIndex !== -1) {
+        aids.splice(aidOldIndex, 1)
+        break
+      }
     }
-  }
-  // 对于没有被记忆的 aid，并且 force 参数为假就直接返回
-  if (aidOldIndex === -1 && !force) {
-    return
-  }
-  // 为新的速度值初始化相应的 aid 数组
-  if (!settings.defaultVideoSpeedList[speed]) {
-    settings.defaultVideoSpeedList[speed] = []
-  }
-  // 追加记忆值
-  settings.defaultVideoSpeedList[speed].push(aid)
-  // 持久化
-  settings.defaultVideoSpeedList = settings.defaultVideoSpeedList
-}
-
-const setup = _.once(async () => {
-  const menu = await SpinQuery.select(".bilibili-player-video-btn-speed-menu")
-
-  if (!menu) {
-    throw "speed menu not found!"
+    // 对于没有被记忆的 aid，并且 force 参数为假就直接返回
+    if (aidOldIndex === -1 && !force) {
+      return
+    }
+    // 为新的速度值初始化相应的 aid 数组
+    if (!settings.defaultVideoSpeedList[speed]) {
+      settings.defaultVideoSpeedList[speed] = []
+    }
+    // 追加记忆值
+    settings.defaultVideoSpeedList[speed].push(aid)
+    // 持久化
+    settings.defaultVideoSpeedList = settings.defaultVideoSpeedList
   }
 
-  Observer.all(menu, (mutations) => {
-    mutations.forEach(mutation => {
-      const selectedSpeedOption = mutation.target as HTMLLIElement
-      if (selectedSpeedOption.classList.contains("bilibili-player-active")) {
+  private _containerElement: HTMLElement
+  private _menuListElement: HTMLElement
+  private _nameBtn: HTMLButtonElement
+  private _videoElement: HTMLVideoElement
+  // 这个值模拟原生内部记录的速度倍数，它不应该被赋值成扩展倍数的值
+  private _nativeSpeedVal = 1
+
+  constructor(containerElement: HTMLElement, videoElement: HTMLVideoElement, nativeSpeedVal: number) {
+    this._containerElement = containerElement
+    this._videoElement = videoElement
+    this._nativeSpeedVal = nativeSpeedVal
+    this._nameBtn = this._containerElement.querySelector(`.${VideoSpeedController.classNameMap.speedNameBtn}`) as HTMLButtonElement
+    this._menuListElement = this._containerElement.querySelector(`.${VideoSpeedController.classNameMap.speedMenuList}`) as HTMLElement
+  }
+
+  get playbackRate() {
+    return this._videoElement.playbackRate
+  }
+
+  get nativeSpeedVal() {
+    return this._nativeSpeedVal
+  }
+
+  getSpeedMenuItem(speed: number): HTMLElement;
+  getSpeedMenuItem(speed?: number) {
+    if (speed) {
+      return this._menuListElement.querySelector(`.${VideoSpeedController.classNameMap.speedMenuItem}[data-value="${speed}"]`)
+    }
+    return this._menuListElement.querySelector(`.${VideoSpeedController.classNameMap.speedMenuItem}.${VideoSpeedController.classNameMap.active}`)
+  }
+
+  // 观察倍数菜单，用于触发事件，记忆选定的倍数
+  observe() {
+    Observer.all(this._menuListElement, (mutations) => {
+      mutations.forEach(mutation => {
+        const selectedSpeedOption = mutation.target as HTMLLIElement
+        // 不需要处理被移除 active 类的变化
+        if (!selectedSpeedOption.classList.contains(VideoSpeedController.classNameMap.active)) {
+          return
+        }
+
         const currentSpeed = parseFloat(selectedSpeedOption.dataset.value || '1')
+
+        this._containerElement.dispatchEvent(new CustomEvent("changed", { detail: { speed: currentSpeed } }))
+
+        if (VideoSpeedController.nativeSupportedRates.includes(currentSpeed)) {
+          this._nativeSpeedVal = currentSpeed
+          this._containerElement.dispatchEvent(new CustomEvent("native-speed-changed", { detail: { speed: this._nativeSpeedVal } }))
+        }
+        // 原生支持倍数的应用后，有必要清除扩展倍数选项上的样式
+        if (settings.extendVideoSpeed && VideoSpeedController.nativeSupportedRates.includes(currentSpeed)) {
+          this._menuListElement.querySelector(`.${VideoSpeedController.classNameMap.speedMenuItem}.extended.${VideoSpeedController.classNameMap.active}`)?.classList.remove(VideoSpeedController.classNameMap.active)
+        }
         if (!unsafeWindow.aid) {
           throw "aid is undefined"
         }
-        if (settings.rememberVideoSpeed) {
-          addSpeedToSetting(currentSpeed, unsafeWindow.aid, currentSpeed !== getDefaultVideoSpeed())
-        } else {
-          settings.latestVideoSpeed = currentSpeed
+        // 记忆
+        // - `useDefaultVideoSpeed` 表示是否启用记忆
+        // - `rememberVideoSpeed` 表示是否启用细化到视频级别的记忆
+        if (settings.useDefaultVideoSpeed) {
+          if (settings.rememberVideoSpeed) {
+            VideoSpeedController.rememberSpeed(currentSpeed, unsafeWindow.aid, currentSpeed !== VideoSpeedController.getDefaultVideoSpeed())
+          } else {
+            settings.latestVideoSpeed = currentSpeed
+          }
         }
+      })
+    })
+  }
+
+  extendMenuItem() {
+    // 如果开启了扩展倍数，存在一种场景使倍数设置会失效：
+    //   1. 用户从原生支持的倍数切换到扩展倍数
+    //   2. 用户从扩展倍数切换到之前选中的原生倍数
+    // 这是因为播放器内部实现维护了一个速度值，但是在切换到扩展倍数时没法更新，因此切换回来的时候被判定没有发生变化
+    // 为了解决这个问题，需要替官方更新元素，并为视频设置正确的倍数，并关闭菜单
+    this._menuListElement.addEventListener("click", (ev) => {
+      const option = (ev.target as HTMLElement)
+      const value = parseFloat(option.dataset.value as string)
+      if ((ev.target as HTMLElement).classList.contains("extended")) {
+        this.setUnsafeVideoSpeed(value)
+      }
+      // 从扩展倍数切换到之前选中的原生倍数
+      if (VideoSpeedController.extendedSupportedRates.includes(this.playbackRate) && this._nativeSpeedVal === value) {
+        this.forceUpdate(value)
       }
     })
-  })
-})
+    // 添加扩展的倍数选项
+    for (const rate of VideoSpeedController.extendedSupportedRates) {
+      const li = document.createElement("li")
+      li.innerText = VideoSpeedController.formatSpeedText(rate)
+      li.classList.add(VideoSpeedController.classNameMap.speedMenuItem, "extended")
+      li.dataset.value = rate.toString()
+      this._menuListElement.prepend(li)
+    }
+  }
 
-Observer.videoChange(async () => {
-  if (!settings.useDefaultVideoSpeed) {
-    return
+  reset() {
+    this.setUnsafeVideoSpeed(1)
   }
-  await setup()
-  if (settings.rememberVideoSpeed) {
-    await setVideoSpeed((getSpeedFromSetting() || getDefaultVideoSpeed()))
-  } else {
-    await setVideoSpeed(settings.latestVideoSpeed)
+
+  setVideoSpeed(speed: number) {
+    if (VideoSpeedController.supportedRates.includes(speed)) {
+      this.getSpeedMenuItem(speed).click()
+    }
   }
-})
+
+  private setUnsafeVideoSpeed(speed: number) {
+    if (VideoSpeedController.nativeSupportedRates.includes(speed)) {
+      this.getSpeedMenuItem(speed).click()
+    } else {
+      this.forceUpdate(speed)
+    }
+  }
+
+  private forceUpdate(value: number) {
+    this._menuListElement.querySelector(`.${VideoSpeedController.classNameMap.speedMenuItem}[data-value="${this.playbackRate}"]`)?.classList.remove(VideoSpeedController.classNameMap.active);
+    this._menuListElement.querySelector(`.${VideoSpeedController.classNameMap.speedMenuItem}[data-value="${value}"]`)?.classList.add(VideoSpeedController.classNameMap.active);
+    this._videoElement.playbackRate = value
+    this._containerElement.classList.remove(VideoSpeedController.classNameMap.show)
+    this._nameBtn.innerText = VideoSpeedController.formatSpeedText(value)
+  }
+}
+
+if (settings.useDefaultVideoSpeed || settings.extendVideoSpeed) {
+  // 分 P 切换时共享同一个倍数
+  let nativeSpeedVal = 1
+
+  Observer.videoChange(async () => {
+    const containerElement = await SpinQuery.select(`.${VideoSpeedController.classNameMap.speedContainer}`)
+    const videoElement = await SpinQuery.select(`.${VideoSpeedController.classNameMap.video} video`)
+
+    if (!containerElement) {
+      throw "speed container element not found!"
+    }
+    if (!videoElement) {
+      throw "video element not found!"
+    }
+    // 有必要传递之前的 nativeSpeedVal，跨分 P 时原生倍数将保持一样
+    const controller = new VideoSpeedController(containerElement, videoElement as HTMLVideoElement, nativeSpeedVal)
+
+    controller.observe()
+
+    if (settings.extendVideoSpeed) {
+      controller.extendMenuItem()
+      containerElement.addEventListener("native-speed-changed", (ev: CustomEvent) => {
+        nativeSpeedVal = ev.detail.speed
+      })
+    }
+    // 首次加载可能会遇到意外情况，导致内部强制更新失效，因此延时 100 ms 再触发速度设置
+    setTimeout(() => {
+      settings.useDefaultVideoSpeed &&
+        controller.setVideoSpeed(settings.rememberVideoSpeed ? (VideoSpeedController.getSpeedFromSetting() || VideoSpeedController.getDefaultVideoSpeed()) : settings.latestVideoSpeed)
+    }, 100)
+  })
+}

--- a/src/video/default-video-speed.ts
+++ b/src/video/default-video-speed.ts
@@ -119,7 +119,7 @@ export class VideoSpeedController {
           if (settings.rememberVideoSpeed) {
             VideoSpeedController.rememberSpeed(currentSpeed, unsafeWindow.aid, currentSpeed !== VideoSpeedController.getDefaultVideoSpeed())
           } else {
-            settings.latestVideoSpeed = currentSpeed
+            settings.defaultVideoSpeed = currentSpeed.toString()
           }
         }
       })
@@ -208,7 +208,7 @@ if (settings.useDefaultVideoSpeed || settings.extendVideoSpeed) {
     // 首次加载可能会遇到意外情况，导致内部强制更新失效，因此延时 100 ms 再触发速度设置
     setTimeout(() => {
       settings.useDefaultVideoSpeed &&
-        controller.setVideoSpeed(settings.rememberVideoSpeed ? (VideoSpeedController.getSpeedFromSetting() || VideoSpeedController.getDefaultVideoSpeed()) : settings.latestVideoSpeed)
+        controller.setVideoSpeed((settings.rememberVideoSpeed && VideoSpeedController.getSpeedFromSetting()) || VideoSpeedController.getDefaultVideoSpeed())
     }, 100)
   })
 }

--- a/src/video/default-video-speed.ts
+++ b/src/video/default-video-speed.ts
@@ -44,9 +44,6 @@ const setup = _.once(async () => {
   }
 
   Observer.all(menu, (mutations) => {
-    if (!settings.useDefaultVideoSpeed) {
-      return
-    }
     mutations.forEach(mutation => {
       const selectedSpeedOption = mutation.target as HTMLLIElement
       if (selectedSpeedOption.classList.contains("bilibili-player-active")) {
@@ -54,15 +51,24 @@ const setup = _.once(async () => {
         if (!unsafeWindow.aid) {
           throw "aid is undefined"
         }
-        addSpeedToSetting(currentSpeed, unsafeWindow.aid, currentSpeed !== getDefaultVideoSpeed())
+        if (settings.rememberVideoSpeed) {
+          addSpeedToSetting(currentSpeed, unsafeWindow.aid, currentSpeed !== getDefaultVideoSpeed())
+        } else {
+          settings.latestVideoSpeed = currentSpeed
+        }
       }
     })
   })
 })
 
 Observer.videoChange(async () => {
+  if (!settings.useDefaultVideoSpeed) {
+    return
+  }
   await setup()
-  if (settings.useDefaultVideoSpeed) {
+  if (settings.rememberVideoSpeed) {
     await setVideoSpeed((getSpeedFromSetting() || getDefaultVideoSpeed()))
+  } else {
+    await setVideoSpeed(settings.latestVideoSpeed)
   }
 })

--- a/src/video/keymap.ts
+++ b/src/video/keymap.ts
@@ -4,53 +4,57 @@ const supportedUrls = [
   'https://www.bilibili.com/watchlater/',
   'https://www.bilibili.com/medialist/play/',
 ]
-let enabled = true
-if (supportedUrls.some(url => document.URL.startsWith(url))) {
-  const clickableKeymap = {
-    f: '.bilibili-player-video-fullscreen', // 全屏
-    w: '.bilibili-player-video-web-fullscreen', // 网页全屏
-    t: '.bilibili-player-video-btn-widescreen', // 宽屏
-    // r: '.bilibili-player-video-btn-repeat', // 切换循环模式
-    m: '.bilibili-player-video-btn-volume .bilibili-player-iconfont-volume', // 切换静音
-    p: '.bilibili-player-video-btn-pip', // 画中画
-    // l: '.video-toolbar .like', // 点赞
-    c: '.video-toolbar .coin,.tool-bar .coin-info, .video-toolbar-module .coin-box, .play-options-ul > li:nth-child(2)', // 投币
-    s: '.video-toolbar .collect, .video-toolbar-module .fav-box, .play-options-ul > li:nth-child(3)', // 收藏
-    ' ': '.bilibili-player-video-btn-start', // 砸瓦撸多
-  } as { [key: string]: string }
-  /** 长按`L`三连使用的记忆变量 */
-  let likeClick = true
-  /** 在稍后再看页面里, 记录当前视频是否赞过 */
-  let liked = false
-  const isWatchlater = document.URL.startsWith('https://www.bilibili.com/watchlater/')
-  const isMediaList = document.URL.startsWith('https://www.bilibili.com/medialist/play/')
-  if (isWatchlater) {
-    Observer.videoChange(() => {
-      Ajax.getJsonWithCredentials(`https://api.bilibili.com/x/web-interface/archive/has/like?aid=${unsafeWindow.aid}`).then(json => {
-        liked = Boolean(json.data)
+let enabled = true;
+
+(async () => {
+  const { VideoSpeedController } = await import("../video/default-video-speed")
+
+  if (supportedUrls.some(url => document.URL.startsWith(url))) {
+    const clickableKeymap = {
+      f: '.bilibili-player-video-fullscreen', // 全屏
+      w: '.bilibili-player-video-web-fullscreen', // 网页全屏
+      t: '.bilibili-player-video-btn-widescreen', // 宽屏
+      // r: '.bilibili-player-video-btn-repeat', // 切换循环模式
+      m: '.bilibili-player-video-btn-volume .bilibili-player-iconfont-volume', // 切换静音
+      p: '.bilibili-player-video-btn-pip', // 画中画
+      // l: '.video-toolbar .like', // 点赞
+      c: '.video-toolbar .coin,.tool-bar .coin-info, .video-toolbar-module .coin-box, .play-options-ul > li:nth-child(2)', // 投币
+      s: '.video-toolbar .collect, .video-toolbar-module .fav-box, .play-options-ul > li:nth-child(3)', // 收藏
+      ' ': '.bilibili-player-video-btn-start', // 砸瓦撸多
+    } as { [key: string]: string }
+    /** 长按`L`三连使用的记忆变量 */
+    let likeClick = true
+    /** 在稍后再看页面里, 记录当前视频是否赞过 */
+    let liked = false
+    const isWatchlater = document.URL.startsWith('https://www.bilibili.com/watchlater/')
+    const isMediaList = document.URL.startsWith('https://www.bilibili.com/medialist/play/')
+    if (isWatchlater) {
+      Observer.videoChange(() => {
+        Ajax.getJsonWithCredentials(`https://api.bilibili.com/x/web-interface/archive/has/like?aid=${unsafeWindow.aid}`).then(json => {
+          liked = Boolean(json.data)
+        })
       })
-    })
-  }
-  /** 播放速度提示框用的`setTimeout`句柄 */
-  let showPlaybackTipOldTimeout: number
-  /**
-   * 显示播放速度提示框
-   * @param speed 播放速度
-   */
-  const showPlaybackTip = (speed: number) => {
-    let tip = dq('.keymap-playback-tip') as HTMLDivElement
-    if (!tip) {
-      const player = dq('.bilibili-player-video-wrap')
-      if (!player) {
-        return
-      }
-      player.insertAdjacentHTML('afterbegin', /*html*/`
+    }
+    /** 播放速度提示框用的`setTimeout`句柄 */
+    let showPlaybackTipOldTimeout: number
+    /**
+     * 显示播放速度提示框
+     * @param speed 播放速度
+     */
+    const showPlaybackTip = (speed: number) => {
+      let tip = dq('.keymap-playback-tip') as HTMLDivElement
+      if (!tip) {
+        const player = dq('.bilibili-player-video-wrap')
+        if (!player) {
+          return
+        }
+        player.insertAdjacentHTML('afterbegin', /*html*/`
         <div class="keymap-playback-tip-container">
           <i class="mdi mdi-fast-forward"></i>
           <div class="keymap-playback-tip"></div>x
         </div>
       `)
-      resources.applyStyleFromText(`
+        resources.applyStyleFromText(`
         .keymap-playback-tip-container {
           position: absolute;
           left: 50%;
@@ -77,147 +81,151 @@ if (supportedUrls.some(url => document.URL.startsWith(url))) {
           font-size: 18pt;
         }
       `, 'keymapStyle')
-      tip = dq('.keymap-playback-tip') as HTMLDivElement
+        tip = dq('.keymap-playback-tip') as HTMLDivElement
+      }
+      tip.innerHTML = speed.toString()
+      if (showPlaybackTipOldTimeout) {
+        clearTimeout(showPlaybackTipOldTimeout)
+      }
+      (dq('.keymap-playback-tip-container') as HTMLDivElement).classList.add('show')
+      showPlaybackTipOldTimeout = window.setTimeout(() => {
+        (dq('.keymap-playback-tip-container') as HTMLDivElement).classList.remove('show')
+      }, 2000)
     }
-    tip.innerHTML = speed.toString()
-    if (showPlaybackTipOldTimeout) {
-      clearTimeout(showPlaybackTipOldTimeout)
-    }
-    (dq('.keymap-playback-tip-container') as HTMLDivElement).classList.add('show')
-    showPlaybackTipOldTimeout = window.setTimeout(() => {
-      (dq('.keymap-playback-tip-container') as HTMLDivElement).classList.remove('show')
-    }, 2000)
-  }
-  document.body.addEventListener('keydown', e => {
-    if (!enabled) {
-      return
-    }
-    if (isWatchlater && document.URL.endsWith('list')) {
-      return
-    }
-    if (document.activeElement && isTyping()) {
-      return
-    }
-    const key = e.key.toLowerCase()
-    const panoramaControl = dq('.bilibili-player-sphere-control') as HTMLElement
-    if (panoramaControl !== null && panoramaControl.style.display !== 'none' && ['w', 'a', 's', 'd'].includes(key)) {
-      return
-    }
-    const noModifyKeys = !e.shiftKey && !e.altKey && !e.ctrlKey && !e.metaKey
-    if (key in clickableKeymap && noModifyKeys) {
-      const element = dq(clickableKeymap[key]) as HTMLElement
-      if (!element) {
+    document.body.addEventListener('keydown', async e => {
+      if (!enabled) {
         return
       }
-      e.stopPropagation()
-      e.preventDefault()
-      element.click()
-    } else if (key === 'd' && noModifyKeys) { // 切换弹幕开关
-      const checkbox = dq('.bilibili-player-video-danmaku-switch input') as HTMLInputElement
-      if (!checkbox) {
+      if (isWatchlater && document.URL.endsWith('list')) {
         return
       }
-      e.stopPropagation()
-      e.preventDefault()
-      checkbox.checked = !checkbox.checked
-      raiseEvent(checkbox, 'change')
-    } else if (key === 'j' && noModifyKeys) { // 绯红之王
-      const video = dq('.bilibili-player-video video') as HTMLVideoElement
-      video.currentTime += settings.keymapJumpSeconds
-      e.stopPropagation()
-      e.preventDefault()
-    } else if (key === 'l' && noModifyKeys) {
-      if (isWatchlater) {
-        const formData = {
-          aid: unsafeWindow.aid,
-          /** `1`点赞; `2`取消赞 */
-          like: liked ? 2 : 1,
-          csrf: getCsrf(),
-        }
-        Ajax.postTextWithCredentials(`https://api.bilibili.com/x/web-interface/archive/like`, Object.entries(formData).map(([k, v]) => `${k}=${v}`).join('&')).then(() => {
-          liked = !liked
-          if (liked) {
-            Toast.success(`已点赞`, `快捷键扩展`, 1000)
-          } else {
-            Toast.success(`已取消点赞`, `快捷键扩展`, 1000)
-          }
-        })
-      } else if (isMediaList) {
-        const likeButton = dq('.play-options-ul > li:first-child') as HTMLLIElement
-        if (likeButton) {
-          likeButton.click()
-        }
-      } else {
-        const likeButton = dq('.video-toolbar .like') as HTMLSpanElement
-        e.preventDefault()
-        const fireEvent = (name: string, args: Event) => {
-          const event = new CustomEvent(name, args)
-          likeButton.dispatchEvent(event)
-        }
-        likeClick = true
-        setTimeout(() => likeClick = false, 200)
-        fireEvent('mousedown', e)
-        document.body.addEventListener('keyup', e => {
-          e.preventDefault()
-          fireEvent('mouseup', e)
-          if (likeClick) {
-            fireEvent('click', e)
-          }
-        }, { once: true })
-      }
-    } else if (key === '`' && noModifyKeys) {
-      // menu size: 386.6 x 311 (2020-03-29)
-      // menu size: 176.65 x 194 (2020-06-09)
-      const player = dq('.bilibili-player-video-wrap') as HTMLElement
-      const rect = player.getBoundingClientRect()
-      player.dispatchEvent(new MouseEvent('contextmenu', {
-        bubbles: true,
-        cancelable: false,
-        view: unsafeWindow,
-        button: 2,
-        buttons: 0,
-        clientX: rect.x + rect.width / 2 - 176.65 / 2,
-        clientY: rect.y + rect.height / 2 - 194 / 2
-      }))
-    } else if (e.shiftKey) {
-      const video = dq('.bilibili-player-video video') as HTMLVideoElement
-      if (video === null) {
+      if (document.activeElement && isTyping()) {
         return
       }
-      const playbackRates = [0.5, 0.75, 1.0, 1.25, 1.5, 2.0, 2.5, 3.0]
-      let preventDefault = true
-      if (key === '>' || key === 'ArrowUp'.toLowerCase()) { // 天堂制造
-        video.playbackRate = playbackRates.find(it => it > video.playbackRate) || playbackRates[playbackRates.length - 1]
-        showPlaybackTip(video.playbackRate)
-      } else if (key === '<' || key === 'ArrowDown'.toLowerCase()) { // 时间减速
-        video.playbackRate = [...playbackRates].reverse().find(it => it < video.playbackRate) || playbackRates[0]
-        showPlaybackTip(video.playbackRate)
-      } else if (key === '?') { // 重置速度
-        video.playbackRate = 1
-        showPlaybackTip(video.playbackRate)
-      } else if (key === 'w') { // 稍后再看
-        const watchlater = dq('.video-toolbar .ops .watchlater, .more-ops-list .ops-watch-later, .video-toolbar-module .see-later-box') as HTMLElement
-        if (watchlater !== null) {
-          watchlater.click()
-        }
-      } else if (key === 'j') { // 败者食尘
-        video.currentTime -= settings.keymapJumpSeconds
-      } else if (key === 's') { // 快速收藏
-        const quickFavorite = dq('.quick-favorite') as HTMLElement
-        if (quickFavorite) {
-          quickFavorite.click()
-        }
-      } else {
-        preventDefault = false
+      const key = e.key.toLowerCase()
+      const panoramaControl = dq('.bilibili-player-sphere-control') as HTMLElement
+      if (panoramaControl !== null && panoramaControl.style.display !== 'none' && ['w', 'a', 's', 'd'].includes(key)) {
+        return
       }
-
-      if (preventDefault) {
+      const noModifyKeys = !e.shiftKey && !e.altKey && !e.ctrlKey && !e.metaKey
+      if (key in clickableKeymap && noModifyKeys) {
+        const element = dq(clickableKeymap[key]) as HTMLElement
+        if (!element) {
+          return
+        }
         e.stopPropagation()
         e.preventDefault()
+        element.click()
+      } else if (key === 'd' && noModifyKeys) { // 切换弹幕开关
+        const checkbox = dq('.bilibili-player-video-danmaku-switch input') as HTMLInputElement
+        if (!checkbox) {
+          return
+        }
+        e.stopPropagation()
+        e.preventDefault()
+        checkbox.checked = !checkbox.checked
+        raiseEvent(checkbox, 'change')
+      } else if (key === 'j' && noModifyKeys) { // 绯红之王
+        const video = dq('.bilibili-player-video video') as HTMLVideoElement
+        video.currentTime += settings.keymapJumpSeconds
+        e.stopPropagation()
+        e.preventDefault()
+      } else if (key === 'l' && noModifyKeys) {
+        if (isWatchlater) {
+          const formData = {
+            aid: unsafeWindow.aid,
+            /** `1`点赞; `2`取消赞 */
+            like: liked ? 2 : 1,
+            csrf: getCsrf(),
+          }
+          Ajax.postTextWithCredentials(`https://api.bilibili.com/x/web-interface/archive/like`, Object.entries(formData).map(([k, v]) => `${k}=${v}`).join('&')).then(() => {
+            liked = !liked
+            if (liked) {
+              Toast.success(`已点赞`, `快捷键扩展`, 1000)
+            } else {
+              Toast.success(`已取消点赞`, `快捷键扩展`, 1000)
+            }
+          })
+        } else if (isMediaList) {
+          const likeButton = dq('.play-options-ul > li:first-child') as HTMLLIElement
+          if (likeButton) {
+            likeButton.click()
+          }
+        } else {
+          const likeButton = dq('.video-toolbar .like') as HTMLSpanElement
+          e.preventDefault()
+          const fireEvent = (name: string, args: Event) => {
+            const event = new CustomEvent(name, args)
+            likeButton.dispatchEvent(event)
+          }
+          likeClick = true
+          setTimeout(() => likeClick = false, 200)
+          fireEvent('mousedown', e)
+          document.body.addEventListener('keyup', e => {
+            e.preventDefault()
+            fireEvent('mouseup', e)
+            if (likeClick) {
+              fireEvent('click', e)
+            }
+          }, { once: true })
+        }
+      } else if (key === '`' && noModifyKeys) {
+        // menu size: 386.6 x 311 (2020-03-29)
+        // menu size: 176.65 x 194 (2020-06-09)
+        const player = dq('.bilibili-player-video-wrap') as HTMLElement
+        const rect = player.getBoundingClientRect()
+        player.dispatchEvent(new MouseEvent('contextmenu', {
+          bubbles: true,
+          cancelable: false,
+          view: unsafeWindow,
+          button: 2,
+          buttons: 0,
+          clientX: rect.x + rect.width / 2 - 176.65 / 2,
+          clientY: rect.y + rect.height / 2 - 194 / 2
+        }))
+      } else if (e.shiftKey) {
+        const containerElement = await SpinQuery.select(`.${VideoSpeedController.classNameMap.speedContainer}`) as HTMLElement
+        const videoElement = await SpinQuery.select(`.${VideoSpeedController.classNameMap.video} video`) as HTMLVideoElement
+
+        const controller = new VideoSpeedController(containerElement, videoElement, 1)
+
+        const playbackRates = VideoSpeedController.supportedRates
+
+        let preventDefault = true
+        if (key === '>' || key === 'ArrowUp'.toLowerCase()) { // 天堂制造
+          controller.setVideoSpeed(playbackRates.find(it => it > controller.playbackRate) || playbackRates[playbackRates.length - 1])
+          showPlaybackTip(controller.playbackRate)
+        } else if (key === '<' || key === 'ArrowDown'.toLowerCase()) { // 时间减速
+          controller.setVideoSpeed([...playbackRates].reverse().find(it => it < controller.playbackRate) || playbackRates[0])
+          showPlaybackTip(controller.playbackRate)
+        } else if (key === '?') { // 重置速度
+          controller.reset()
+          showPlaybackTip(controller.playbackRate)
+        } else if (key === 'w') { // 稍后再看
+          const watchlater = dq('.video-toolbar .ops .watchlater, .more-ops-list .ops-watch-later, .video-toolbar-module .see-later-box') as HTMLElement
+          if (watchlater !== null) {
+            watchlater.click()
+          }
+        } else if (key === 'j') { // 败者食尘
+          videoElement.currentTime -= settings.keymapJumpSeconds
+        } else if (key === 's') { // 快速收藏
+          const quickFavorite = dq('.quick-favorite') as HTMLElement
+          if (quickFavorite) {
+            quickFavorite.click()
+          }
+        } else {
+          preventDefault = false
+        }
+
+        if (preventDefault) {
+          e.stopPropagation()
+          e.preventDefault()
+        }
       }
-    }
-  })
-}
+    })
+  }
+})()
+
 export default {
   reload: () => enabled = true,
   unload: () => enabled = false,


### PR DESCRIPTION
<!-- 可以参考下代码贡献指南: https://github.com/the1812/Bilibili-Evolved/blob/preview/CONTRIBUTING.md -->

来自 #1315

- 修复：通过扩展快捷键修改倍数后，界面元素（倍数菜单）状态与实际情况不一致
- 变更：`useDefaultVideoSpeed` 设置项现在指示是否记忆上次所选的倍数
- 新增：`rememberVideoSpeed` 设置项可指示是否记忆视频级别的倍数
    - 依赖 `useDefaultVideoSpeed`，当 `useDefaultVideoSpeed` 设置为 true 时，此设置项才有效 
- 新增：`rememberVideoSpeedList` 设置项用于存储细化到视频级别的倍数记忆值
- 变更： `defaultVideoSpeed` 将指示缺省情况下的默认速度值
    - 当启用 `useDefaultVideoSpeed` 并禁用 `rememberVideoSpeed` 时，可通过原生倍数菜单（或快捷键扩展）设置不相同的倍数来修改此值
    - 当启用 `useDefaultVideoSpeed` 并启用 `rememberVideoSpeed` 时，如果当前视频没有相应的记忆值，则使用此值作为默认值
- 新增：`extendVideoSpeed` 设置项可指示是否扩展原生倍数（也会影响快捷键扩展的播放速度上限）
  ![image](https://user-images.githubusercontent.com/34429322/102590284-4a4f5d80-414b-11eb-975f-a7e2c4843010.png)
