### PR TITLE
播放器返回开头播放

### DIFF
--- a/src/utils/gui-settings/tooltip/settings-tooltip.zh-CN.ts
+++ b/src/utils/gui-settings/tooltip/settings-tooltip.zh-CN.ts
@@ -157,7 +157,8 @@ export const toolTips = new Map<keyof BilibiliEvolvedSettings, string>([
 - <kbd>Shift + w</kbd> 稍后再看
 - <kbd>Shift + s</kbd> 快速收藏
 - <kbd>Shift + ↑/↓</kbd> / <kbd>Shift + ,/.</kbd> 播放速度调整
-- <kbd>Shift + /</kbd> 重置播放速度`],
+- <kbd>Shift + /</kbd> 重置播放速度
+- <kbd>0</kbd> 返回开头播放`],
   ['doubleClickFullscreen', /*html*/`允许双击播放器切换全屏, 请注意不能与<span>播放器触摸支持-启用双击控制</span>一同使用.`],
   ['ajaxHook', /*html*/`是否启用 Ajax Hook API, 其他插件或附加功能能够通过此 API 获取 Ajax 请求的信息.`],
   ['scriptLoadingMode', /*html*/`脚本功能的加载模式:

--- a/src/video/keymap/keymap.ts
+++ b/src/video/keymap/keymap.ts
@@ -237,7 +237,7 @@ if (supportedUrls.some(url => document.URL.startsWith(url))) {
     takeScreenshot: 'ctrl alt c',
     previousFrame: 'shift arrowLeft',
     nextFrame: 'shift arrowRight',
-    seekBegin: '0'
+    seekBegin: '0',
   }
   const parseBindings = (bindings: { [action: string]: string }) => {
     return Object.entries(bindings).map(([actionName, keyString]) => {
@@ -250,11 +250,11 @@ if (supportedUrls.some(url => document.URL.startsWith(url))) {
   }
 
   ;(async () => {
-      const { loadKeyBindings } = await import('./key-bindings')
-      config = loadKeyBindings(parseBindings(
-        { ...defaultBindings, ...settings.customKeyBindings }
-      ))
-    })()
+    const { loadKeyBindings } = await import('./key-bindings')
+    config = loadKeyBindings(parseBindings(
+      { ...defaultBindings, ...settings.customKeyBindings }
+    ))
+  })()
 }
 
 export default {

--- a/src/video/keymap/keymap.ts
+++ b/src/video/keymap/keymap.ts
@@ -201,6 +201,12 @@ if (supportedUrls.some(url => document.URL.startsWith(url))) {
     takeScreenshot: clickElement('.video-take-screenshot'),
     previousFrame: clickElement('.prev-frame'),
     nextFrame: clickElement('.next-frame'),
+    returnBegin: () => {
+      if (unsafeWindow.player) {
+        unsafeWindow.player.play()
+        setTimeout(() => unsafeWindow.player.seek(0))
+      }
+    },
   }
   const defaultBindings: { [action in keyof typeof actions]: string } = {
     fullscreen: 'f',
@@ -224,6 +230,7 @@ if (supportedUrls.some(url => document.URL.startsWith(url))) {
     takeScreenshot: 'ctrl alt c',
     previousFrame: 'shift arrowLeft',
     nextFrame: 'shift arrowRight',
+    returnBegin: '0'
   }
   const parseBindings = (bindings: { [action: string]: string }) => {
     return Object.entries(bindings).map(([actionName, keyString]) => {

--- a/src/video/keymap/keymap.ts
+++ b/src/video/keymap/keymap.ts
@@ -201,7 +201,7 @@ if (supportedUrls.some(url => document.URL.startsWith(url))) {
     takeScreenshot: clickElement('.video-take-screenshot'),
     previousFrame: clickElement('.prev-frame'),
     nextFrame: clickElement('.next-frame'),
-    returnBegin: () => {
+    seekBegin: () => {
       if (!unsafeWindow.player) {
         return
       }
@@ -237,7 +237,7 @@ if (supportedUrls.some(url => document.URL.startsWith(url))) {
     takeScreenshot: 'ctrl alt c',
     previousFrame: 'shift arrowLeft',
     nextFrame: 'shift arrowRight',
-    returnBegin: '0'
+    seekBegin: '0'
   }
   const parseBindings = (bindings: { [action: string]: string }) => {
     return Object.entries(bindings).map(([actionName, keyString]) => {

--- a/src/video/keymap/keymap.ts
+++ b/src/video/keymap/keymap.ts
@@ -202,10 +202,17 @@ if (supportedUrls.some(url => document.URL.startsWith(url))) {
     previousFrame: clickElement('.prev-frame'),
     nextFrame: clickElement('.next-frame'),
     returnBegin: () => {
-      if (unsafeWindow.player) {
-        unsafeWindow.player.play()
-        setTimeout(() => unsafeWindow.player.seek(0))
+      if (!unsafeWindow.player) {
+        return
       }
+      unsafeWindow.player.play()
+      setTimeout(() => {
+        unsafeWindow.player.seek(0)
+        const toastText = dq(".bilibili-player-video-toast-bottom .bilibili-player-video-toast-item:first-child .bilibili-player-video-toast-item-text span:nth-child(2)")
+        if (toastText) {
+          toastText.textContent = " 00:00"
+        }
+      })
     },
   }
   const defaultBindings: { [action in keyof typeof actions]: string } = {
@@ -243,11 +250,11 @@ if (supportedUrls.some(url => document.URL.startsWith(url))) {
   }
 
   ;(async () => {
-    const { loadKeyBindings } = await import('./key-bindings')
-    config = loadKeyBindings(parseBindings(
-      { ...defaultBindings, ...settings.customKeyBindings }
-    ))
-  })()
+      const { loadKeyBindings } = await import('./key-bindings')
+      config = loadKeyBindings(parseBindings(
+        { ...defaultBindings, ...settings.customKeyBindings }
+      ))
+    })()
 }
 
 export default {


### PR DESCRIPTION
<!-- 可以参考下代码贡献指南: https://github.com/the1812/Bilibili-Evolved/blob/preview/CONTRIBUTING.md -->

来自 #1411

不知道为啥，直接调用 `unsafeWindow.player.seek(0)` 会导致播放器开始播放，但是居然还保持了上次播放位置的记忆状态，等到用户再次暂停播放时就会被触发，只好先调用一遍 `unsafeWindow.player.play()`。

但这样做也并非没有缺点，还是会弹出提示：

![image](https://user-images.githubusercontent.com/34429322/103611431-3bdfaf00-4f5d-11eb-9a3c-52c5ef9a23d9.png)

要屏蔽这个提示也不是做不到，就是感觉有点麻烦，不知道有没有更好的办法