### PR TITLE
fix #1504

### DIFF
--- a/src/video/video-speed/video-speed-controller.ts
+++ b/src/video/video-speed/video-speed-controller.ts
@@ -92,7 +92,7 @@ export class VideoSpeedController {
     settings.rememberVideoSpeedList = settings.rememberVideoSpeedList
   }
 
-  static async getInstance(previousSpeed?: number, previousNativeSpeed?: number) {
+  static async getInstance(previousSpeed?: number, nativeSpeed?: number) {
     const containerElement = await SpinQuery.select(`.${VideoSpeedController.classNameMap.speedContainer}`)
     const videoElement = await SpinQuery.select(`.${VideoSpeedController.classNameMap.video} video`) as HTMLVideoElement
 
@@ -103,7 +103,7 @@ export class VideoSpeedController {
       throw "video element not found!"
     }
 
-    return new VideoSpeedController(containerElement, videoElement, previousSpeed, previousNativeSpeed)
+    return new VideoSpeedController(containerElement, videoElement, previousSpeed, nativeSpeed)
   }
 
   static init = _.once(() => {

--- a/src/video/video-speed/video-speed-controller.ts
+++ b/src/video/video-speed/video-speed-controller.ts
@@ -92,7 +92,7 @@ export class VideoSpeedController {
     settings.rememberVideoSpeedList = settings.rememberVideoSpeedList
   }
 
-  static async getInstance(previousSpeed?: number) {
+  static async getInstance(previousSpeed?: number, previousNativeSpeed?: number) {
     const containerElement = await SpinQuery.select(`.${VideoSpeedController.classNameMap.speedContainer}`)
     const videoElement = await SpinQuery.select(`.${VideoSpeedController.classNameMap.video} video`) as HTMLVideoElement
 
@@ -103,19 +103,20 @@ export class VideoSpeedController {
       throw "video element not found!"
     }
 
-    return new VideoSpeedController(containerElement, videoElement, previousSpeed)
+    return new VideoSpeedController(containerElement, videoElement, previousSpeed, previousNativeSpeed)
   }
 
   static init = _.once(() => {
     // 分 P 切换时共享同一个倍数
     let sharedSpeed = 1
+    let sharedNativeSpeed = 1
     // 持有菜单容器元素的引用，videoChange 时更换（以前缓存的 VideoController 就没有意义了）
     let containerElement: HTMLElement
 
     Observer.videoChange(async () => {
       const { getExtraSpeedMenuItemElements } = await import("./extend-video-speed")
-      // 有必要传递之前的 nativeSpeedVal，跨分 P 时原生倍数将保持一样
-      const controller = await VideoSpeedController.getInstance(sharedSpeed)
+      // 有必要传递之前的 nativeSpeed，跨分 P 时原生倍数将保持一样
+      const controller = await VideoSpeedController.getInstance(sharedSpeed, sharedNativeSpeed)
       controller.observe();
       if (settings.extendVideoSpeed) {
         controller._menuListElement.prepend(...await getExtraSpeedMenuItemElements())
@@ -136,10 +137,13 @@ export class VideoSpeedController {
           }
         })
       }
-      // 理论上这里的 controller 一定是非缓存的，因此不用太担心事件监听注册重复
+      // 理论上这里的 controller 一定是非缓存的（换 P 的时候 containerElement 是会发生改变的），因此不用担心重复注册事件监听
       ({ containerElement } = controller)
-      containerElement.addEventListener("changed", ({ detail: { speed } }: CustomEvent) => {
+      containerElement.addEventListener("changed", ({ detail: { speed, isNativeSpeed } }: CustomEvent) => {
         sharedSpeed = speed
+        if (isNativeSpeed) {
+          sharedNativeSpeed = speed
+        }
       })
       // 首次加载可能会遇到意外情况，导致内部强制更新失效，因此延时 100 ms 再触发速度设置
       setTimeout(() => {
@@ -156,9 +160,9 @@ export class VideoSpeedController {
   private _nativeSpeedVal: number
   private _previousSpeedVal: number
 
-  constructor(containerElement: HTMLElement, videoElement: HTMLVideoElement, previousSpeed?: number) {
+  constructor(containerElement: HTMLElement, videoElement: HTMLVideoElement, previousSpeed?: number, nativeSpeed?: number) {
     const controller = VideoSpeedController.instanceMap.get(containerElement)
-    if (controller && (!previousSpeed || controller.playbackRate === previousSpeed)) {
+    if (controller && (!previousSpeed || controller._previousSpeedVal === previousSpeed) && (!nativeSpeed || controller._nativeSpeedVal === nativeSpeed)) {
       return controller
     }
 
@@ -168,7 +172,7 @@ export class VideoSpeedController {
 
     this._containerElement = containerElement
     this._previousSpeedVal = previousSpeed
-    this._nativeSpeedVal = VideoSpeedController.nativeSupportedRates.includes(previousSpeed) ? previousSpeed : 1
+    this._nativeSpeedVal = nativeSpeed ? nativeSpeed : (VideoSpeedController.nativeSupportedRates.includes(previousSpeed) ? previousSpeed : 1)
     this._nameBtn = this._containerElement.querySelector(`.${VideoSpeedController.classNameMap.speedNameBtn}`) as HTMLButtonElement
     this._menuListElement = this._containerElement.querySelector(`.${VideoSpeedController.classNameMap.speedMenuList}`) as HTMLElement
 
@@ -213,11 +217,13 @@ export class VideoSpeedController {
 
         currentSpeed = parseFloat(selectedSpeedOption.dataset.value ?? '1')
 
-        this._containerElement.dispatchEvent(new CustomEvent("changed", { detail: { speed: currentSpeed, previousSpeed: this._previousSpeedVal } }))
-
+        let isNativeSpeed = false
         if (VideoSpeedController.nativeSupportedRates.includes(currentSpeed)) {
           this._nativeSpeedVal = currentSpeed
+          isNativeSpeed = true
         }
+
+        this._containerElement.dispatchEvent(new CustomEvent("changed", { detail: { speed: currentSpeed, isNativeSpeed, previousSpeed: this._previousSpeedVal } }))
         // 原生支持倍数的应用后，有必要清除扩展倍数选项上的样式
         if (settings.extendVideoSpeed && VideoSpeedController.nativeSupportedRates.includes(currentSpeed)) {
           this._menuListElement.querySelector(`.${VideoSpeedController.classNameMap.speedMenuItem}.extended.${VideoSpeedController.classNameMap.active}`)?.classList.remove(VideoSpeedController.classNameMap.active)


### PR DESCRIPTION
<!-- 可以参考下代码贡献指南: https://github.com/the1812/Bilibili-Evolved/blob/preview/CONTRIBUTING.md -->

基本上可以确定是在 ea3ec8645c6a400bae48df94875ee5c3c14874a3 中引入的 BUG，当时想着存储上一次的倍数包括了原生倍速值，就不用单独传递原生倍速了，事实是上一次倍数可能是原生倍速，但也有可能是扩展倍速，原生倍速还是要单独传递。

* API 变化
  - `getInstance` 和 `constructor` 均新增一个参数，用于传递原生倍速值
  - 在 `containerElement` 元素上分发的自定义事件的 `detail` 属性新增一个 `isNativeSpeed` 属性，用于表示变更的倍速是否为原生倍速
  - `setVideoSpeed` 方法的参数可省，这样调用不会产生任何副作用
  - 现在实例化时传入的 `previousSpeed` 参数真·可省，不会提供默认值
* 功能变化
  - 现在缓存命中机制除了考虑 `containerElement` 元素，还会比较上一次倍数值和原生倍速值
  - 修正了内部原生倍速值的获取方法，现在优先使用传入的原生倍速值，其次尝试使用上一次倍数值，最后才使用默认的 1.0x 值
  - `reset` 方法如果用于清除视频记忆，则必须在开启记忆倍数功能后使用，否则不会生效