### PR TITLE
夜间模式适配 2021 拜年纪活动页

### DIFF
--- a/src/style/dark/dark-slice-bnj2021.scss
+++ b/src/style/dark/dark-slice-bnj2021.scss
@@ -34,3 +34,20 @@
   .bui-bar.bui-bar-normal {
   @include theme-background-color();
 }
+#danmukuBox[style*="background:#B22D43" i] {
+  .bui-collapse-header {
+    background-color: #b22d43 !important;
+  }
+  .player-auxiliary-filter-title,
+  .player-auxiliary-filter-menu {
+    color: #ffd886 !important;
+  }
+}
+.app-section .game-box ~ {
+  .videos-box .video-title {
+    color: #872339 !important;
+  }
+  .footer-box .comment-container {
+    @include background-color();
+  }
+}

--- a/src/style/dark/dark-slice-bnj2021.scss
+++ b/src/style/dark/dark-slice-bnj2021.scss
@@ -1,0 +1,36 @@
+@import "./dark-definitions";
+
+.festival-main-panel ~ {
+  .video-toolbar {
+    color: #ffd886 !important;
+    .share-box {
+      .title {
+        @include color("e");
+      }
+      .name,
+      .box-b-title {
+        @include color("a");
+      }
+    }
+    .more-list {
+      @include border-color();
+      @include background-color("2");
+      @include color("e");
+      li:hover {
+        @include theme-color();
+        @include background-color("4");
+      }
+    }
+  }
+  .comment-wrapper .comment-m {
+    @include background-color("2");
+  }
+}
+.festival-video-player
+  .bilibili-player.bilibili-player-theme-red
+  .bui-slider
+  .bui-track
+  .bui-bar-wrap
+  .bui-bar.bui-bar-normal {
+  @include theme-background-color();
+}


### PR DESCRIPTION
<!-- 可以参考下代码贡献指南: https://github.com/the1812/Bilibili-Evolved/blob/preview/CONTRIBUTING.md -->

> [活动页地址](https://www.bilibili.com/festival/2021bnj)

主要修复了一下明晃晃的评论区，以及一些比较明显的样式冲突：

![image](https://user-images.githubusercontent.com/34429322/106777993-7766b980-6680-11eb-8939-eb27e9bc76e9.png)

恢复了弹幕列表头部的背景色：

![image](https://user-images.githubusercontent.com/34429322/107109799-1efd0b00-687e-11eb-81ea-20ff2a39281f.png)
