### PR TITLE
修复互动视频在切换剧情分支时，倍数菜单重复初始化的问题

### DIFF
--- a/src/video/video-speed/video-speed-controller.ts
+++ b/src/video/video-speed/video-speed-controller.ts
@@ -119,6 +119,10 @@ export class VideoSpeedController {
       const { calcOrder } = await import("./video-speed-common")
       // 有必要传递之前的 nativeSpeedVal，跨分 P 时原生倍数将保持一样
       const controller = await VideoSpeedController.getInstance(sharedSpeed)
+      containerElement = controller.containerElement
+      if (containerElement.classList.contains("extended")) {
+        return
+      }
       if (settings.extendVideoSpeed) {
         controller._menuListElement.prepend(...await getExtraSpeedMenuItemElements())
         // 为所有原生倍速菜单项设置 Order
@@ -143,8 +147,6 @@ export class VideoSpeedController {
         })
       }
       controller.observe();
-      // 理论上这里的 controller 一定是非缓存的（换 P 的时候 containerElement 是会发生改变的），因此不用担心重复注册事件监听
-      ({ containerElement } = controller)
       containerElement.addEventListener("changed", ({ detail: { speed, isNativeSpeed } }: CustomEvent) => {
         sharedSpeed = speed
         if (isNativeSpeed) {
@@ -155,6 +157,7 @@ export class VideoSpeedController {
       setTimeout(() => {
         controller.setVideoSpeed((settings.useDefaultVideoSpeed && settings.rememberVideoSpeed && VideoSpeedController.getRememberSpeed()) || VideoSpeedController.fallbackVideoSpeed || sharedSpeed)
       }, 100)
+      containerElement.classList.add("extended")
     })
   })
 


### PR DESCRIPTION
<!-- 可以参考下代码贡献指南: https://github.com/the1812/Bilibili-Evolved/blob/preview/CONTRIBUTING.md -->

参考 https://github.com/the1812/Bilibili-Evolved/pull/1570#issuecomment-780542638

这肯定是发生了某种异变（看来还是得在初始化完成之后标记一下