### PR TITLE
PlayerAgent support LightOff action.

### DIFF
--- a/registry/lib/components/video/player/auto-light/index.ts
+++ b/registry/lib/components/video/player/auto-light/index.ts
@@ -23,17 +23,17 @@ export const component: ComponentMetadata = {
 
     videoChange(async () => {
       if (playerAgentInstance != null) {
-        const oldVideo = await playerAgentInstance.query.video.element() as HTMLVideoElement
+        const oldVideo = await playerAgentInstance.query.video.element()
         oldVideo.removeEventListener('ended', lightOn)
         oldVideo.removeEventListener('pause', lightOn)
         oldVideo.removeEventListener('play', lightOff)
       }
 
       playerAgentInstance = playerAgent
-      const { query, getPlayerConfig } = playerAgentInstance
-      const video = await query.video.element() as HTMLVideoElement
+      const { query, isAutoPlay } = playerAgentInstance
+      const video = await query.video.element()
 
-      if (getPlayerConfig('video_status.autoplay')) {
+      if (isAutoPlay()) {
         lightOff()
       }
 

--- a/registry/lib/components/video/player/auto-light/index.ts
+++ b/registry/lib/components/video/player/auto-light/index.ts
@@ -1,6 +1,9 @@
 import { ComponentMetadata } from '@/components/types'
+import { playerAgent } from '@/components/video/player-agent'
 import { videoChange } from '@/core/observer'
 import { allVideoUrls } from '@/core/utils/urls'
+
+let playerAgentInstance
 
 export const component: ComponentMetadata = {
   name: 'playerAutoLight',
@@ -17,19 +20,26 @@ export const component: ComponentMetadata = {
     if (isEmbeddedPlayer()) {
       return
     }
-    const autoPlay = lodash.get(
-      JSON.parse(localStorage.getItem('bilibili_player_settings')),
-      'video_status.autoplay',
-      false,
-    )
-    videoChange(() => {
-      const video = dq('video') as HTMLVideoElement
-      if (autoPlay) {
+
+    videoChange(async () => {
+      if (playerAgentInstance != null) {
+        const oldVideo = await playerAgentInstance.query.video.element() as HTMLVideoElement
+        oldVideo.removeEventListener('ended', lightOn)
+        oldVideo.removeEventListener('pause', lightOn)
+        oldVideo.removeEventListener('play', lightOff)
+      }
+
+      playerAgentInstance = playerAgent
+      const { query, getPlayerConfig } = playerAgentInstance
+      const video = await query.video.element() as HTMLVideoElement
+
+      if (getPlayerConfig('video_status.autoplay')) {
         lightOff()
       }
-      video.addEventListener('ended', () => lightOn())
-      video.addEventListener('pause', () => lightOn())
-      video.addEventListener('play', () => lightOff())
+
+      video.addEventListener('ended', lightOn)
+      video.addEventListener('pause', lightOn)
+      video.addEventListener('play', lightOff)
     })
   },
 }

--- a/registry/lib/components/video/player/default-mode/index.ts
+++ b/registry/lib/components/video/player/default-mode/index.ts
@@ -40,11 +40,7 @@ const entry: ComponentEntry = async ({ settings: { options } }) => {
   if (!video) {
     return
   }
-  const autoPlay = lodash.get(
-    JSON.parse(localStorage.getItem('bilibili_player_settings')),
-    'video_status.autoplay',
-    false,
-  )
+  const autoPlay = playerAgent.getPlayerConfig('video_status.autoplay')
   const action = actions.get(options.mode)
   const onplay = () => {
     const isNormalMode = !dq('body[class*=player-mode-]')

--- a/registry/lib/components/video/player/default-mode/index.ts
+++ b/registry/lib/components/video/player/default-mode/index.ts
@@ -40,7 +40,6 @@ const entry: ComponentEntry = async ({ settings: { options } }) => {
   if (!video) {
     return
   }
-  const autoPlay = playerAgent.getPlayerConfig('video_status.autoplay')
   const action = actions.get(options.mode)
   const onplay = () => {
     const isNormalMode = !dq('body[class*=player-mode-]')
@@ -48,7 +47,7 @@ const entry: ComponentEntry = async ({ settings: { options } }) => {
       action()
     }
   }
-  if (options.applyOnPlay && !autoPlay) {
+  if (options.applyOnPlay && !playerAgent.isAutoPlay()) {
     video.addEventListener('play', onplay, { once: true })
   } else {
     onplay()

--- a/registry/lib/components/video/player/intersection-actions/index.ts
+++ b/registry/lib/components/video/player/intersection-actions/index.ts
@@ -23,11 +23,19 @@ export const component: ComponentMetadata = {
       pause: boolean
       light: boolean
     }
-    const { query: { video } } = playerAgent
+    const playerAgentInstance = playerAgent
+    const { query: { video } } = playerAgentInstance
 
     const videoEl = await video.element() as HTMLVideoElement
     // const playerWrap = await video.wrap()
-    const playerWrap = (dq('.player-wrap') || dq('.player-module')) as HTMLElement
+    // 如果有 video-player 优先的使用该盒子
+    // 因为在稍后再看页面（medialist）视频也有 player-wrap
+    // 选择 player-wrap 会导致闪烁。
+    const playerWrap = (
+      document.getElementById('video-player')
+        ?? (dq('.player-wrap') || dq('.player-module'))
+      ) as HTMLElement
+
     let observer: IntersectionObserver
     let intersectionLock = true // Lock intersection action
 
@@ -101,11 +109,7 @@ export const component: ComponentMetadata = {
     )
 
     function mountPlayListener() {
-      const autoPlay = lodash.get(
-        JSON.parse(localStorage.getItem('bilibili_player_settings')),
-        'video_status.autoplay',
-        false,
-      )
+      const autoPlay = playerAgentInstance.getPlayerConfig('video_status.autoplay')
       videoChange(async () => {
         if (autoPlay) {
           addPlayerOutEvent()

--- a/registry/lib/components/video/player/intersection-actions/index.ts
+++ b/registry/lib/components/video/player/intersection-actions/index.ts
@@ -23,8 +23,7 @@ export const component: ComponentMetadata = {
       pause: boolean
       light: boolean
     }
-    const playerAgentInstance = playerAgent
-    const { query: { video } } = playerAgentInstance
+    const { query: { video } } = playerAgent
 
     const videoEl = await video.element() as HTMLVideoElement
     // const playerWrap = await video.wrap()
@@ -109,9 +108,8 @@ export const component: ComponentMetadata = {
     )
 
     function mountPlayListener() {
-      const autoPlay = playerAgentInstance.getPlayerConfig('video_status.autoplay')
       videoChange(async () => {
-        if (autoPlay) {
+        if (playerAgent.isAutoPlay()) {
           addPlayerOutEvent()
         }
         videoEl.addEventListener('play', addPlayerOutEvent)

--- a/src/components/video/player-agent.ts
+++ b/src/components/video/player-agent.ts
@@ -140,6 +140,11 @@ export abstract class PlayerAgent {
       false,
     )
   }
+
+  isAutoPlay() {
+    return this.getPlayerConfig('video_status.autoplay')
+  }
+
   abstract isMute(): boolean
   /** 更改音量 (%) */
   abstract changeVolume(change: number): number
@@ -245,8 +250,7 @@ export class VideoPlayerAgent extends PlayerAgent {
     return this.nativeApi.getCurrentTime()
   }
   async toggleLight(on:boolean) {
-    // const checkbox = this.query.control.settings.lightOff.sync() as HTMLInputElement
-    const checkbox = await select(this.query.control.settings.lightOff.selector) as HTMLInputElement
+    const checkbox = await this.query.control.settings.lightOff() as HTMLInputElement
     checkbox.checked = !on
     raiseEvent(checkbox, 'change')
   }

--- a/src/components/video/player-agent.ts
+++ b/src/components/video/player-agent.ts
@@ -93,9 +93,6 @@ const click = (target: ElementQuery) => {
 export abstract class PlayerAgent {
   abstract type: AgentType
   abstract query: PlayerQuery<ElementQuery>
-
-  abstract rawQueryObject: PlayerQuery<string>
-
   provideCustomQuery<CustomQueryType extends CustomQuery<string>>(
     config: CustomQueryProvider<CustomQueryType>,
   ) {
@@ -157,7 +154,7 @@ export class VideoPlayerAgent extends PlayerAgent {
     return unsafeWindow.player
   }
   type: AgentType = 'video'
-  rawQueryObject = {
+  query = selectorWrap({
     playerWrap: '.player-wrap',
     bilibiliPlayer: '.bilibili-player',
     playerArea: '.bilibili-player-area',
@@ -207,8 +204,7 @@ export class VideoPlayerAgent extends PlayerAgent {
     toastWrap: '.bilibili-player-video-toast-wrp',
     danmakuTipLayer: '.bilibili-player-dm-tip-wrap',
     danmakuSwitch: '.bilibili-player-video-danmaku-switch input',
-  }
-  query = selectorWrap(this.rawQueryObject) as PlayerQuery<ElementQuery>
+  }) as PlayerQuery<ElementQuery>
   isMute() {
     if (!this.nativeApi) {
       return null
@@ -250,7 +246,7 @@ export class VideoPlayerAgent extends PlayerAgent {
   }
   async toggleLight(on:boolean) {
     // const checkbox = this.query.control.settings.lightOff.sync() as HTMLInputElement
-    const checkbox = await select(this.rawQueryObject.control.settings.lightOff) as HTMLInputElement
+    const checkbox = await select(this.query.control.settings.lightOff.selector) as HTMLInputElement
     checkbox.checked = !on
     raiseEvent(checkbox, 'change')
   }
@@ -264,7 +260,7 @@ export class BwpPlayerAgent extends VideoPlayerAgent {
 }
 export class BangumiPlayerAgent extends PlayerAgent {
   type: AgentType = 'bangumi'
-  rawQueryObject = {
+  query = selectorWrap({
     playerWrap: '.player-module',
     bilibiliPlayer: '.bpx-player-container',
     playerArea: '.bpx-player-primary-area',
@@ -314,8 +310,7 @@ export class BangumiPlayerAgent extends PlayerAgent {
     toastWrap: '.bpx-player-tooltip-area',
     danmakuTipLayer: '.bpx-player-dialog-wrap',
     danmakuSwitch: '.bpx-player-dm-switch input',
-  }
-  query = selectorWrap(this.rawQueryObject) as PlayerQuery<ElementQuery>
+  }) as PlayerQuery<ElementQuery>
   constructor() {
     super()
     bpxPlayerPolyfill()

--- a/src/components/video/player-light.ts
+++ b/src/components/video/player-light.ts
@@ -12,15 +12,15 @@ const setLight = (on: boolean) => {
   return async () => {
     const playerAgentInstance = playerAgent
     const {
-      rawQueryObject: {
+      query: {
         control: { settings, buttons },
       },
     } = playerAgentInstance
 
     // if (!initialized) {
     loadLazyPlayerSettingsPanel(
-      buttons.settings,
-      settings.wrap,
+      buttons.settings.selector,
+      settings.wrap.selector,
     )
     // initialized = true
     // }

--- a/src/components/video/player-light.ts
+++ b/src/components/video/player-light.ts
@@ -1,52 +1,32 @@
-import { select } from '@/core/spin-query'
-import { matchUrlPattern, raiseEvent, none } from '@/core/utils'
+import { matchUrlPattern, none } from '@/core/utils'
 import { loadLazyPlayerSettingsPanel } from '@/core/utils/lazy-panel'
 import { playerUrls } from '@/core/utils/urls'
+import { playerAgent } from './player-agent'
 
-let initialized = false
+// let initialized = false
 
-const setLightAdaptor = {
-  bangumi: (doLightOn: boolean) => async () => {
-    if (!initialized) {
-      loadLazyPlayerSettingsPanel('.squirtle-setting-wrap', '.squirtle-video-setting')
-      initialized = true
-    }
-    const checkbox = await select('.squirtle-lightoff') as HTMLElement
-    const event = new MouseEvent('click')
-    // 处于关灯状态，要开灯 -> 开灯
-    checkbox.classList.contains('active') && doLightOn ? checkbox.dispatchEvent(event) : ''
-    // 处于开灯状态，要关灯 -> 关灯
-    !checkbox.classList.contains('active') && !doLightOn ? checkbox.dispatchEvent(event) : ''
-  },
-  fallback: (on: boolean) => {
-    if (!playerUrls.some(url => matchUrlPattern(url))) {
-      return none
-    }
-    return async () => {
-      if (!initialized) {
-        loadLazyPlayerSettingsPanel(
-          '.bilibili-player-video-btn-setting',
-          '.bilibili-player-video-btn-setting-wrap',
-          {
-            style: '.bilibili-player-video-btn-setting-wrap { display: none !important }',
-          },
-        )
-        initialized = true
-      }
-      const checkbox = await select('.bilibili-player-video-btn-setting-right-others-content-lightoff .bui-checkbox-input') as HTMLInputElement
-      checkbox.checked = !on
-      raiseEvent(checkbox, 'change')
-    }
-  },
-}
+const setLight = (on: boolean) => {
+  if (!playerUrls.some(url => matchUrlPattern(url))) {
+    return none
+  }
+  return async () => {
+    const playerAgentInstance = playerAgent
+    const {
+      rawQueryObject: {
+        control: { settings, buttons },
+      },
+    } = playerAgentInstance
 
-let setLight = setLightAdaptor.fallback
-for (const key in setLightAdaptor) {
-  if (Object.prototype.hasOwnProperty.call(setLightAdaptor, key)) {
-    if (matchUrlPattern(key)) {
-      setLight = setLightAdaptor[key]
-    }
+    // if (!initialized) {
+    loadLazyPlayerSettingsPanel(
+      buttons.settings,
+      settings.wrap,
+    )
+    // initialized = true
+    // }
+    playerAgentInstance.toggleLight(on)
   }
 }
+
 export const lightOn = setLight(true)
 export const lightOff = setLight(false)


### PR DESCRIPTION
`player-light` 我把判断是否初始化去掉了，现在每次`setlight`都会去加载一下设置面板。主要是为了应对多P的情况，多P切视频后要去触发一下面板才能关灯。

而且我发现一个问题，`playerAgent`貌似是一个自执行函数，这个函数返回`agent`实例，是特意设计的吗（比如强制使用`playerAgent.xxx`的形式调用实例方法，解构得话会导致`this`丢失）？
那么，如果在一个函数或者是一个功能里多次`playerAgent.xxx`是不是意味着会出现多个`agent`实例。