### PR TITLE
修复 Safari 无法加载问题

### DIFF
--- a/src/client/init.ts
+++ b/src/client/init.ts
@@ -28,6 +28,12 @@ export const init = async () => {
     await headLoaded(none)
   })
 
+  await promiseLoadTrace('compatibility patch', async () => {
+    // 兼容性补丁
+    const { compatibilityPatch } = await import('./compatibility')
+    compatibilityPatch()
+  })
+
   const { coreApis, externalApis } = await import('@/core/core-apis')
   unsafeWindow.bilibiliEvolved = externalApis
   /** sand-boxed window, safe to use original name */
@@ -36,12 +42,6 @@ export const init = async () => {
   window.dqa = coreApis.utils.dqa
   window.none = coreApis.utils.none
   window.componentsTags = coreApis.componentApis.component.componentsTags
-
-  await promiseLoadTrace('compatibility patch', async () => {
-    // 兼容性补丁
-    const { compatibilityPatch } = await import('./compatibility')
-    compatibilityPatch()
-  })
 
   const { loadAllUserComponents } = await import('@/components/component')
   await promiseLoadTrace('parse user components', loadAllUserComponents)

--- a/src/components/settings-panel/index.ts
+++ b/src/components/settings-panel/index.ts
@@ -12,6 +12,12 @@ export enum SettingsPanelDockSide {
   Left = '左侧',
   Right = '右侧',
 }
+
+export enum Branch {
+  Master = 'master',
+  Preview = 'preview'
+}
+
 const entry: ComponentEntry = async ({ metadata }) => {
   const { isIframe } = await import('@/core/utils')
   if (isIframe()) {
@@ -62,6 +68,11 @@ export const component: ComponentMetadata = {
       defaultValue: CdnTypes.jsDelivr,
       displayName: '更新源',
       dropdownEnum: CdnTypes,
+    },
+    branch: {
+      defaultValue: Branch.Preview,
+      displayName: '更新分支',
+      dropdownEnum: Branch,
     },
     dockSide: {
       defaultValue: SettingsPanelDockSide.Left,

--- a/src/components/settings-panel/sub-pages/online-registry/OnlineRegistry.vue
+++ b/src/components/settings-panel/sub-pages/online-registry/OnlineRegistry.vue
@@ -107,10 +107,11 @@ export default Vue.extend({
       if (this.loading) {
         return
       }
+      const fetchPath = cdnRoots[getGeneralSettings().cdnRoot](getGeneralSettings().branch)
       try {
         this.loading = true
-        const featureListUrl = `${cdnRoots[getGeneralSettings().cdnRoot](meta.compilationInfo.branch)}doc/features/features.json`
-        const packListUrl = `${cdnRoots[getGeneralSettings().cdnRoot](meta.compilationInfo.branch)}doc/features/pack/pack.json`
+        const featureListUrl = `${fetchPath}doc/features/features.json`
+        const packListUrl = `${fetchPath}doc/features/pack/pack.json`
         const featureList = await monkey({
           url: featureListUrl,
           responseType: 'json',

--- a/src/components/settings-panel/sub-pages/online-registry/OnlineRegistry.vue
+++ b/src/components/settings-panel/sub-pages/online-registry/OnlineRegistry.vue
@@ -47,7 +47,6 @@
 <script lang="ts">
 import { monkey } from '@/core/ajax'
 import { cdnRoots } from '@/core/cdn-types'
-import { meta } from '@/core/meta'
 import { getGeneralSettings } from '@/core/settings'
 import { logError } from '@/core/utils/log'
 import {


### PR DESCRIPTION
...没想到解决办法竟然如此简单, 在 #2349 中提到的 `core-api` 中 ,有些使用了 `requestIdleCallback` 这个 api, 而兼容性补丁则比加载 `core-api` 的过程要晚, 导致了问题.

另外, 我给设置添加了一个来源分支选项, 这对用户影响不大, 但应该可以方便开发者( 有时候自己的仓库里的分支名和上游仓库里的分支名可能不同