### PR TITLE
添加feat - 下载视频：MPV播放支持（列表）插件

### DIFF
--- a/registry/lib/plugins/video/download/mpv-output-playlist/MpvConfig.vue
+++ b/registry/lib/plugins/video/download/mpv-output-playlist/MpvConfig.vue
@@ -1,0 +1,65 @@
+<template>
+<div class="rpc-config download-video-config-section">
+    <div class="profile-dir">
+      <div class="profile-item-name">
+        命令路径:
+      </div>
+      <TextBox v-model="mpvInfo.dir" @blur="saveInfo" />
+    </div>
+    <div class="profile-host">
+      <div class="profile-item-name">
+        主机:
+      </div>
+      <TextBox v-model="mpvInfo.host" @blur="saveInfo" />
+    </div>
+    <div class="profile-port">
+      <div class="profile-item-name">
+        端口:
+      </div>
+      <TextBox v-model="mpvInfo.port" @blur="saveInfo" />
+    </div>
+</div>
+</template>
+<script lang="ts">
+
+import { getComponentSettings } from '@/core/settings'
+import {
+  TextBox,
+} from '@/ui'
+
+const defaultMpvInfo = {
+  dir: 'mpv',
+  host: '127.0.0.1',
+  port: '50000',
+}
+const { options: storedMpvInfo } = getComponentSettings('downloadVideo')
+const info = { ...defaultMpvInfo, ...storedMpvInfo }
+export default Vue.extend({
+  components: {
+    TextBox,
+  },
+  data() {
+    return {
+      mpvInfo: info,
+    }
+  },
+  methods: {
+    saveInfo() {
+      Object.assign(storedMpvInfo, info)
+    },
+  },
+})
+</script>
+<style lang="scss">
+@import "common";
+.rpc-config.download-video-config-section {
+  @include v-center();
+  align-items: stretch;
+  > * {
+    @include h-center();
+    &:not(:last-child) {
+      margin-bottom: 12px;
+    }
+  }
+}
+</style>

--- a/registry/lib/plugins/video/download/mpv-output-playlist/index.ts
+++ b/registry/lib/plugins/video/download/mpv-output-playlist/index.ts
@@ -1,0 +1,15 @@
+import { PluginMetadata } from '@/plugins/plugin'
+import { DownloadVideoOutput } from '../../../../components/video/download/types'
+import { mpvPlaylist } from './mpv-playlist'
+
+export const plugin: PluginMetadata = {
+  name: 'downloadVideo.outputs.mpv-playlist',
+  displayName: '下载视频 - MPV 播放支持（列表）',
+  // FIXME: plugin 也需要 author 字段
+  description: 'by [@wuliic]\n\n为下载视频增加 MPV 输出支持,支持列表播放，配置方式请参考 [playwithmpv](https://github.com/videoanywhere/playwithmpv)',
+  setup: ({ addData }) => {
+    addData('downloadVideo.outputs', (outputs: DownloadVideoOutput[]) => {
+      outputs.push(mpvPlaylist)
+    })
+  },
+}

--- a/registry/lib/plugins/video/download/mpv-output-playlist/mpv-playlist.ts
+++ b/registry/lib/plugins/video/download/mpv-output-playlist/mpv-playlist.ts
@@ -1,0 +1,34 @@
+import { postJson } from '@/core/ajax'
+import { Toast } from '@/core/toast'
+import { UserAgent } from '@/core/utils/constants'
+import { logError } from '@/core/utils/log'
+import { DownloadVideoOutput } from '../../../../components/video/download/types'
+
+export const mpvPlaylist: DownloadVideoOutput = {
+  name: 'mpv-playlist',
+  displayName: 'MPV播放',
+  description: '格式选择flv，千万不能选音画分离的dash。建议把mpv.exe所在目录加进环境变量。',
+  runAction: async (action, instance) => {
+    const { infos } = action
+    const { mpvInfo } = instance
+    const videoUrls = infos.flatMap(it => it.titledFragments).map(f => f.url)
+    const videoTitles = infos.flatMap(it => it.titledFragments).map(f => f.title)
+    // console.log(videoTitles)
+    const data = {
+      dir: mpvInfo.dir,
+      referer: 'https://www.bilibili.com/',
+      'user-agent': UserAgent,
+      urls: videoUrls,
+      titles: videoTitles,
+    }
+    const url = `http://${mpvInfo.host}:${mpvInfo.port}`
+    const result = await postJson(url, data)
+    const resp = JSON.parse(result)
+    if (resp.success) {
+      Toast.success(`成功发送了请求: ${resp.message}`, 'MPV播放', 3000)
+    } else {
+      logError(resp.message)
+    }
+  },
+  component: () => import('./MpvConfig.vue').then(m => m.default),
+}


### PR DESCRIPTION
<!-- 可以参考下代码贡献指南: ç -->
  - 该插件属于下载视频组件
  - 使用该插件，需要安装MPV，能用mpv命令播放video url
  - 使用该插件，需要安装[playwithmpv](https://github.com/videoanywhere/playwithmpv)
  - 使用该插件的方法：选中对应的输出方式，点击开始按钮，使用本地的MPV播放器打开多P播放列表