### PR TITLE
修复某些情况下扩展倍速可能会出现不正确的推荐值

### DIFF
--- a/registry/lib/components/video/player/common/speed/context.ts
+++ b/registry/lib/components/video/player/common/speed/context.ts
@@ -207,7 +207,7 @@ const buildElementPart = (
 
   const updateAvailableSpeedValues = () => {
     availableSpeedValues = lodash([...menuListElement.children])
-      .map(element => lodash.attempt(() => parseSpeedText(element.innerHTML)))
+      .map(element => lodash.attempt(() => parseSpeedText(element.textContent)))
       .reject(speed => lodash.isError(speed))
       .sort(ascendingSort())
       .value() as number[]


### PR DESCRIPTION
<!-- 可以参考下代码贡献指南: https://github.com/the1812/Bilibili-Evolved/blob/preview/CONTRIBUTING.md -->
![image](https://user-images.githubusercontent.com/34429322/158815045-81579592-7987-4c24-b487-6ac647b281ee.png)

原因是获取可用倍速数组时，采用了 `innerHTML` 拿到节点文本，但有时生成的 `scoped id`  包含了 `?x` 这种形式的字符串（如上图），导致 `parseSpeedText` 误识别，扩展倍速就会拿到有问题的可用倍速数组，生成不正确的推荐值.

解决方案是换成 `textContext` 获取节点文本.

ps. 这个 BUG 是随机触发的，虽然我今天晚上才发现的，但并不难触发（