### PR TITLE
Fix mountVueComponent

### DIFF
--- a/src/core/common-types.ts
+++ b/src/core/common-types.ts
@@ -1,4 +1,4 @@
-import { VueConstructor } from 'vue'
+import { Component } from 'vue'
 
 export type Executable<ReturnType = void> = () => ReturnType | Promise<ReturnType>
 export type ExecutableWithParameter<Parameters extends any[] = never[], ReturnType = void> = (
@@ -7,7 +7,7 @@ export type ExecutableWithParameter<Parameters extends any[] = never[], ReturnTy
 
 export type TestPattern = (string | RegExp)[]
 export type ArrayContent<T> = T extends Array<infer R> ? R : T
-export type VueModule = VueConstructor | { default: VueConstructor }
+export type VueModule = Component | { default: Component }
 export type I18nDescription = string | { 'zh-CN': string; [key: string]: string }
 export type WithName = {
   name: string

--- a/src/core/utils/index.ts
+++ b/src/core/utils/index.ts
@@ -98,10 +98,15 @@ export const matchUrlPattern = (pattern: string | RegExp) => (
  * @param module Vue组件模块对象
  * @param target 组件的挂载目标元素, 省略时不挂载直接返回
  */
-export const mountVueComponent = <T>(module: VueModule, target?: Element | string) => {
-  const instance = new Vue('default' in module ? module.default : module)
-  // const instance = new Vue({ render: h => h('default' in module ? module.default : module) })
-  return instance.$mount(target) as Vue & T
+export const mountVueComponent = <T>(
+  module: VueModule,
+  target?: Element | string,
+): Vue & T => {
+  const options = 'default' in module ? module.default : module
+  const getInstance = (o: any) => (
+    o.functional ? new (Vue.extend(o))() : new Vue(o)
+  )
+  return getInstance(options).$mount(target) as Vue & T
 }
 /** 是否处于其他网站的内嵌播放器中 */
 export const isEmbeddedPlayer = () => window.location.host === 'player.bilibili.com' || document.URL.startsWith('https://www.bilibili.com/html/player.html')


### PR DESCRIPTION
- 更正了 `src/core/common-types.ts` 中 `VueModule` 的类型

  Vue 文件导出的类型不是 `VueConstructor` 而是 `Component`

- 修正了 `src/core/utils/index.ts` 中 `mountVueComponent` 的实现
  
  根据 `node_modules/vue/types/vue.d.ts` 中 `VueConstructor` 的定义（即变量 `Vue` 的类型），该类型作为构造器时，不接受函数式组件。相反，类型中的 `extend` 方法能接受函数式组件的选项。而 Vue 文件可导函数式组件，因此应该根据不同的组件类型采用不同的实现。