### PR TITLE
改进代码字符串的加载方式

### DIFF
--- a/src/core/external-input.ts
+++ b/src/core/external-input.ts
@@ -54,22 +54,112 @@ export const parseExternalInput = async <T>(input: ExternalInput<T>): Promise<T>
     return input
   }
 }
-export const batchParseCode = async<T>(inputs: string[]): Promise<T[]> => {
-  try {
-    const exports = {}
-    const result = inputs.map(input => eval(input) as T)
-    if (Object.values(exports).length > 0) {
-      const { coreApis } = await import('@/core/core-apis')
-      return Object.values(exports).map(value => {
-        if (typeof value === 'function') {
-          return value(coreApis) as T
-        }
-        return value as T
-      })
-    }
-    return result
-  } catch (error) {
-    console.error(error)
-    return null
+
+/**
+ * 加载的代码没有任何导出值
+ */
+export class NoExportError extends Error {
+  constructor() {
+    super('No exported value in loaded feature code.')
   }
 }
+
+/**
+ * 加载的代码有抛出值
+ */
+export class CodeThrewError extends Error {
+  /** 代码抛出的值 */
+  public readonly thrown: unknown
+
+  constructor(thrown: unknown) {
+    super('Something was thrown when loading feature code.')
+    this.thrown = thrown
+  }
+}
+
+/**
+ * 加载组件或插件的代码字符串，获取其导出 feature
+ *
+ * @param code 代码字符串
+ * @returns 一个 `Promise`。
+ *
+ * 若一切顺利，则 `Promise` 的最终状态为 `fulfilled`，其结果为导出值
+ *
+ * 若代码执行过程中有任何抛出值，则 `Promise` 的最终状态为 `rejected`，且结果为 `CodeThrewError` 对象
+ *
+ * 若代码没有任何导出，则 `Promise` 的最终状态为 `rejected`，且结果为 `NoExportError` 对象
+ */
+export const loadFeatureCode = async <X>(code: string): Promise<X> => {
+  // 收集代码导出值
+  const exports = {}
+  try {
+    eval(code)
+  } catch (thrown) {
+    return Promise.reject(new CodeThrewError(thrown))
+  }
+  const values = Object.values(exports)
+  if (values.length === 0) {
+    return Promise.reject(new NoExportError())
+  }
+  const value = values[0]
+  if (typeof value === 'function') {
+    const { coreApis } = await import('@/core/core-apis')
+    try {
+      return value(coreApis)
+    } catch (thrown) {
+      return Promise.reject(new CodeThrewError(thrown))
+    }
+  }
+  return value as X
+}
+
+/**
+ * 批量加载组件或插件的代码字符串，获取其导出 feature
+ *
+ * @param codes 代码字符串数组
+ * @returns 一个 `Promise`。
+ *
+ * 若一切顺利，则 `Promise` 的最终状态为 `fulfilled`，其结果为导出值数组
+ *
+ * 若有任何代码在执行过程中有抛出值，则 `Promise` 的最终状态为 `rejected`，
+ * 其结果类型为 `[number, CodeThrewError]`，其中 `number` 为传入代码的索引，
+ *
+ * 若存在代码没有任何导出，则 `Promise` 的最终状态为 `rejected`，
+ * 其结果类型为 `[number, NoExportError]`，其中 `number` 为传入代码的索引
+ */
+export const loadFeatureCodeAll = <X>(codes: string[]): Promise<X[]> => {
+  const sequence = ([i, p]: [number, Promise<any>]): Promise<any> => p.then(
+    lodash.identity,
+    rej => [i, rej],
+  )
+  return lodash
+    .chain(codes)
+    .map(loadFeatureCode)
+    .zipWith(lodash.range(codes.length), (p, i) => [i, p])
+    .map(sequence)
+    .thru(Promise.all)
+    .value() as Promise<X[]>
+}
+
+/**
+ * 批量加载组件或插件的代码字符串，获取其导出 feature
+ *
+ * @param codes 代码字符串数组
+ * @returns 一个 `Promise`。
+ *
+ * 无论代码执行是否成功，`Promise` 的完成状态都是 `fulfilled`，其结果为一个
+ * `PromiseSettledResult` 数组，数组下标与传入代码的下标对应。
+ *
+ * 每个 `PromiseSettledResult` 可为以下几种状态之一：
+ *
+ * - 若代码执行顺利，则其类型为：`{ status: 'fulfilled', value: X }`
+ * - 若代码有抛出值，则其类型为：`{ status: 'rejected', reason: CodeThrewError }`
+ * - 若代码没有导出值，则其类型为：`{ status: 'rejected', reason: NoExportError }`
+ */
+export const loadFeatureCodeAllSettled = <X>(
+  codes: string[],
+): Promise<PromiseSettledResult<X>[]> => lodash
+  .chain(codes)
+  .map(loadFeatureCode)
+  .thru(Promise.allSettled)
+  .value() as Promise<PromiseSettledResult<X>[]>


### PR DESCRIPTION
目前加载组件代码使用的方法是 `batchParseCode`。该方法的特点是：只要有一个组件抛出异常，就会直接返回 `null`；而且其错误处理也比较简陋。

我删除了这个方法，并添加了两个新方法：`loadFeatureCodeAll` 和 `loadFeatureCodeAllSettled`。它们的行为模式类似于 `Promise.all` 和 `Promise.allSettled`，并且拥有更完善的异常处理。

目前 `batchParseCode` 方法的使用处还没有替换成新的 api。我会尽快完成替换，并且对没有加载成功的组件输出控制台提示和用户界面提示。
