### PR TITLE
改进代码字符串的加载方式2

### DIFF
--- a/src/core/external-input/index.ts
+++ b/src/core/external-input/index.ts
@@ -1,4 +1,4 @@
-import { pickFile } from './file-picker'
+import { pickFile } from '@/core/file-picker'
 
 /** 外部输入包装类型, 详见`parseExternalInput`的文档 */
 export type ExternalInput<T> = undefined | string | T
@@ -52,24 +52,5 @@ export const parseExternalInput = async <T>(input: ExternalInput<T>): Promise<T>
     }
   } else {
     return input
-  }
-}
-export const batchParseCode = async<T>(inputs: string[]): Promise<T[]> => {
-  try {
-    const exports = {}
-    const result = inputs.map(input => eval(input) as T)
-    if (Object.values(exports).length > 0) {
-      const { coreApis } = await import('@/core/core-apis')
-      return Object.values(exports).map(value => {
-        if (typeof value === 'function') {
-          return value(coreApis) as T
-        }
-        return value as T
-      })
-    }
-    return result
-  } catch (error) {
-    console.error(error)
-    return null
   }
 }

--- a/src/core/external-input/load-feature-code-all-settled.ts
+++ b/src/core/external-input/load-feature-code-all-settled.ts
@@ -1,4 +1,6 @@
-import { loadFeatureCode, LoadFeatureCodeResult } from '@/core/external-input/load-feature-code'
+import {
+  loadFeatureCode, LoadFeatureCodeResult,
+} from '@/core/external-input/load-feature-code'
 
 type LdRes<X> = LoadFeatureCodeResult<X>
 type SettledRes<T> = PromiseSettledResult<T>
@@ -6,11 +8,13 @@ type FilledRes<T> = PromiseFulfilledResult<T>
 
 const unwrapSettledResult = <T>(r: SettledRes<T>): T => (r as FilledRes<T>).value
 
-const mapSettledArray = <T>(arr: SettledRes<T>[]): T[] =>
+const mapSettledArray = <T>(arr: SettledRes<T>[]): T[] => (
   arr.map(unwrapSettledResult)
+)
 
-const mapSettleResult = <T>(p: Promise<SettledRes<T>[]>): Promise<T[]> =>
+const mapSettleResult = <T>(p: Promise<SettledRes<T>[]>): Promise<T[]> => (
   p.then(mapSettledArray)
+)
 
 /**
  * 批量加载组件或插件的代码字符串，获取其导出 feature
@@ -18,8 +22,10 @@ const mapSettleResult = <T>(p: Promise<SettledRes<T>[]>): Promise<T[]> =>
  * @param codes 代码字符串数组
  * @returns 不会失败的 `Promise`。其结果为一个数组，其中每个元素都是代表代码执行结果的对象
  */
-export const loadFeatureCodeAllSettled = <X>(codes: string[]): Promise<LoadFeatureCodeResult<X>[]> => lodash(codes)
-  .map<Promise<LdRes<X>>>(loadFeatureCode)
-  .thru<Promise<SettledRes<LdRes<X>>[]>>(arr => Promise.allSettled(arr))
-  .thru(mapSettleResult)
-  .value()
+export const loadFeatureCodeAllSettled = <X>(
+  codes: string[],
+): Promise<LoadFeatureCodeResult<X>[]> => lodash(codes)
+    .map<Promise<LdRes<X>>>(loadFeatureCode)
+    .thru<Promise<SettledRes<LdRes<X>>[]>>(arr => Promise.allSettled(arr))
+    .thru(mapSettleResult)
+    .value()

--- a/src/core/external-input/load-feature-code-all-settled.ts
+++ b/src/core/external-input/load-feature-code-all-settled.ts
@@ -1,0 +1,25 @@
+import { loadFeatureCode, LoadFeatureCodeResult } from '@/core/external-input/load-feature-code'
+
+type LdRes<X> = LoadFeatureCodeResult<X>
+type SettledRes<T> = PromiseSettledResult<T>
+type FilledRes<T> = PromiseFulfilledResult<T>
+
+const unwrapSettledResult = <T>(r: SettledRes<T>): T => (r as FilledRes<T>).value
+
+const mapSettledArray = <T>(arr: SettledRes<T>[]): T[] =>
+  arr.map(unwrapSettledResult)
+
+const mapSettleResult = <T>(p: Promise<SettledRes<T>[]>): Promise<T[]> =>
+  p.then(mapSettledArray)
+
+/**
+ * 批量加载组件或插件的代码字符串，获取其导出 feature
+ *
+ * @param codes 代码字符串数组
+ * @returns 不会失败的 `Promise`。其结果为一个数组，其中每个元素都是代表代码执行结果的对象
+ */
+export const loadFeatureCodeAllSettled = <X>(codes: string[]): Promise<LoadFeatureCodeResult<X>[]> => lodash(codes)
+  .map<Promise<LdRes<X>>>(loadFeatureCode)
+  .thru<Promise<SettledRes<LdRes<X>>[]>>(arr => Promise.allSettled(arr))
+  .thru(mapSettleResult)
+  .value()

--- a/src/core/external-input/load-feature-code-all.ts
+++ b/src/core/external-input/load-feature-code-all.ts
@@ -1,0 +1,148 @@
+import {
+  loadFeatureCode,
+  LoadFeatureCodeError,
+  LoadFeatureCodeResult,
+  LoadFeatureCodeResultOk,
+} from '@/core/external-input/load-feature-code'
+import { FeatureBase } from '@/components/types'
+
+// ========== result type definitions ==========
+
+class LoadFeatureCodeAllResultConstructor<X extends FeatureBase> {
+  isOk(): this is LoadFeatureCodeAllResultOk<X> {
+    return this instanceof LoadFeatureCodeAllResultOk
+  }
+
+  isError(): this is LoadFeatureCodeAllError {
+    return !this.isOk()
+  }
+
+  isNoExport(): this is LoadFeatureCodeAllResultNoExport {
+    return this instanceof LoadFeatureCodeAllResultNoExport
+  }
+
+  isCodeThrew(): this is LoadFeatureCodeAllResultCodeThrew {
+    return this instanceof LoadFeatureCodeAllResultCodeThrew
+  }
+
+  tryGetFeatures(): X[] | undefined {
+    if (this.isOk()) {
+      return this.features
+    }
+    return undefined
+  }
+}
+
+/**
+ * 成活从代码中获取 features
+ *
+ * @member features 从代码中获取的导出值
+ */
+export class LoadFeatureCodeAllResultOk<X extends FeatureBase> extends LoadFeatureCodeAllResultConstructor<X> {
+  constructor(public readonly features: X[]) {
+    super()
+  }
+}
+
+/**
+ * 代码没有导出任何值
+ *
+ * @member index 出错代码对应的代码数组下标
+ */
+export class LoadFeatureCodeAllResultNoExport extends LoadFeatureCodeAllResultConstructor<never> {
+  constructor(public readonly index: number) {
+    super()
+  }
+}
+
+/**
+ * 执行代码过程中产生了抛出值。
+ *
+ * @member index 出错代码对应的代码数组索引
+ * @member thrown 抛出的值
+ */
+export class LoadFeatureCodeAllResultCodeThrew extends LoadFeatureCodeAllResultConstructor<never> {
+  constructor(public readonly index: number, public readonly thrown: unknown) {
+    super()
+  }
+}
+
+export type LoadFeatureCodeAllError =
+  LoadFeatureCodeAllResultNoExport
+  | LoadFeatureCodeAllResultCodeThrew
+export type LoadFeatureCodeAllResult<X extends FeatureBase> =
+  LoadFeatureCodeAllResultOk<X>
+  | LoadFeatureCodeAllError
+
+// ========== internal definitions ==========
+
+type Task<Ok, Err = never> = Promise<Ok>
+
+type LdRes<X> = LoadFeatureCodeResult<X>
+type LdOk<X> = LoadFeatureCodeResultOk<X>
+type LdErr = LoadFeatureCodeError
+
+type LdAllRes<X> = LoadFeatureCodeAllResult<X>
+type LdAllOk<X> = LoadFeatureCodeAllResultOk<X>
+type LdAllErr = LoadFeatureCodeAllError
+
+type LoadCodesTask<X> = Task<LdOk<X>[], [number, LdErr]>
+
+const LdCodeThrew = LoadFeatureCodeAllResultCodeThrew
+const LdAllOk = LoadFeatureCodeAllResultOk
+const LdAllNoExport = LoadFeatureCodeAllResultNoExport
+const LdAllCodeThrew = LoadFeatureCodeAllResultCodeThrew
+
+// covert `Task<LdRes<X>>` to `Task<LdOk<X>, LdErr>`
+const rejectErrorResult = <X>(t: Task<LdRes<X>>): Task<LdOk<X>, LdErr> => (
+  t.then(r => r.isOk() ? r : Promise.reject(r))
+)
+
+// load feature code, and return `Task<LdOk<X>, LdErr>`
+const loadCode = <X>(code: string): Task<LdOk<X>, LdErr> => (
+  rejectErrorResult(loadFeatureCode(code))
+)
+
+// covert `Task`'s `Err` type from `T` to `[number, T]`
+const addIndexToRejected = <N extends number, O, E>(t: Task<O, E>, i: N): Task<O, [N, E]> => (
+  t.catch(e => Promise.reject([i, e]))
+)
+
+// create `LdAllOk` from an array of `LdOk`
+const createOkResult = <X>(arr: LdOk<X>[]): LdAllOk<X> => (
+  new LdAllOk(arr.map(r => r.feature))
+)
+
+// create `LdAllErr` from `[number, LdErr]`
+const createErrResult = (t: [number, LdErr]): LdAllErr => (
+  t[1] instanceof LdCodeThrew
+    ? new LdAllCodeThrew(t[0], t[1].thrown)
+    : new LdAllNoExport(t[0])
+)
+
+// load all feature codes, and return `LoadCodesTask`
+const loadCodes = <X>(codes: string[]): LoadCodesTask<X> => lodash(codes)
+  .map<Task<LdOk<X>, LdErr>>(loadCode)
+  .map(addIndexToRejected)
+  .thru<LoadCodesTask<X>>(arr => Promise.all(arr))
+  .value()
+
+// create a `LdAllRes` wrapped by `Task`
+const createTaskResult = <X>(t: LoadCodesTask<X>): Task<LdAllRes<X>> => t
+  .then(createOkResult)
+  .catch(createErrResult)
+
+// ========== paramount function to export ==========
+
+/**
+ * 批量加载组件或插件的代码字符串，获取其导出 feature
+ *
+ * 只要有一个代码出现了错误，则返回错误。
+ *
+ * @param codes 代码字符串数组
+ * @returns 一个不会失败的 `Promise`，其结果值为 `LoadFeatureCodeAllResult`
+ */
+export const loadFeatureCodeAll = <X>(codes: string[]): Promise<LoadFeatureCodeAllResult<X>> => lodash(codes)
+  .thru<LoadCodesTask<X>>(loadCodes)
+  .thru(createTaskResult)
+  .value()

--- a/src/core/external-input/load-feature-code.ts
+++ b/src/core/external-input/load-feature-code.ts
@@ -1,0 +1,78 @@
+import { FeatureBase } from '@/components/types'
+
+class LoadFeatureCodeResultConstructor<X extends FeatureBase> {
+  isOk(): this is LoadFeatureCodeResultOk<X> {
+    return this instanceof LoadFeatureCodeResultOk
+  }
+
+  isError(): this is LoadFeatureCodeError {
+    return !this.isOk()
+  }
+
+  isNoExport(): this is LoadFeatureCodeResultNoExport {
+    return this instanceof LoadFeatureCodeResultNoExport
+  }
+
+  isCodeThrew(): this is LoadFeatureCodeResultCodeThrew {
+    return this instanceof LoadFeatureCodeResultCodeThrew
+  }
+
+  tryGetFeature(): X | undefined {
+    if (this.isOk()) {
+      return this.feature
+    }
+    return undefined
+  }
+}
+
+/**
+ * 成功从代码中获取 feature
+ *
+ * @member feature 从代码中获取的导出值
+ */
+export class LoadFeatureCodeResultOk<X extends FeatureBase> extends LoadFeatureCodeResultConstructor<X> {
+  constructor(public readonly feature: X) {
+    super()
+  }
+}
+
+/** 代码没有导出任何值 */
+export class LoadFeatureCodeResultNoExport extends LoadFeatureCodeResultConstructor<never> {
+}
+
+/**
+ * 执行代码过程中产生了抛出值。
+ *
+ * @member {unknown} thrown 抛出的值
+ */
+export class LoadFeatureCodeResultCodeThrew extends LoadFeatureCodeResultConstructor<never> {
+  constructor(public readonly thrown: unknown) {
+    super()
+  }
+}
+
+export type LoadFeatureCodeError = LoadFeatureCodeResultNoExport | LoadFeatureCodeResultCodeThrew
+export type LoadFeatureCodeResult<X extends FeatureBase> =
+  LoadFeatureCodeResultOk<X>
+  | LoadFeatureCodeError
+
+/**
+ * 加载组件或插件的代码字符串，获取其导出 feature
+ *
+ * @param code 代码字符串
+ * @returns 一个不会失败的 `Promise`，其结果值为 {@link LoadFeatureCodeResult}
+ */
+export const loadFeatureCode = async <X extends FeatureBase>(code: string): Promise<LoadFeatureCodeResult<X>> => {
+  // 收集代码导出值
+  const exports = {}
+  try {
+    eval(code)
+  } catch (thrown) {
+    return new LoadFeatureCodeResultCodeThrew(thrown)
+  }
+  const values = Object.values(exports)
+  if (values.length === 0) {
+    return new LoadFeatureCodeResultNoExport()
+  }
+  return new LoadFeatureCodeResultOk(values[0] as X)
+}

--- a/src/core/external-input/load-feature-code.ts
+++ b/src/core/external-input/load-feature-code.ts
@@ -1,60 +1,83 @@
 import { FeatureBase } from '@/components/types'
 
-class LoadFeatureCodeResultConstructor<X extends FeatureBase> {
-  isOk(): this is LoadFeatureCodeResultOk<X> {
-    return this instanceof LoadFeatureCodeResultOk
-  }
+interface ResultInstance {
+  readonly isOk: <X extends FeatureBase>(
+    this: LoadFeatureCodeResult<X>
+  ) => this is LoadFeatureCodeResultOk<X>
 
-  isError(): this is LoadFeatureCodeError {
-    return !this.isOk()
-  }
+  readonly isError: (
+    this: LoadFeatureCodeResult<FeatureBase>
+  ) => this is LoadFeatureCodeResultError
 
-  isNoExport(): this is LoadFeatureCodeResultNoExport {
-    return this instanceof LoadFeatureCodeResultNoExport
-  }
+  readonly isNoExport: (
+    this: LoadFeatureCodeResult<FeatureBase>
+  ) => this is LoadFeatureCodeResultNoExport
 
-  isCodeThrew(): this is LoadFeatureCodeResultCodeThrew {
-    return this instanceof LoadFeatureCodeResultCodeThrew
-  }
-
-  tryGetFeature(): X | undefined {
-    if (this.isOk()) {
-      return this.feature
-    }
-    return undefined
-  }
+  readonly isCodeThrew: (
+    this: LoadFeatureCodeResult<FeatureBase>
+  ) => this is LoadFeatureCodeResultCodeThrew
 }
 
 /**
  * 成功从代码中获取 feature
  *
- * @member feature 从代码中获取的导出值
+ * @namespace
+ * @property feature 从代码中获取的导出值
  */
-export class LoadFeatureCodeResultOk<X extends FeatureBase> extends LoadFeatureCodeResultConstructor<X> {
-  constructor(public readonly feature: X) {
-    super()
-  }
+interface LoadFeatureCodeResultOk<X extends FeatureBase> extends ResultInstance {
+  readonly tag: 'Ok',
+  readonly feature: X,
 }
 
 /** 代码没有导出任何值 */
-export class LoadFeatureCodeResultNoExport extends LoadFeatureCodeResultConstructor<never> {
+interface LoadFeatureCodeResultNoExport extends ResultInstance {
+  readonly tag: 'NoExport',
 }
 
 /**
  * 执行代码过程中产生了抛出值。
  *
- * @member {unknown} thrown 抛出的值
+ * @namespace
+ * @property thrown 抛出的值
  */
-export class LoadFeatureCodeResultCodeThrew extends LoadFeatureCodeResultConstructor<never> {
-  constructor(public readonly thrown: unknown) {
-    super()
-  }
+interface LoadFeatureCodeResultCodeThrew extends ResultInstance {
+  readonly tag: 'CodeThrew',
+  readonly thrown: unknown,
 }
 
-export type LoadFeatureCodeError = LoadFeatureCodeResultNoExport | LoadFeatureCodeResultCodeThrew
-export type LoadFeatureCodeResult<X extends FeatureBase> =
+type LoadFeatureCodeResultError =
+  LoadFeatureCodeResultNoExport
+  | LoadFeatureCodeResultCodeThrew
+type LoadFeatureCodeResult<X extends FeatureBase> =
   LoadFeatureCodeResultOk<X>
-  | LoadFeatureCodeError
+  | LoadFeatureCodeResultError
+
+const resultProto: ResultInstance = {
+  isOk() { return this.tag === 'Ok' },
+  isError() { return this.tag !== 'Ok' },
+  isNoExport() { return this.tag === 'NoExport' },
+  isCodeThrew() { return this.tag === 'CodeThrew' },
+}
+
+const okResult = <X extends FeatureBase>(feature: X): LoadFeatureCodeResultOk<X> => lodash.create(
+  resultProto,
+  {
+    tag: 'Ok' as const,
+    feature,
+  },
+)
+
+const noExportResult = lodash.create(resultProto, {
+  tag: 'NoExport' as const,
+})
+
+const codeThrewResult = (thrown: unknown): LoadFeatureCodeResultCodeThrew => lodash.create(
+  resultProto,
+  {
+    tag: 'CodeThrew' as const,
+    thrown,
+  },
+)
 
 /**
  * 加载组件或插件的代码字符串，获取其导出 feature
@@ -62,17 +85,28 @@ export type LoadFeatureCodeResult<X extends FeatureBase> =
  * @param code 代码字符串
  * @returns 一个不会失败的 `Promise`，其结果值为 {@link LoadFeatureCodeResult}
  */
-export const loadFeatureCode = async <X extends FeatureBase>(code: string): Promise<LoadFeatureCodeResult<X>> => {
+const loadFeatureCode = async <X extends FeatureBase>(
+  code: string,
+): Promise<LoadFeatureCodeResult<X>> => {
   // 收集代码导出值
   const exports = {}
   try {
     eval(code)
   } catch (thrown) {
-    return new LoadFeatureCodeResultCodeThrew(thrown)
+    return codeThrewResult(thrown)
   }
   const values = Object.values(exports)
   if (values.length === 0) {
-    return new LoadFeatureCodeResultNoExport()
+    return noExportResult
   }
-  return new LoadFeatureCodeResultOk(values[0] as X)
+  return okResult(values[0] as X)
+}
+
+export {
+  loadFeatureCode,
+  LoadFeatureCodeResult,
+  LoadFeatureCodeResultOk,
+  LoadFeatureCodeResultError,
+  LoadFeatureCodeResultNoExport,
+  LoadFeatureCodeResultCodeThrew,
 }

--- a/src/core/external-input/load-features-from-codes.ts
+++ b/src/core/external-input/load-features-from-codes.ts
@@ -1,0 +1,116 @@
+import {
+  LoadFeatureCodeError,
+  LoadFeatureCodeResultNoExport,
+  LoadFeatureCodeResultOk,
+} from '@/core/external-input/load-feature-code'
+import { Toast } from '@/core/toast'
+import { useScopedConsole } from '@/core/utils/log'
+import { ComponentMetadata } from '@/components/types'
+import { PluginMetadata } from '@/plugins/plugin'
+import { loadFeatureCodeAllSettled } from '@/core/external-input/load-feature-code-all-settled'
+
+const curConsole = useScopedConsole('@/core/external-input/load-features-from-codes.ts')
+
+export enum FeatureKind {
+  Component = 'Component',
+  Plugin = 'Plugin',
+}
+
+const logError = (kind: FeatureKind): (featureName: string, err: LoadFeatureCodeError) => void => {
+  const prefix = kind === FeatureKind.Component ? 'component' : 'plugin'
+  return (featureName, err) => {
+    if (err instanceof LoadFeatureCodeResultNoExport) {
+      curConsole.error(`${prefix} '${featureName}' exports no value, failed to load`)
+    } else {
+      curConsole.error(`${prefix} '${featureName}' throws something when importing, failed to load`, { thrown: err.thrown })
+    }
+  }
+}
+
+const reportErrToUser = (featureKind: FeatureKind, errNames: string[]): void => {
+  type ErrInfo = number | string[]
+
+  const emptyErrInfo: () => string[] = () => []
+
+  const accErrInfo = (acc: ErrInfo, featureName: string): ErrInfo => {
+    if (Array.isArray(acc)) {
+      if (acc.length < 3) {
+        acc.push(featureName)
+        return acc
+      } else {
+        return 4
+      }
+    } else {
+      return acc + 1
+    }
+  }
+
+  const reportErrInfo = (featureKind: FeatureKind, info: ErrInfo): void => {
+    const kindName = featureKind === FeatureKind.Component ? '组件' : '插件'
+    if (Array.isArray(info)) {
+      Toast.error(
+        `${kindName} "${info.join('", "')}" 加载失败。请向我们反馈，以解决此问题。`,
+        `${kindName}加载失败`,
+      )
+    } else {
+      Toast.error(
+        `有 ${info} 个${kindName}加载失败，请向我们反馈，以解决此问题。`,
+        `${kindName}加载失败`,
+      )
+    }
+  }
+
+  const errInfo = errNames.reduce(accErrInfo, emptyErrInfo())
+  reportErrInfo(featureKind, errInfo)
+}
+
+type KindToType<K extends FeatureKind> =
+  K extends FeatureKind.Component ? ComponentMetadata : PluginMetadata
+
+/**
+ * 批量加载组件或插件代码
+ *
+ * 如果遇到错误会向 console 和用户输出错误信息
+ *
+ * `names` 和 `codes` 应该是一一对应的
+ *
+ * @param kind 组件或插件类型
+ * @param names 组件或插件名称
+ * @param codes 组件或插件代码
+ * @return 返回加载成功的组件或插件
+ */
+export async function loadFeaturesFromCodes(
+  kind: FeatureKind.Component,
+  names: string[],
+  codes: string[],
+): Promise<ComponentMetadata[]>
+export async function loadFeaturesFromCodes(
+  kind: FeatureKind.Plugin,
+  names: string[],
+  codes: string[],
+): Promise<PluginMetadata[]>
+export async function loadFeaturesFromCodes(
+  kind: FeatureKind,
+  names: string[],
+  codes: string[],
+): Promise<(ComponentMetadata | PluginMetadata)[]> {
+  const results = await loadFeatureCodeAllSettled<KindToType<typeof kind>>(codes)
+  const [namedOk, namedErr] = lodash(results)
+    .map((r, i) => [names[i], r] as const)
+    .partition(([, r]) => r.isOk())
+    .value()
+
+  // 输出日志
+  lodash.forEach(namedErr, lodash.spread(logError(kind)))
+
+  // 向用户输出错误报告
+  if (namedErr.length > 0) {
+    const errNames = namedErr.map(([name]) => name)
+    reportErrToUser(kind, errNames)
+  }
+
+  return lodash.map(
+    namedOk,
+    ([, r]) => (r as LoadFeatureCodeResultOk<KindToType<typeof kind>>).feature,
+  )
+}

--- a/src/plugins/plugin.ts
+++ b/src/plugins/plugin.ts
@@ -23,7 +23,6 @@ export interface PluginMinimalData extends FeatureBase {
   /** 显示名称, 默认同插件名称 */
   displayName?: string
 }
-
 type PartialRequired<Target, Props extends keyof Target> = Target & {
   [P in Props]-?: Target[P]
 }
@@ -68,12 +67,11 @@ export const installPlugin = async (code: string) => {
       message: `已更新插件'${plugin.displayName}', 刷新后生效`,
     }
   }
-  const newPlugin = lodash(plugin)
-    .set<PluginMetadata & { code: string }>(['code'], code)
-    .defaults({
-      displayName: plugin.name, // 默认等于 name
-    })
-    .value()
+  const newPlugin = {
+    code,
+    displayName: plugin.name, // 默认等于 name
+    ...plugin,
+  }
   settings.userPlugins[plugin.name] = newPlugin
   plugins.push(newPlugin)
   // const { coreApis } = await import('../core/core-apis')
@@ -161,8 +159,8 @@ export const loadAllPlugins = async (components: ComponentMetadata[]) => {
     loadFeaturesFromCodes,
     FeatureKind,
   } = await import('@/core/external-input/load-features-from-codes')
-  const otherPlugins = lodash(components).map(extractPluginFromComponent).filter(p => p !== null)
-    .map(p => p!).concat(await loadFeaturesFromCodes(
+  const otherPlugins = lodash(components).map(extractPluginFromComponent).filter(p => p !== null).
+    map(p => p!).concat(await loadFeaturesFromCodes(
       FeatureKind.Plugin,
       Object.keys(settings.userPlugins),
       Object.values(settings.userPlugins).map(p => p.code),

--- a/src/plugins/plugin.ts
+++ b/src/plugins/plugin.ts
@@ -23,6 +23,7 @@ export interface PluginMinimalData extends FeatureBase {
   /** 显示名称, 默认同插件名称 */
   displayName?: string
 }
+
 type PartialRequired<Target, Props extends keyof Target> = Target & {
   [P in Props]-?: Target[P]
 }
@@ -67,11 +68,12 @@ export const installPlugin = async (code: string) => {
       message: `已更新插件'${plugin.displayName}', 刷新后生效`,
     }
   }
-  const newPlugin = {
-    code,
-    displayName: plugin.name, // 默认等于 name
-    ...plugin,
-  }
+  const newPlugin = lodash(plugin)
+    .set<PluginMetadata & { code: string }>(['code'], code)
+    .defaults({
+      displayName: plugin.name, // 默认等于 name
+    })
+    .value()
   settings.userPlugins[plugin.name] = newPlugin
   plugins.push(newPlugin)
   // const { coreApis } = await import('../core/core-apis')
@@ -159,8 +161,8 @@ export const loadAllPlugins = async (components: ComponentMetadata[]) => {
     loadFeaturesFromCodes,
     FeatureKind,
   } = await import('@/core/external-input/load-features-from-codes')
-  const otherPlugins = lodash(components).map(extractPluginFromComponent).filter(p => p !== null).
-    map(p => p!).concat(await loadFeaturesFromCodes(
+  const otherPlugins = lodash(components).map(extractPluginFromComponent).filter(p => p !== null)
+    .map(p => p!).concat(await loadFeaturesFromCodes(
       FeatureKind.Plugin,
       Object.keys(settings.userPlugins),
       Object.values(settings.userPlugins).map(p => p.code),

--- a/src/plugins/plugin.ts
+++ b/src/plugins/plugin.ts
@@ -23,6 +23,7 @@ export interface PluginMinimalData extends FeatureBase {
   /** 显示名称, 默认同插件名称 */
   displayName?: string
 }
+
 type PartialRequired<Target, Props extends keyof Target> = Target & {
   [P in Props]-?: Target[P]
 }
@@ -95,9 +96,11 @@ export const installPlugin = async (code: string) => {
  */
 export const uninstallPlugin = async (nameOrDisplayName: string) => {
   const { settings } = await import('@/core/settings')
-  const existingPlugin = Object.entries(settings.userPlugins).find(([name, { displayName }]) => {
-    return name === nameOrDisplayName || displayName === nameOrDisplayName
-  })
+  const existingPlugin = Object.entries(settings.userPlugins).find(
+    ([name, { displayName }]) => (
+      name === nameOrDisplayName || displayName === nameOrDisplayName
+    ),
+  )
   if (!existingPlugin) {
     throw new Error(`没有找到与名称'${nameOrDisplayName}'相关联的插件`)
   }
@@ -159,12 +162,16 @@ export const loadAllPlugins = async (components: ComponentMetadata[]) => {
     loadFeaturesFromCodes,
     FeatureKind,
   } = await import('@/core/external-input/load-features-from-codes')
-  const otherPlugins = lodash(components).map(extractPluginFromComponent).filter(p => p !== null).
-    map(p => p!).concat(await loadFeaturesFromCodes(
+  const otherPlugins = lodash(components)
+    .map(extractPluginFromComponent)
+    .filter(p => p !== null)
+    .map(p => p as PluginMetadata)
+    .concat(await loadFeaturesFromCodes(
       FeatureKind.Plugin,
       Object.keys(settings.userPlugins),
       Object.values(settings.userPlugins).map(p => p.code),
-    )).value()
+    ))
+    .value()
   plugins.push(...otherPlugins)
   return Promise.allSettled(
     plugins.map(loadPlugin),


### PR DESCRIPTION
目前加载组件代码使用的方法是 batchParseCode。该方法的特点是：只要有一个组件抛出异常，就会直接返回 null；而且其错误处理也比较简陋。

这个提交改用了新的 API。新 API 在 feature 抛出异常时，只会输出错误日志，并继续其他组件的加载。