### PR TITLE
修复自定义顶栏右侧 padding 的显示问题

### DIFF
--- a/registry/lib/components/style/custom-navbar/CustomNavbar.vue
+++ b/registry/lib/components/style/custom-navbar/CustomNavbar.vue
@@ -247,11 +247,16 @@ body.fixed-navbar {
       content: "";
       position: absolute;
       top: 0;
-      left: 0;
       width: 100%;
       height: 100%;
       box-sizing: border-box;
       border: 2px dashed;
+    }
+    &.left-pad::after {
+      left: 0;
+    }
+    &.right-pad::after {
+      right: 0;
     }
   }
 }


### PR DESCRIPTION
bug 见视频：

<video src="https://user-images.githubusercontent.com/46739861/170842105-dd3d4c46-862e-4360-ae4c-afc6153662a7.mp4" controls></video>

如下图所示，右侧虚线所在的元素采用了绝对定位，且有 `left: 0`，当其宽度为 0 时，border 会出现在顶栏右侧，使得顶栏宽度溢出页面，于是就出现了横向滚动条。

<img width="960" alt="溢出" src="https://user-images.githubusercontent.com/46739861/170842361-35a84c2d-a32a-4d32-bf7f-67c180868a57.png">

