### PR TITLE
fix(bvidConvert): copied link

### DIFF
--- a/registry/lib/components/feeds/filter/FeedsFilterCard.vue
+++ b/registry/lib/components/feeds/filter/FeedsFilterCard.vue
@@ -50,7 +50,13 @@
 </template>
 
 <script lang="ts">
-import { FeedsCard, FeedsCardType, feedsCardTypes, forEachFeedsCard, RepostFeedsCard } from '@/components/feeds/api'
+import {
+  FeedsCard,
+  FeedsCardType,
+  feedsCardTypes,
+  forEachFeedsCard,
+  RepostFeedsCard,
+} from '@/components/feeds/api'
 import { getComponentSettings } from '@/core/settings'
 import { select } from '@/core/spin-query'
 import { attributes } from '@/core/observer'

--- a/registry/lib/components/feeds/unfold/index.ts
+++ b/registry/lib/components/feeds/unfold/index.ts
@@ -21,7 +21,9 @@ export const component: ComponentMetadata = {
     const { forEachFeedsCard } = await import('@/components/feeds/api')
     forEachFeedsCard({
       added: async card => {
-        const foldButton = await select(() => dq(card.element, '.fold-hoverable, .bili-dyn-item-fold') as HTMLElement)
+        const foldButton = await select(
+          () => dq(card.element, '.fold-hoverable, .bili-dyn-item-fold') as HTMLElement,
+        )
         foldButton?.click()
       },
     })

--- a/registry/lib/components/video/bvid-convert/BvidConvert.vue
+++ b/registry/lib/components/video/bvid-convert/BvidConvert.vue
@@ -60,7 +60,7 @@ const linkProviders: LinkProvider[] = [
       }
     }
     return `https://www.bilibili.com/video/${id}${newQuery ? `?${newQuery.toString()}` : ''}`
-  }
+  },
 ]
 export default Vue.extend({
   components: { VIcon },
@@ -117,7 +117,7 @@ export default Vue.extend({
   box-sizing: border-box;
   box-shadow: 0 0 0 1px #8884;
   @include default-background-color();
-&-item {
+  &-item {
     font-size: 14px;
     @include h-center(6px);
     &-copy {

--- a/registry/lib/components/video/bvid-convert/BvidConvert.vue
+++ b/registry/lib/components/video/bvid-convert/BvidConvert.vue
@@ -33,7 +33,7 @@ enum CopyIdType {
   Bvid = 'bvid',
 }
 const copyIds = [CopyIdType.Aid, CopyIdType.Bvid]
-type LinkProvider = (context: { id: string; url: string; query: string }) => string
+type LinkProvider = (context: { id: string; query: string }) => string
 const linkProviders: LinkProvider[] = [
   // 参数类页面, 如 festival
   ({ id, query }) => {
@@ -50,7 +50,17 @@ const linkProviders: LinkProvider[] = [
     return null
   },
   // 普通视频
-  ({ id, url, query }) => url.replace(/\/[^\/]+$/, `/${id}`) + query,
+  ({ id, query }) => {
+    const params = new URLSearchParams(query)
+    const newQuery = new URLSearchParams()
+    for (const key of ['p', 't']) {
+      const value = params.get(key)
+      if (value) {
+        newQuery.set(key, value)
+      }
+    }
+    return `https://www.bilibili.com/video/${id}${newQuery ? `?${newQuery.toString()}` : ''}`
+  }
 ]
 export default Vue.extend({
   components: { VIcon },
@@ -107,7 +117,7 @@ export default Vue.extend({
   box-sizing: border-box;
   box-shadow: 0 0 0 1px #8884;
   @include default-background-color();
-  &-item {
+&-item {
     font-size: 14px;
     @include h-center(6px);
     &-copy {

--- a/src/components/feeds/BangumiCard.vue
+++ b/src/components/feeds/BangumiCard.vue
@@ -30,7 +30,7 @@ export default Vue.extend({
 })
 </script>
 <style lang="scss" scoped>
-@import "common";
+@import 'common';
 
 .bangumi-card {
   --cover-width: 94px;


### PR DESCRIPTION
<!-- 可以参考下代码贡献指南: https://github.com/the1812/Bilibili-Evolved/blob/preview/CONTRIBUTING.md -->

#3794 

修复后，普通视频的「复制链接」会根据AV、BV给出不同链接，并忽略无用的query。如AV号处复制得`https://www.bilibili.com/video/av247571422`。

「带上标题」原本会「将标题写两遍，以 - 分隔」，修复后只会显示一遍。这个的根源在于**`getFriendlyTitle`默认返回的标题就是如此**。我觉得这个默认行为很奇怪，但尝试进一步调试时发现修改本体代码后 网页虽然会自动刷新但根本就没有应用修改后的代码，翻`CONTRIBUTING.md`也没找到该怎么做，就作罢了。目前只在`bvidConvert`这个组件里修改了调用参数，但我感觉这里可能需要进一步除根。