### PR TITLE
隐藏检测广告插件的提示

### DIFF
--- a/registry/lib/components/utils/remove-promotions/remove-promotions.scss
+++ b/registry/lib/components/utils/remove-promotions/remove-promotions.scss
@@ -29,7 +29,8 @@ body.remove-game-match-module #reportFirst3,
 .video-page-game-card-small,
 .video-page-operator-card-small,
 [data-be-promotion-mark],
-body:not(.preserve-feed-goods) .dyn-goods {
+body:not(.preserve-feed-goods) .dyn-goods,
+.adblock-tips {
   display: none !important;
 }
 .recommend-list .rec-list > :not(.video-page-card) + .video-page-card {


### PR DESCRIPTION
当开启广告拦截插件后会出现提示
![1670168336115](https://user-images.githubusercontent.com/63504321/205500081-d95ce5e2-8bd3-49dc-885e-3db7683fd406.png)
