### PR TITLE
feat: 组件二等分

### DIFF
--- a/src/components/bisector/DialogContent.vue
+++ b/src/components/bisector/DialogContent.vue
@@ -40,7 +40,7 @@ export default Vue.extend({
 
 <style lang="scss" scoped>
 .bisector-dialog-content-container {
-  padding: 8px;
+  padding: 12px;
   .bisector-dialog-content-text {
     margin-bottom: 8px;
   }

--- a/src/components/bisector/DialogContent.vue
+++ b/src/components/bisector/DialogContent.vue
@@ -1,0 +1,56 @@
+<template>
+  <div class="bisector-dialog-content-container">
+    <div class="bisector-dialog-content-text">
+      组件二等分进行中，预计剩余{{ rouge }}轮次，请确认当前情况：
+    </div>
+    <div class="bisector-dialog-button-group">
+      <VButton @click="onGood">正常</VButton>
+      <VButton @click="onBad">不正常</VButton>
+      <VButton type="primary" @click="onAbort">终止</VButton>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import Vue from 'vue'
+import { VButton } from '@/ui'
+
+export default Vue.extend({
+  components: { VButton },
+  props: {
+    rouge: {
+      type: Number,
+      required: true,
+    },
+    onAbort: {
+      type: Function,
+      default: none,
+    },
+    onGood: {
+      type: Function,
+      default: none,
+    },
+    onBad: {
+      type: Function,
+      default: none,
+    },
+  },
+})
+</script>
+
+<style lang="scss" scoped>
+.bisector-dialog-content-container {
+  padding: 8px;
+  .bisector-dialog-content-text {
+    margin-bottom: 8px;
+  }
+  .bisector-dialog-button-group {
+    display: grid;
+    gap: 8px;
+    grid-template-columns: 1fr 1fr;
+    .be-button:last-child {
+      grid-column: span 2;
+    }
+  }
+}
+</style>

--- a/src/components/bisector/DialogContent.vue
+++ b/src/components/bisector/DialogContent.vue
@@ -1,12 +1,16 @@
 <template>
   <div class="bisector-dialog-content-container">
     <div class="bisector-dialog-content-text">
-      组件二等分进行中，预计剩余{{ rouge }}轮次，请确认当前情况：
+      组件二等分进行中，预计剩余
+      <b style="color: var(--theme-color)">{{ rouge }} </b>轮次，请确认当前情况：
     </div>
     <div class="bisector-dialog-button-group">
       <VButton @click="onGood">正常</VButton>
       <VButton @click="onBad">不正常</VButton>
       <VButton type="primary" @click="onAbort">终止</VButton>
+    </div>
+    <div class="bisector-dialog-content-text weak">
+      *可以点击×号关闭对话框，刷新页面后，会再次询问
     </div>
   </div>
 </template>
@@ -40,10 +44,19 @@ export default Vue.extend({
 
 <style lang="scss" scoped>
 .bisector-dialog-content-container {
-  padding: 12px;
+  padding: 0 16px;
+
   .bisector-dialog-content-text {
+    &.weak {
+      opacity: 0.6;
+    }
+  }
+
+  .bisector-dialog-content-text,
+  .bisector-dialog-button-group {
     margin-bottom: 8px;
   }
+
   .bisector-dialog-button-group {
     display: grid;
     gap: 8px;

--- a/src/components/bisector/DialogTitle.vue
+++ b/src/components/bisector/DialogTitle.vue
@@ -1,0 +1,43 @@
+<template>
+  <div>
+    组件二等分
+    <div
+      class="peek"
+      title="透视"
+      style="margin-left: auto"
+      @mouseover="peek = true"
+      @mouseout="peek = false"
+    >
+      <VIcon icon="eye" :size="18" />
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import Vue from 'vue'
+import { VIcon } from '@/ui'
+
+export default Vue.extend({
+  components: { VIcon },
+  data() {
+    return { peek: false }
+  },
+  watch: {
+    peek(value) {
+      this.$el.closest('.be-dialog').style.opacity = value ? '0.1' : '1'
+    },
+  },
+})
+</script>
+
+<style lang="scss" scoped>
+@import 'common';
+
+div {
+  @include h-center(8px);
+}
+
+.peek {
+  cursor: pointer;
+}
+</style>

--- a/src/components/bisector/ResultToastContent.vue
+++ b/src/components/bisector/ResultToastContent.vue
@@ -1,0 +1,54 @@
+<template>
+  <div>
+    <div>可能出问题的组件是：{{ displayName }}（{{ name }}）</div>
+    <div>
+      <span class="link" @click="restore">恢复原状（{{ countdown }} 秒）</span>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import Vue from 'vue'
+
+export default Vue.extend({
+  data() {
+    return {
+      countdown: 30,
+      userComponent: undefined,
+    }
+  },
+  computed: {
+    displayName() {
+      return this.userComponent?.metadata?.displayName
+    },
+    name() {
+      return this.userComponent?.metadata?.name
+    },
+  },
+  watch: {
+    countdown(value) {
+      if (value === 0) {
+        this.restore()
+      }
+    },
+  },
+  created() {
+    this.interval = setInterval(() => {
+      if (this.countdown > 0) {
+        this.countdown--
+      } else {
+        clearInterval(this.interval)
+      }
+    }, 1e3)
+  },
+  destroyed() {
+    clearInterval(this.interval)
+  },
+  methods: {
+    restore() {
+      clearInterval(this.interval)
+      this.$emit('restore')
+    },
+  },
+})
+</script>

--- a/src/components/bisector/api.ts
+++ b/src/components/bisector/api.ts
@@ -1,7 +1,7 @@
 import { DialogInstance, showDialog } from '@/core/dialog'
 import type { Settings } from '@/core/settings/types'
 import { Toast } from '@/core/toast'
-import { getRandomId, mountVueComponent, sleep } from '@/core/utils'
+import { getRandomId, mountVueComponent, delay } from '@/core/utils'
 import { useScopedConsole } from '@/core/utils/log'
 import type { RecordValue } from '../types'
 import type { BisectNext, BisectReturn } from './bisect'
@@ -93,7 +93,7 @@ export const stop = async () => {
     const msg = `部分组件未能还原状态：${getComponentNames(unmatchedComponents)}`
     scopedConsole?.warn(`stop - ${msg}`)
     Toast.error(msg, '组件二等分')
-    await sleep(3e3)
+    await delay(3e3)
   }
   scopedConsole?.log('stop - 清理状态')
   bisectorGenerator = null
@@ -117,7 +117,7 @@ export const next = async (seeingBad?: boolean, autoReload?: boolean) => {
     bisectorOptions.bisectInitialState = { low, high }
     const elementId = `bisector-result-toast-content-${getRandomId()}`
     Toast.info(/* html */ `<div id="${elementId}"></div>`, '组件二等分结果')
-    await sleep()
+    await delay()
     const vm = mountVueComponent<{ userComponent: UserComponent }>(
       ResultToastContent,
       `#${elementId}`,

--- a/src/components/bisector/api.ts
+++ b/src/components/bisector/api.ts
@@ -1,0 +1,200 @@
+import { DialogInstance, showDialog } from '@/core/dialog'
+import type { Settings } from '@/core/settings/types'
+import { Toast } from '@/core/toast'
+import { mountVueComponent } from '@/core/utils'
+import { useScopedConsole } from '@/core/utils/log'
+import type { RecordValue } from '../types'
+import type { BisectNext } from './bisect'
+import { bisect } from './bisect'
+import { BisectorOptions } from './options'
+import ResultToastContent from './ResultToastContent.vue'
+
+type UserComponent = RecordValue<Settings['userComponents']>
+
+let bisectorOptions: BisectorOptions
+let scopedConsole: ReturnType<typeof useScopedConsole>
+let bisectorGenerator: ReturnType<typeof bisect>
+let groupedComponents: Awaited<ReturnType<typeof classifyComponents>>
+let dialog: DialogInstance
+
+export const setOptions = (options: BisectorOptions) => {
+  if (!bisectorOptions) {
+    bisectorOptions = options
+  } else {
+    Object.assign(bisectorOptions, options)
+  }
+}
+
+export const setConsole = (console: ReturnType<typeof useScopedConsole>) => {
+  scopedConsole = console
+}
+
+const classifyComponents = async () => {
+  const { settings } = await import('@/core/settings')
+
+  const { userComponents } = settings
+  const configurableUserComponents = lodash.pickBy(
+    userComponents,
+    v => v.metadata.configurable || true,
+  )
+  const { targetComponents, keepDisabledComponents, keepEnabledComponents } = lodash.transform(
+    configurableUserComponents,
+    (result, v, k) => {
+      if (bisectorOptions.keepEnabledComponents?.includes(k)) {
+        result.keepEnabledComponents.push(v)
+        return
+      }
+      if (bisectorOptions.keepDisabledComponents?.includes(k)) {
+        result.keepDisabledComponents.push(v)
+        return
+      }
+      result.targetComponents.push(v)
+    },
+    {
+      targetComponents: [] as UserComponent[],
+      keepDisabledComponents: [] as UserComponent[],
+      keepEnabledComponents: [] as UserComponent[],
+    },
+  )
+
+  return {
+    userComponents,
+    configurableUserComponents,
+    targetComponents,
+    keepDisabledComponents,
+    keepEnabledComponents,
+  }
+}
+
+const setComponentsEnabled = (components: UserComponent[], enabled: boolean) =>
+  components.forEach(component => (component.settings.enabled = enabled))
+
+const getComponentNames = (components: UserComponent[]) =>
+  components
+    .map(component => `${component.metadata.displayName}（${component.metadata.name}）`)
+    .join(', ') || '无'
+
+export const isRecover = () => !lodash.isEmpty(bisectorOptions.bisectInitialState)
+
+export const stop = async () => {
+  scopedConsole?.log('stop - 准备停止组件二等分')
+  dialog?.close()
+  const { configurableUserComponents } = await classifyComponents()
+  const unmatchedComponentNames = []
+  for (const [componentName, componentSettings] of Object.entries(configurableUserComponents)) {
+    const originalStatus = bisectorOptions.originalComponentEnableState?.[componentName]
+    if (originalStatus == null) {
+      unmatchedComponentNames.push(componentName)
+      continue
+    }
+    componentSettings.settings.enabled = originalStatus
+  }
+  if (unmatchedComponentNames.length) {
+    scopedConsole?.warn(
+      `stop - 部分组件未能还原状态：${getComponentNames(unmatchedComponentNames)}`,
+    )
+  }
+  scopedConsole?.log('stop - 清理状态')
+  bisectorGenerator = null
+  bisectorOptions.bisectInitialState = {}
+  scopedConsole?.log('stop - 重载页面')
+  location.reload()
+}
+
+export const next = async (seeingBad?: boolean, autoReload?: boolean) => {
+  dialog?.close()
+  scopedConsole?.log(
+    `next - 当前工作状态：${
+      // eslint-disable-next-line no-nested-ternary
+      seeingBad == null ? '未知' : seeingBad ? '异常' : '正常'
+    }`,
+  )
+  const { done, value } = bisectorGenerator.next(seeingBad) as unknown as {
+    done: boolean
+    value: BisectNext<UserComponent> | UserComponent
+  }
+  if (done) {
+    const elementId = `bisector-result-toast-content-${Math.floor(
+      Math.random() * (Number.MAX_SAFE_INTEGER + 1),
+    )}`
+    Toast.info(/* html */ `<div id="${elementId}"></div>`, '二等分结果')
+    setTimeout(() => {
+      const vm = mountVueComponent<{ userComponent: UserComponent }>(
+        ResultToastContent,
+        `#${elementId}`,
+      )
+      vm.userComponent = value as UserComponent
+      vm.$on('restore', () => {
+        stop()
+      })
+    })
+  } else {
+    const { slice, low, high } = value as BisectNext<UserComponent>
+    const needEnabled = slice
+    const needDisabled = lodash.difference(groupedComponents.targetComponents, slice)
+    bisectorOptions.bisectInitialState = { low, high }
+    scopedConsole?.log(`next - 关闭组件：${getComponentNames(needDisabled)}`)
+    scopedConsole?.log(`next - 开启组件：${getComponentNames(needEnabled)}`)
+    setComponentsEnabled(needDisabled, false)
+    setComponentsEnabled(needEnabled, true)
+    if (autoReload) {
+      scopedConsole?.log('next - 重载页面')
+      location.reload()
+    }
+  }
+  return { done, value }
+}
+
+export const recover = async () => {
+  scopedConsole?.log('recover - 准备恢复组件二等分')
+  groupedComponents = await classifyComponents()
+  const { targetComponents, keepDisabledComponents, keepEnabledComponents } = groupedComponents
+  setComponentsEnabled(keepEnabledComponents, true)
+  setComponentsEnabled(keepDisabledComponents, false)
+  scopedConsole?.log(`recover - 保持关闭组件：${getComponentNames(keepDisabledComponents)}`)
+  scopedConsole?.log(`recover - 保持开启组件：${getComponentNames(keepEnabledComponents)}`)
+  scopedConsole?.log(`recover - 全部目标组件：${getComponentNames(targetComponents)}`)
+  bisectorGenerator = bisect(targetComponents, bisectorOptions.bisectInitialState)
+  const { done, value } = await next()
+  if (!done) {
+    const { rouge } = value as BisectNext<UserComponent>
+    dialog = showDialog({
+      title: () => import('./DialogTitle.vue'),
+      content: () => import('./DialogContent.vue'),
+      contentProps: {
+        rouge,
+        onGood: () => next(false, true),
+        onBad: () => next(true, true),
+        onAbort: () => stop(),
+      },
+    })
+  }
+}
+
+export const start = async () => {
+  if (isRecover()) {
+    await recover()
+    return
+  }
+  scopedConsole?.log('start - 准备开始组件二等分')
+  groupedComponents = await classifyComponents()
+  const {
+    configurableUserComponents,
+    targetComponents,
+    keepDisabledComponents,
+    keepEnabledComponents,
+  } = groupedComponents
+  scopedConsole?.log('start - 保存组件初始启用状态')
+  bisectorOptions.originalComponentEnableState = lodash.mapValues(
+    configurableUserComponents,
+    v => v.settings.enabled,
+  )
+  setComponentsEnabled(targetComponents, true)
+  setComponentsEnabled(keepEnabledComponents, true)
+  setComponentsEnabled(keepDisabledComponents, false)
+  scopedConsole?.log(`start - 保持关闭组件：${getComponentNames(keepDisabledComponents)}`)
+  scopedConsole?.log(`start - 保持开启组件：${getComponentNames(keepEnabledComponents)}`)
+  scopedConsole?.log(`start - 启用全部目标组件：${getComponentNames(targetComponents)}`)
+  bisectorGenerator = bisect(targetComponents, bisectorOptions.bisectInitialState)
+  await next(undefined, true)
+}

--- a/src/components/bisector/bisect.ts
+++ b/src/components/bisector/bisect.ts
@@ -33,7 +33,7 @@ export function* bisectLeft<O>(
       high,
       mid,
       slice: data.slice(low, mid),
-      rouge: ~~Math.log2(high - low),
+      rouge: Math.trunc(Math.log2(high - low)),
     }
 
     if (seeingBad) {
@@ -48,7 +48,7 @@ export function* bisectLeft<O>(
     high,
     mid,
     slice: data.slice(low, mid),
-    rouge: ~~Math.log2(high - low),
+    rouge: Math.trunc(Math.log2(high - low)),
     target: data[low],
   }
 }
@@ -69,7 +69,7 @@ export function* bisectRight<O>(
       high,
       mid,
       slice: data.slice(mid, high),
-      rouge: ~~Math.log2(high - low),
+      rouge: Math.trunc(Math.log2(high - low)),
     }
 
     if (seeingBad) {
@@ -84,7 +84,7 @@ export function* bisectRight<O>(
     high,
     mid,
     slice: data.slice(low, mid),
-    rouge: ~~Math.log2(high - low),
+    rouge: Math.trunc(Math.log2(high - low)),
     target: data[low],
   }
 }

--- a/src/components/bisector/bisect.ts
+++ b/src/components/bisector/bisect.ts
@@ -8,62 +8,84 @@ export interface BisectNext<O> {
   rouge: number
 }
 
+export interface BisectReturn<O> extends BisectNext<O> {
+  target: O
+}
+
 export interface InitialState {
   low?: number
   high?: number
 }
 
-export function* bisectLeft<O>(data: readonly O[], initialState?: InitialState) {
+export function* bisectLeft<O>(
+  data: readonly O[],
+  initialState?: InitialState,
+): Generator<BisectNext<O>, BisectReturn<O>> {
   let low = initialState?.low ?? 0
   let high = initialState?.high ?? data.length
-  let mid = (low + high) >>> 1
+  let mid: number
 
-  while (true) {
-    const seeingBad = yield ({
+  while (low + 1 < high) {
+    mid = (low + high) >>> 1
+
+    const seeingBad = yield {
       low,
       high,
       mid,
       slice: data.slice(low, mid),
       rouge: ~~Math.log2(high - low),
-    } as BisectNext<O>) || false
+    }
 
     if (seeingBad) {
       high = mid
     } else {
       low = mid
     }
-    if (low + 1 < high) {
-      mid = (low + high) >>> 1
-    } else {
-      return data[low]
-    }
+  }
+
+  return {
+    low,
+    high,
+    mid,
+    slice: data.slice(low, mid),
+    rouge: ~~Math.log2(high - low),
+    target: data[low],
   }
 }
 
-export function* bisectRight<O>(data: readonly O[], initialState?: InitialState) {
+export function* bisectRight<O>(
+  data: readonly O[],
+  initialState?: InitialState,
+): Generator<BisectNext<O>, BisectReturn<O>> {
   let low = initialState?.low ?? 0
   let high = initialState?.high ?? data.length
   let mid = (low + high) >>> 1
 
-  while (true) {
-    const seeingBad = yield ({
+  while (low + 1 < high) {
+    mid = (low + high) >>> 1
+
+    const seeingBad = yield {
       low,
       high,
       mid,
       slice: data.slice(mid, high),
       rouge: ~~Math.log2(high - low),
-    } as BisectNext<O>) || false
+    }
 
     if (seeingBad) {
       low = mid
     } else {
       high = mid
     }
-    if (low + 1 < high) {
-      mid = (low + high) >>> 1
-    } else {
-      return data[low]
-    }
+  }
+
+  return {
+    low,
+    high,
+    mid,
+    slice: data.slice(low, mid),
+    rouge: ~~Math.log2(high - low),
+    target: data[low],
   }
 }
 

--- a/src/components/bisector/bisect.ts
+++ b/src/components/bisector/bisect.ts
@@ -1,0 +1,70 @@
+/* eslint-disable no-bitwise */
+
+export interface BisectNext<O> {
+  low: number
+  high: number
+  mid: number
+  slice: O[]
+  rouge: number
+}
+
+export interface InitialState {
+  low?: number
+  high?: number
+}
+
+export function* bisectLeft<O>(data: readonly O[], initialState?: InitialState) {
+  let low = initialState?.low ?? 0
+  let high = initialState?.high ?? data.length
+  let mid = (low + high) >>> 1
+
+  while (true) {
+    const seeingBad = yield ({
+      low,
+      high,
+      mid,
+      slice: data.slice(low, mid),
+      rouge: ~~Math.log2(high - low),
+    } as BisectNext<O>) || false
+
+    if (seeingBad) {
+      high = mid
+    } else {
+      low = mid
+    }
+    if (low + 1 < high) {
+      mid = (low + high) >>> 1
+    } else {
+      return data[low]
+    }
+  }
+}
+
+export function* bisectRight<O>(data: readonly O[], initialState?: InitialState) {
+  let low = initialState?.low ?? 0
+  let high = initialState?.high ?? data.length
+  let mid = (low + high) >>> 1
+
+  while (true) {
+    const seeingBad = yield ({
+      low,
+      high,
+      mid,
+      slice: data.slice(mid, high),
+      rouge: ~~Math.log2(high - low),
+    } as BisectNext<O>) || false
+
+    if (seeingBad) {
+      low = mid
+    } else {
+      high = mid
+    }
+    if (low + 1 < high) {
+      mid = (low + high) >>> 1
+    } else {
+      return data[low]
+    }
+  }
+}
+
+export const bisect = bisectLeft

--- a/src/components/bisector/index.ts
+++ b/src/components/bisector/index.ts
@@ -30,7 +30,7 @@ export const component = defineComponentMetadata({
           name: 'bisector-start',
           getActions: async () => [
             {
-              name: '开始/继续组件二等分',
+              name: '开始 / 继续组件二等分',
               description: 'Start/Continue component bisection',
               icon: 'mdi-view-split-horizontal',
               action: async () => {

--- a/src/components/bisector/index.ts
+++ b/src/components/bisector/index.ts
@@ -1,0 +1,45 @@
+import { defineComponentMetadata } from '@/components/define'
+import { bisectorOptionsMetadata } from './options'
+import { LifeCycleEventTypes } from '@/core/life-cycle'
+import { componentsTags } from '@/components/types'
+import * as bisector from './api'
+import { useScopedConsole } from '@/core/utils/log'
+import type { LaunchBarActionProvider } from '../launch-bar/launch-bar-action'
+
+export const component = defineComponentMetadata({
+  name: 'bisector',
+  displayName: '组件二等分',
+  tags: [componentsTags.general, componentsTags.utils],
+  hidden: true,
+  configurable: false,
+  entry: async ({ settings: { options } }) => {
+    bisector.setOptions(options)
+    bisector.setConsole(useScopedConsole('组件二等分'))
+    unsafeWindow.addEventListener(LifeCycleEventTypes.ComponentsLoaded, () => {
+      if (bisector.isRecover()) {
+        bisector.recover()
+      }
+    })
+  },
+  options: bisectorOptionsMetadata,
+  plugin: {
+    displayName: '组件二等分 - 功能扩展',
+    setup: ({ addData }) => {
+      addData('launchBar.actions', (providers: LaunchBarActionProvider[]) => {
+        providers.push({
+          name: 'bisector-start',
+          getActions: async () => [
+            {
+              name: '开始/继续组件二等分',
+              description: 'Start/Continue component bisection',
+              icon: 'mdi-view-split-horizontal',
+              action: async () => {
+                await bisector.start()
+              },
+            },
+          ],
+        })
+      })
+    },
+  },
+})

--- a/src/components/bisector/options.ts
+++ b/src/components/bisector/options.ts
@@ -1,0 +1,31 @@
+import { defineOptionsMetadata, OptionsOfMetadata } from '@/components/define'
+import { getComponentSettings } from '@/core/settings'
+import type { InitialState } from './bisect'
+
+export const bisectorOptionsMetadata = defineOptionsMetadata({
+  // 原始的组件启用状态
+  originalComponentEnableState: {
+    defaultValue: {} as Record<string, boolean>,
+    hidden: true,
+  },
+  // 保持禁用状态的组件内部名称数组
+  keepDisabledComponents: {
+    defaultValue: [] as string[],
+    hidden: true,
+  },
+  // 保持启用状态的组件内部名称数组
+  keepEnabledComponents: {
+    defaultValue: [] as string[],
+    hidden: true,
+  },
+  // bisect 生成器的初始状态
+  bisectInitialState: {
+    defaultValue: {} as Partial<InitialState>,
+    hidden: true,
+  },
+})
+
+export const getBisectorOptions = () =>
+  getComponentSettings<OptionsOfMetadata<typeof bisectorOptionsMetadata>>('bisector').options
+
+export type BisectorOptions = ReturnType<typeof getBisectorOptions>

--- a/src/components/built-in-components.ts
+++ b/src/components/built-in-components.ts
@@ -4,6 +4,7 @@ import { component as LaunchBar } from './launch-bar'
 import { component as I18n } from './i18n'
 import { component as AutoUpdate } from './auto-update'
 import { component as NotifyNewVersion } from './notify-new-version'
+import { component as Bisector } from './bisector'
 
 export const getBuiltInComponents = (): ComponentMetadata[] => [
   SettingsPanel,
@@ -11,6 +12,7 @@ export const getBuiltInComponents = (): ComponentMetadata[] => [
   I18n,
   AutoUpdate,
   NotifyNewVersion,
+  Bisector,
 ]
 
 export const isBuiltInComponent = (name: string) =>

--- a/src/components/types.ts
+++ b/src/components/types.ts
@@ -216,3 +216,6 @@ export interface ComponentMetadata<O extends UnknownOptions = UnknownOptions>
 
 /** 用户组件的非函数基本信息, 用于直接保存为 JSON */
 export type UserComponentMetadata = Omit<ComponentMetadata, keyof FunctionalMetadata>
+
+/** 推断 Record 的 Value 类型 */
+export type RecordValue<R> = R extends Record<any, infer V> ? V : never

--- a/src/components/user-component.ts
+++ b/src/components/user-component.ts
@@ -1,6 +1,8 @@
 import { componentToSettings } from '@/core/settings'
 import { isBuiltInComponent } from './built-in-components'
 import { ComponentMetadata, componentsMap } from './component'
+import * as bisector from './bisector/api'
+import { BisectorOptions } from './bisector/options'
 
 /**
  * 安装自定义组件
@@ -129,4 +131,17 @@ export const toggleComponent = async (nameOrDisplayName: string) => {
   const { enabled } = userComponent.settings
   const { displayName } = userComponent.metadata
   return `已${enabled ? '开启' : '关闭'}组件'${displayName}', 可能需要刷新后才能生效`
+}
+
+/**
+ * 二等分自定义组件的开关状态
+ *
+ * @param options 二等分选项
+ * @returns
+ */
+export const bisectComponent = async (options?: BisectorOptions) => {
+  if (options) {
+    bisector.setOptions(options)
+  }
+  return bisector
 }

--- a/src/core/dialog/index.ts
+++ b/src/core/dialog/index.ts
@@ -10,7 +10,7 @@ export interface DialogInputs {
 }
 export interface DialogInstance extends Required<DialogInputs> {
   open: boolean
-  close: Promise<void>
+  close(): Promise<void>
   closeListeners: (() => void)[]
 }
 export const showDialog = (inputs: DialogInputs) => {

--- a/src/core/utils/index.ts
+++ b/src/core/utils/index.ts
@@ -634,11 +634,3 @@ export const getRandomId = (length = 8) => {
     .join('')
     .substring(0, length)
 }
-
-/**
- * 异步延时指定毫秒数
- *
- * @param ms 传递给 setTimeout 的第二个参数，表示延时时间
- * @returns
- */
-export const sleep = (ms?: number) => new Promise(resolve => setTimeout(resolve, ms))

--- a/src/core/utils/index.ts
+++ b/src/core/utils/index.ts
@@ -634,3 +634,11 @@ export const getRandomId = (length = 8) => {
     .join('')
     .substring(0, length)
 }
+
+/**
+ * 异步延时指定毫秒数
+ *
+ * @param ms 传递给 setTimeout 的第二个参数，表示延时时间
+ * @returns
+ */
+export const sleep = (ms?: number) => new Promise(resolve => setTimeout(resolve, ms))


### PR DESCRIPTION
<!-- 可以参考下代码贡献指南: https://github.com/the1812/Bilibili-Evolved/blob/preview/CONTRIBUTING.md -->

和 vscode 的「扩展二等分」功能类似，可帮助开发人员定位是哪个组件导致的问题。

idea 来自：#3829

目前支持两种方式唤起二等分操作：

- 通过 launchBar（搜索栏），输入「二等分」
- 通过 `componentApis` API，在控制台中调用 `bilibiliEvolved.componentApis.bisectComponent` 方法

API 方式可指定需要固定启用或禁用状态的组件，以便进一步缩小范围。例如，下面的调用方式表示在始终启用「记忆倍速」和「扩展倍速」组件的情况下，对其他组件进行二等分：

```javascript
const bisector = await bilibiliEvolved.componentApis.bisectComponent({keepEnabledComponents: ["extendVideoSpeed", "rememberVideoSpeed"]})
bisector.start()
```

### 演示效果

[视频2.webm](https://user-images.githubusercontent.com/34429322/216808529-a9d44f8a-dc19-49c3-824f-3217b77d6ae8.webm)

[视频.webm](https://user-images.githubusercontent.com/34429322/216775158-517e2763-0578-4e5c-9d2c-b799245db942.webm)
