### PR TITLE
Fix UserItem.vue

### DIFF
--- a/src/components/settings-panel/sub-pages/manage-panel/UserItem.vue
+++ b/src/components/settings-panel/sub-pages/manage-panel/UserItem.vue
@@ -50,10 +50,12 @@ export default Vue.extend({
     if (this.config.getSettings) {
       this.settings = this.config.getSettings(this.config.item)
     }
-    Toast.mini(this.$refs.removeConfirmTemplate, this.$refs.removeIcon, {
-      trigger: 'click',
-      hideOnClick: true,
-    })
+    if (this.config.isUserItem) {
+      Toast.mini(this.$refs.removeConfirmTemplate, this.$refs.removeIcon, {
+        trigger: 'click',
+        hideOnClick: true,
+      })
+    }
   },
   methods: {
     async removeItem() {


### PR DESCRIPTION
`removeConfirmTemplate` 和 `removeIcon` 仅在 `this.config.isUserItem` 时才存在。所以需要限制 Toast 的显示条件，避免传入 `null`。