### PR TITLE
Preview fixes

### DIFF
--- a/registry/lib/components/style/home-redesign/fresh/layouts/categories/content/BangumiTimeline.vue
+++ b/registry/lib/components/style/home-redesign/fresh/layouts/categories/content/BangumiTimeline.vue
@@ -408,11 +408,40 @@ export default Vue.extend({
     }
     &-seasons {
       @include h-stretch(calc(var(--timeline-item-gap) / 2));
-      @include no-scrollbar();
+      //@include no-scrollbar();
+      overflow-x: auto;
       overscroll-behavior: initial;
       width: 0;
       flex: 1 0 0;
       scroll-snap-type: x mandatory;
+      scrollbar-width: thin;
+      scrollbar-color: rgba(0, 0, 0, 0.5) rgba(0, 0, 0, 0.1);
+      &::-webkit-scrollbar {
+        height: 4px;
+        background-color: rgba(0, 0, 0, 0.1);
+      }
+      &::-webkit-scrollbar-thumb {
+        background-color: rgba(0, 0, 0, 0.5);
+        border-radius: 2px;
+      }
+      body.dark & {
+        scrollbar-color: rgba(255, 255, 255, 0.5) rgba(255, 255, 255, 0.1);
+        &::-webkit-scrollbar {
+          background-color: rgba(255, 255, 255, 0.1);
+        }
+        &::-webkit-scrollbar-thumb {
+          background-color: rgba(255, 255, 255, 0.5);
+        }
+      }
+      @media (prefers-color-scheme: dark) {
+        scrollbar-color: rgba(255, 255, 255, 0.5) rgba(255, 255, 255, 0.1);;
+        &::-webkit-scrollbar {
+          background-color: rgba(255, 255, 255, 0.1);
+        }
+        &::-webkit-scrollbar-thumb {
+          background-color: rgba(255, 255, 255, 0.5);
+        }
+      }
     }
     &-season {
       --cover-size: 50px;

--- a/registry/lib/components/style/home-redesign/fresh/layouts/categories/content/BangumiTimeline.vue
+++ b/registry/lib/components/style/home-redesign/fresh/layouts/categories/content/BangumiTimeline.vue
@@ -434,7 +434,7 @@ export default Vue.extend({
         }
       }
       @media (prefers-color-scheme: dark) {
-        scrollbar-color: rgba(255, 255, 255, 0.5) rgba(255, 255, 255, 0.1);;
+        scrollbar-color: rgba(255, 255, 255, 0.5) rgba(255, 255, 255, 0.1);
         &::-webkit-scrollbar {
           background-color: rgba(255, 255, 255, 0.1);
         }


### PR DESCRIPTION
清爽首页番剧列表 使用了no-scrollbar()样式 导致番剧列表一行最多只能给用户展示3条信息
重新适配了相应的滚动样式，以便用户可以查看全天的番剧
<img width="808" alt="微信截图_20230322145550" src="https://user-images.githubusercontent.com/14851843/226825858-b00bdab4-70ee-4661-9598-5cc0fd487e53.png">
<img width="769" alt="微信截图_20230322145605" src="https://user-images.githubusercontent.com/14851843/226825887-12092c64-005b-42e6-9f72-b714a9378af9.png">
