### PR TITLE
feat: + fallback jsdelivr host

### DIFF
--- a/webpack/cdn/jsdelivr.ts
+++ b/webpack/cdn/jsdelivr.ts
@@ -2,13 +2,16 @@ import { CdnConfig } from './types'
 
 const owner = 'the1812'
 let host: string = 'fastly.jsdelivr.net';
-const timeout = 1000; // 单位ms
+const timeout = 50000; // 单位ms
 
 const controller = new AbortController();
 const signal = controller.signal;
 const timer = setTimeout(() => controller.abort(), timeout);
 
-fetch(`https://${host}/favicon.ico`, { signal })
+fetch(`https://${host}/favicon.ico`, { 
+  signal,
+  cache: 'no-store'
+})
   .then(response => {
     clearTimeout(timer);
     if (response.ok) {

--- a/webpack/cdn/jsdelivr.ts
+++ b/webpack/cdn/jsdelivr.ts
@@ -1,7 +1,29 @@
 import { CdnConfig } from './types'
 
 const owner = 'the1812'
-const host = 'fastly.jsdelivr.net'
+let host: string = 'https://fastly.jsdelivr.net';
+const timeout = 1000; // 单位ms
+
+const controller = new AbortController();
+const signal = controller.signal;
+const timer = setTimeout(() => controller.abort(), timeout);
+
+fetch(host, { signal })
+  .then(response => {
+    clearTimeout(timer);
+    if (response.ok) {
+      // console.log('fastly.jsdelivr.net is accessible');
+      host = 'https://fastly.jsdelivr.net';
+    } else {
+      console.log('fastly.jsdelivr.net returned an error:', response.status);
+      host = 'https://testingcf.jsdelivr.net';
+    }
+  })
+  .catch(error => {
+    console.log('fastly.jsdelivr.net timed out or returned an error:', error.message);
+    host = 'https://testingcf.jsdelivr.net';
+  });
+
 export const jsDelivr: CdnConfig = {
   name: 'jsDelivr',
   owner,

--- a/webpack/cdn/jsdelivr.ts
+++ b/webpack/cdn/jsdelivr.ts
@@ -1,27 +1,27 @@
 import { CdnConfig } from './types'
 
 const owner = 'the1812'
-let host: string = 'https://fastly.jsdelivr.net';
+let host: string = 'fastly.jsdelivr.net';
 const timeout = 1000; // 单位ms
 
 const controller = new AbortController();
 const signal = controller.signal;
 const timer = setTimeout(() => controller.abort(), timeout);
 
-fetch(host, { signal })
+fetch(`https://${host}/favicon.ico`, { signal })
   .then(response => {
     clearTimeout(timer);
     if (response.ok) {
       // console.log('fastly.jsdelivr.net is accessible');
-      host = 'https://fastly.jsdelivr.net';
+      host = 'fastly.jsdelivr.net';
     } else {
       console.log('fastly.jsdelivr.net returned an error:', response.status);
-      host = 'https://testingcf.jsdelivr.net';
+      host = 'testingcf.jsdelivr.net';
     }
   })
   .catch(error => {
     console.log('fastly.jsdelivr.net timed out or returned an error:', error.message);
-    host = 'https://testingcf.jsdelivr.net';
+    host = 'testingcf.jsdelivr.net';
   });
 
 export const jsDelivr: CdnConfig = {


### PR DESCRIPTION
目前内地大部分地区testingcf(cloudflare源)比fastly可访问性更加（去年是反过来的），建议增加备选。