### PR TITLE
fix(extend-live): 修复新版动态无法打开“正在直播”十个以后的链接

### DIFF
--- a/registry/lib/components/feeds/extend-live/index.ts
+++ b/registry/lib/components/feeds/extend-live/index.ts
@@ -44,7 +44,7 @@ const entry = async () => {
       const clone = liveDetailItem.cloneNode(true) as HTMLElement
       const url = `https://live.bilibili.com/${it.roomid}`
       dqa(clone, 'a[href]').forEach(a => a.setAttribute('href', url))
-      if (clone.matches('.bili-dyn-live-users__item')) {
+      if (clone.matches('.bili-dyn-live-users__item, .bili-dyn-live-users__container')) {
         clone.addEventListener('click', () => {
           window.open(url, '_blank')
         })


### PR DESCRIPTION
<!-- 可以参考下代码贡献指南: https://github.com/the1812/Bilibili-Evolved/blob/preview/CONTRIBUTING.md -->
参照：#4034、#3917

直播信息扩充组件，在新版动态下，十个之后的直播间无法点击进入。而旧版动态没问题，所以做了下兼容。