### PR TITLE
Feat(extend-live): 让重构的 `直播信息扩充` 能够在下滑时固定

### DIFF
--- a/registry/lib/components/feeds/extend-live/LiveList.vue
+++ b/registry/lib/components/feeds/extend-live/LiveList.vue
@@ -129,6 +129,8 @@ export default Vue.extend({
   font-size: 12px;
   color: #000;
   background-color: #fff;
+  position: sticky;
+  top: 72px;
   body.dark & {
     background-color: #444;
     color: #eee;
@@ -196,6 +198,7 @@ export default Vue.extend({
   }
   &-item {
     @include h-center(8px);
+    padding: 4px 0;
     cursor: pointer;
     &-avatar {
       overflow: hidden;

--- a/registry/lib/components/feeds/extend-live/index.ts
+++ b/registry/lib/components/feeds/extend-live/index.ts
@@ -6,9 +6,7 @@ import { useScopedConsole } from '@/core/utils/log'
 
 const entry = async () => {
   const console = useScopedConsole('extendFeedsLive')
-  const container = (await select(
-    '.bili-dyn-home--member aside.left section:last-child',
-  )) as HTMLElement
+  const container = (await select('.bili-dyn-home--member aside.left')) as HTMLElement
   if (!container) {
     console.error('container not found')
   }


### PR DESCRIPTION
让重构的 `直播信息扩充` 像原版的 直播栏 一样，能够在下滑动态时固定住
把每个元素的边距改大了一点
