### PR TITLE
fix: 修正播放器模式切换时 body类名响应问题

### DIFF
--- a/registry/lib/components/video/player/disable-scroll-volume/index.ts
+++ b/registry/lib/components/video/player/disable-scroll-volume/index.ts
@@ -5,11 +5,9 @@ let cancel: () => void
 const prevent = () => {
   cancel?.()
   cancel = preventEvent(unsafeWindow, 'mousewheel', () => {
-    const isFullscreen = [
-      'player-mode-webfullscreen',
-      'player-fullscreen-fix',
-      'player-full-win',
-    ].some(token => document.body.classList.contains(token))
+    const isFullscreen = ['player-mode-full', 'player-fullscreen-fix', 'player-full-win'].some(
+      token => document.body.classList.contains(token),
+    )
     return isFullscreen
   })
 }

--- a/src/components/video/player-adaptor/bpx.ts
+++ b/src/components/video/player-adaptor/bpx.ts
@@ -11,11 +11,14 @@ const playerModePolyfill = async () => {
   }
   attributes(bpxContainer, () => {
     const dataScreen = bpxContainer.getAttribute('data-screen')
-    document.body.classList.toggle(
-      'player-mode-webfullscreen',
-      dataScreen === 'full' || dataScreen === 'web',
-    )
-    dataScreen === 'wide' ? document.body.classList.add('player-mode-widescreen') : ''
+    const prefix = 'player-mode-'
+    const enumList = ['normal', 'wide', 'web', 'full'].map(it => `${prefix}${it}`)
+
+    // clear all class
+    document.body.classList.remove(...enumList)
+
+    // add class
+    document.body.classList.add(dataScreen !== 'normal' ? `${prefix}${dataScreen}` : '')
   })
 }
 const idPolyfill = async () => {

--- a/src/ui/_common.scss
+++ b/src/ui/_common.scss
@@ -145,8 +145,8 @@
   left: 50%;
   transform: translateX(-50%) translateY(-50%);
 }
-@mixin on-fullscreen($bodyClass: "*") {
-  #{selector-unify("body.player-mode-webfullscreen", $bodyClass)} &,
+@mixin on-fullscreen($bodyClass: '*') {
+  #{selector-unify("body.player-mode-full", $bodyClass)} &,
   #{selector-unify("body.player-fullscreen-fix", $bodyClass)} &,
   #{selector-unify("body.player-full-win", $bodyClass)} & {
     @content;


### PR DESCRIPTION
[fix: 修正播放器模式切换时 body类名响应问题](https://github.com/the1812/Bilibili-Evolved/commit/5d132bbe3eb58fb799b16cc549327149be0c87b7) 

- 调整了应用到`body`的类名
- `player-mode-webfullscreen` => `player-mode-full`
- `player-mode-widescreen` => `player-mode-wide`

[fix: 适应 bpx.ts 中类名变化](https://github.com/the1812/Bilibili-Evolved/commit/ac6e0e40f7082633a96180382eada2d34dd20fc3) 

- 全局搜索只找到了这一处，不知道还有没有其他地方