### PR TITLE
build: 截取构建时CLI提示信息 | intercept the CLI prompt information during the build

### DIFF
--- a/registry/webpack/build.ts
+++ b/registry/webpack/build.ts
@@ -1,5 +1,8 @@
+import path from 'path'
 import glob from 'glob'
 import { buildByEntry } from './config'
+
+const shorten = (p: string) => path.dirname(p).replace('./registry/lib/', '')
 
 export const builders = Object.fromEntries(
   ['component', 'plugin', 'doc'].map(type => {
@@ -7,11 +10,14 @@ export const builders = Object.fromEntries(
     return [
       type,
       async ({ buildAll = false } = {}) => {
-        const entries = glob.sync(`${src}**/index.ts`)
+        const entries = glob.sync(`${src}**/index.ts`).map(entry => ({
+          name: shorten(entry),
+          value: entry,
+        }))
 
         if (buildAll) {
           console.log(`[build all] discovered ${entries.length} ${type}s`)
-          return entries.map(entry => buildByEntry({ src, type, entry }))
+          return entries.map(({ value }) => buildByEntry({ src, type, entry: value }))
         }
 
         let entry: string
@@ -25,9 +31,9 @@ export const builders = Object.fromEntries(
           })
           entry = await prompt.run()
         } else {
-          ;[entry] = entries
-          console.log(`Build target · ${entry}`)
+          ;[{ value: entry }] = entries
         }
+        console.log(`Build target · ${entry}`)
         return [buildByEntry({ src, type, entry })]
       },
     ]


### PR DESCRIPTION
## PR Desc

- 之前展示的是完整路径 当路径过长时会导致提示信息过长 选取体验很差
- 做统一截取处理 只展示能够区分当前组件的部分

- 可以优化部分场景下的开发体验：比如下例中将终端放在一侧的场景
- 组件、插件、doc做了统一处理
- 这里使用`replace`局部替换的代码中，使用的`/`分隔符是否适用于Windows存疑

## Screenshots

处理前：

> <img width="25%" alt="Snipaste_2023-05-10_17-12-49" src="https://github.com/the1812/Bilibili-Evolved/assets/64892985/348ddb12-f424-4b65-993b-e01bf641c62d">

处理后：

> <img width="25%" alt="Snipaste_2023-05-10_17-12-22" src="https://github.com/the1812/Bilibili-Evolved/assets/64892985/c25b1d0f-8313-4ef0-9d2a-56192445f02b">

## Commit Details

[build: 缩短构建组件时CLI提示长度](https://github.com/the1812/Bilibili-Evolved/commit/bd3b452631fe0e39f8d932b0fff4da63bbdfc047) 

- 之前展示的是完整路径 当路径过长时会导致提示信息过长 选取体验很差
- 做统一截取处理 只展示能够区分当前组件的部分
