### PR TITLE
修复IP属地显示在处理楼中楼回复时的问题

### DIFF
--- a/registry/lib/components/utils/comments/copy-link/index.ts
+++ b/registry/lib/components/utils/comments/copy-link/index.ts
@@ -36,7 +36,7 @@ const entry = async () => {
       })
     }
     processItems([comment, ...comment.replies])
-    comment.onRepliesUpdate = replies => processItems(replies)
+    comment.addEventListener('repliesUpdate', e => processItems(e.detail))
   }
   forEachCommentItem({
     added: addCopyLinkButton,

--- a/registry/lib/components/utils/ip-show/index.ts
+++ b/registry/lib/components/utils/ip-show/index.ts
@@ -132,10 +132,13 @@ const processItems = (items: CommentReplyItem[]) => {
       const replyTime =
         item.element.querySelector('.reply-info>.reply-time') ??
         item.element.querySelector('.sub-reply-info>.sub-reply-time')
-      const replyLocation = document.createElement('span')
-      replyLocation.style.marginLeft = '5px'
-      replyLocation.innerText = location
-      replyTime.appendChild(replyLocation)
+      if (replyTime.childElementCount === 0) {
+        // 避免在评论更新的情况下重复添加
+        const replyLocation = document.createElement('span')
+        replyLocation.style.marginLeft = '5px'
+        replyLocation.innerText = location
+        replyTime.appendChild(replyLocation)
+      }
     }
   })
 }

--- a/registry/lib/components/utils/ip-show/index.ts
+++ b/registry/lib/components/utils/ip-show/index.ts
@@ -9,7 +9,7 @@ const getIpLocation = (element: HTMLElement) => {
   return reply?.reply_control?.location ?? undefined
 }
 
-let version = -1
+let version = 2
 let bbComment: any
 
 // 带IP属地显示的评论创建
@@ -117,37 +117,33 @@ const observer = new MutationObserver(mutations => {
       bbComment = unsafeWindow.bbComment
       bbComment.prototype._createListCon = createListCon
       bbComment.prototype._createSubReplyItem = createSubReplyItem
+      version = 1
       observer.disconnect()
     }
   })
 })
 
+observer.observe(document.head, { childList: true })
+
 const processItems = (items: CommentReplyItem[]) => {
   items.forEach(item => {
     const location = getIpLocation(item.element)
     if (location !== undefined) {
-      item.element.querySelector(
-        '.reply-info>.reply-time',
-      ).innerHTML += `<span style="margin-left:5px;">${location}</span>`
+      const replyTime =
+        item.element.querySelector('.reply-info>.reply-time') ??
+        item.element.querySelector('.sub-reply-info>.sub-reply-time')
+      const replyLocation = document.createElement('span')
+      replyLocation.style.marginLeft = '5px'
+      replyLocation.innerText = location
+      replyTime.appendChild(replyLocation)
     }
   })
 }
 
-observer.observe(document.head, { childList: true })
-
 const entry = async () => {
   const { forEachCommentItem } = await import('@/components/utils/comment-apis')
   const addIpLocation = (comment: CommentItem) => {
-    if (version === -1) {
-      version = comment.timeText === undefined ? 2 : 1
-      if (version === 1) {
-        // 旧版评论区
-        observer.disconnect()
-        return
-      }
-      processItems([comment, ...comment.replies])
-    } else if (version === 2) {
-      // 新版评论区
+    if (version === 2) {
       processItems([comment, ...comment.replies])
       comment.onRepliesUpdate = replies => processItems(replies)
     }

--- a/registry/lib/components/utils/ip-show/index.ts
+++ b/registry/lib/components/utils/ip-show/index.ts
@@ -148,7 +148,7 @@ const entry = async () => {
   const addIpLocation = (comment: CommentItem) => {
     if (version === 2) {
       processItems([comment, ...comment.replies])
-      comment.onRepliesUpdate = replies => processItems(replies)
+      comment.addEventListener('repliesUpdate', replies => processItems(replies.detail))
     }
   }
   forEachCommentItem({

--- a/registry/lib/deprecated/comments-translate/index.ts
+++ b/registry/lib/deprecated/comments-translate/index.ts
@@ -23,7 +23,7 @@ const entry = async () => {
   forEachCommentItem({
     added: item => {
       const { element } = item
-      item.onRepliesUpdate = replies => replies.forEach(r => injectButton(r.element))
+      item.addEventListener('repliesUpdate', e => e.detail.forEach(r => injectButton(r.element)))
       injectButton(element)
     },
   })


### PR DESCRIPTION
刚刚发现IP属地展示在处理新版评论区的楼中楼回复时会出错（应查找`.sub-reply-info>.sub-reply-time`而不是`.reply-info>.reply-time`），已修复该问题

另外我还发现`onRepliesUpdate`只能处理旧版评论区的展开和翻页，对于新版评论区无效（依赖此功能的复制评论链接也受此影响）
可以将`/src/components/utils/comment-apis.ts`第113行开始的
```
childList(replyBox, () => {
  item.replies = parseReplies()
})
```

替换为

```
childList(replyBox, () => {
  item.replies = parseReplies()
  item.onRepliesUpdate?.(item.replies)
})
```

来对此进行修复

但这样带来了一个新问题，目前项目里使用了`onRepliesUpdate`这个功能的就只有我这个IP属地显示（`ipShow`）以及原先的复制评论链接（`copyCommentsLink`），也就是说原先使用此功能的只有复制评论链接这一个组件。现在我的IP属地显示同样需要使用这个功能，但`onRepliesUpdate`只能同时绑定一个回调函数，经测试开启复制评论链接后，IP属地显示将会无法处理新版评论区的回复更新