### PR TITLE
Fix image style of customNavbar(fix #4312)

### DIFF
--- a/registry/lib/components/style/custom-navbar/favorites/NavbarFavorites.vue
+++ b/registry/lib/components/style/custom-navbar/favorites/NavbarFavorites.vue
@@ -22,7 +22,7 @@
       <transition-group v-else name="cards" tag="div" class="cards">
         <div v-for="card of filteredCards" :key="card.id" class="favorite-card">
           <a
-            class="cover-container"
+            class="favorites-cover-container"
             target="_blank"
             :href="'https://www.bilibili.com/video/' + card.bvid"
           >
@@ -376,7 +376,7 @@ export default Vue.extend({
         &:hover .cover {
           transform: scale(1.05);
         }
-        .cover-container {
+        .favorites-cover-container {
           grid-area: cover;
           overflow: hidden;
           border-radius: 8px 0 0 8px;

--- a/registry/lib/components/style/custom-navbar/history/NavbarHistory.vue
+++ b/registry/lib/components/style/custom-navbar/history/NavbarHistory.vue
@@ -48,7 +48,7 @@
           </div>
           <transition-group name="time-group" tag="div" class="time-group-items">
             <div v-for="h of g.items" :key="h.id" class="time-group-item">
-              <a class="cover-container" target="_blank" :href="h.url">
+              <a class="history-cover-container" target="_blank" :href="h.url">
                 <DpiImage
                   class="cover"
                   :src="h.cover"
@@ -381,7 +381,7 @@ export default Vue.extend({
                 opacity: 1;
               }
             }
-            .cover-container {
+            .history-cover-container {
               $height: 55px;
               $padding: 2px;
               grid-area: cover;

--- a/registry/lib/components/style/custom-navbar/subscriptions/SubscriptionsList.vue
+++ b/registry/lib/components/style/custom-navbar/subscriptions/SubscriptionsList.vue
@@ -11,7 +11,7 @@
           :href="card.playUrl"
           target="_blank"
         >
-          <div class="cover-container">
+          <div class="subscriptions-cover-container">
             <DpiImage class="cover" :src="card.coverUrl" :size="64"></DpiImage>
           </div>
           <div class="card-info">
@@ -186,7 +186,7 @@ export default Vue.extend({
         background-color: #2d2d2d;
         color: #eee;
       }
-      .cover-container {
+      .subscriptions-cover-container {
         height: 64px;
         width: 64px;
         border-radius: $radius 0 0 $radius;

--- a/registry/lib/components/style/custom-navbar/watchlater/NavbarWatchlater.vue
+++ b/registry/lib/components/style/custom-navbar/watchlater/NavbarWatchlater.vue
@@ -24,7 +24,7 @@
     <VEmpty v-else-if="!loading && cards.length === 0"></VEmpty>
     <transition-group v-else name="cards" tag="div" class="watchlater-list-content">
       <div v-for="(card, index) of filteredCards" :key="card.aid" class="watchlater-card">
-        <a class="cover-container" target="_blank" :href="card.href">
+        <a class="watchlater-cover-container" target="_blank" :href="card.href">
           <DpiImage
             class="cover"
             :src="card.coverUrl"
@@ -285,7 +285,7 @@ export default Vue.extend({
       &:hover .cover {
         transform: scale(1.05);
       }
-      .cover-container {
+      .watchlater-cover-container {
         grid-area: cover;
         overflow: hidden;
         border-radius: 8px 0 0 8px;


### PR DESCRIPTION
原因：自定义顶栏的图片使用了 CSS 类 cover-container；该类被 B 站使用，进而影响到自定义顶栏

修复方式：更改使用的 CSS 类名

<!-- 可以参考下代码贡献指南: https://github.com/the1812/Bilibili-Evolved/blob/preview/CONTRIBUTING.md -->