### PR TITLE
Avoid adding empty strings to classList

### DIFF
--- a/src/components/video/player-adaptor/bpx.ts
+++ b/src/components/video/player-adaptor/bpx.ts
@@ -18,7 +18,7 @@ const playerModePolyfill = async () => {
     document.body.classList.remove(...enumList)
 
     // add class
-    document.body.classList.add(dataScreen !== 'normal' ? `${prefix}${dataScreen}` : '')
+    dataScreen !== 'normal' && document.body.classList.add(`${prefix}${dataScreen}`)
   })
 }
 const idPolyfill = async () => {


### PR DESCRIPTION
classList.add 的参数不能有空字符串

见：<https://developer.mozilla.org/en-US/docs/Web/API/DOMTokenList/add#exceptions>

（中文文档中没有关于异常的描述）