### PR TITLE
feat: 添加粉丝/关注列表关注时间显示

### DIFF
--- a/registry/lib/components/utils/subscribe-time-show/index.ts
+++ b/registry/lib/components/utils/subscribe-time-show/index.ts
@@ -18,9 +18,12 @@ const observeFans = (node: Element) => {
     relationList.querySelectorAll('.list-item>.content').forEach(e => {
       // 防止重复添加元素
       if (!processed.has(e)) {
-        e.innerHTML += `<div style="color: #6d757a;position: absolute;margin-top: 5px;font-size: 8px;">关注时间：${new Date(
-          subscribeTime[i] * 1000,
-        ).toLocaleString()}</div>`
+        const time = subscribeTime[i]
+        if (time !== undefined) {
+          e.innerHTML += `<div style="color: #6d757a;position: absolute;margin-top: 5px;font-size: 8px;">关注时间：${new Date(
+            time * 1000,
+          ).toLocaleString()}</div>`
+        }
         processed.add(e)
       }
       i++

--- a/registry/lib/components/utils/subscribe-time-show/index.ts
+++ b/registry/lib/components/utils/subscribe-time-show/index.ts
@@ -1,0 +1,51 @@
+import { defineComponentMetadata } from '@/components/define'
+import { childList } from '@/core/observer'
+
+let relationList: Element
+const processed = new WeakSet<Element>()
+
+const observeFans = (node: Element) => {
+  // 监听关注列表元素变化
+  childList(node, () => {
+    // 读取Vue属性里的关注列表
+    // eslint-disable-next-line no-underscore-dangle
+    const subscribeTime = (
+      relationList.parentElement.parentElement.parentElement.parentElement as any
+    ).__vue__.relationList.map(l => l.mtime)
+
+    // 为所有子元素添加关注时间显示
+    let i = 0
+    relationList.querySelectorAll('.list-item>.content').forEach(e => {
+      // 防止重复添加元素
+      if (!processed.has(e)) {
+        e.innerHTML += `<div style="color: #6d757a;position: absolute;margin-top: 5px;font-size: 8px;">关注时间：${new Date(
+          subscribeTime[i] * 1000,
+        ).toLocaleString()}</div>`
+        processed.add(e)
+      }
+      i++
+    })
+  })
+}
+const entry = async () => {
+  // 非粉丝/关注页面则不启动
+  if (!document.URL.match(/\/\/space\.bilibili\.com\/(\d+)\/fans/)) {
+    return
+  }
+  relationList = dq('.relation-list')
+  observeFans(relationList)
+}
+
+export const component = defineComponentMetadata({
+  name: 'subscribeTimeShow',
+  author: {
+    name: 'Light_Quanta',
+    link: 'https://github.com/LightQuanta',
+  },
+  displayName: '关注时间显示',
+  tags: [componentsTags.utils],
+  entry,
+  description: {
+    'zh-CN': '在粉丝/关注列表显示关注的具体时间',
+  },
+})

--- a/registry/lib/components/utils/subscribe-time-show/subscribe-time.scss
+++ b/registry/lib/components/utils/subscribe-time-show/subscribe-time.scss
@@ -1,0 +1,14 @@
+/* 上移原名称 */
+#page-follows .list-item .content .title {
+    margin-top: -9px;
+}
+
+/* 上移原简介/官方认证 */
+#page-follows .list-item .content p {
+    margin-top: -1px;
+}
+
+/* 修复关注时间元素的高度带来的布局影响 */
+.subscribe-time-fix {
+    margin-bottom: -10px;
+}


### PR DESCRIPTION
在关注/粉丝列表中显示用户/粉丝关注的具体时间

效果图
![S1NJ2QGKR7ANPV$N0C{5}VU](https://github.com/the1812/Bilibili-Evolved/assets/18213217/47ff8bb8-0964-4d1a-adf5-a1ddd1648dc0)

注：分组的关注列表里不显示关注时间并不是bug，而是分组关注里b站的api确实没有返回关注时间（
还有就是我感觉现在的关注时间显示有点丑，有没有人能想出更好看一点的样式