### PR TITLE
[组件-自定义顶栏] feat: 为导航栏使用 `nav-link` style 的弹窗增加更多的对齐样式

### DIFF
--- a/registry/lib/components/style/custom-navbar/_nav-link.scss
+++ b/registry/lib/components/style/custom-navbar/_nav-link.scss
@@ -8,7 +8,7 @@
   line-height: normal;
 
   &::before {
-    content: "";
+    content: '';
     position: absolute;
     top: calc(100% - 4px);
     left: 8px;
@@ -26,7 +26,7 @@
 
   html[data-navbar-link-popup-content-align-style='left'] &,
   &.left {
-    justify-content: left;
+    justify-content: flex-start;
   }
 
   html[data-navbar-link-popup-content-align-style='center'] &,
@@ -36,6 +36,6 @@
 
   html[data-navbar-link-popup-content-align-style='right'] &,
   &.right {
-    justify-content: right;
+    justify-content: flex-end;
   }
 }

--- a/registry/lib/components/style/custom-navbar/_nav-link.scss
+++ b/registry/lib/components/style/custom-navbar/_nav-link.scss
@@ -6,6 +6,7 @@
   border-bottom: 2px solid transparent;
   font-size: 15px;
   line-height: normal;
+
   &::before {
     content: "";
     position: absolute;
@@ -18,7 +19,23 @@
     transition: 0.16s 0.1s ease-out;
     transform: scaleX(0);
   }
+
   &:hover::before {
     transform: scaleX(1);
+  }
+
+  html[data-navbar-link-popup-content-align-style='left'] &,
+  &.left {
+    justify-content: left;
+  }
+
+  html[data-navbar-link-popup-content-align-style='center'] &,
+  &.center {
+    justify-content: center;
+  }
+
+  html[data-navbar-link-popup-content-align-style='right'] &,
+  &.right {
+    justify-content: right;
   }
 }

--- a/registry/lib/components/style/custom-navbar/entry.ts
+++ b/registry/lib/components/style/custom-navbar/entry.ts
@@ -2,6 +2,7 @@ import { ComponentEntry } from '@/components/types'
 import { addComponentListener } from '@/core/settings'
 import { isIframe, isNotHtml, matchUrlPattern, mountVueComponent } from '@/core/utils'
 import { setupNotifyStyle } from './notify-style'
+import { setupLinkPopupContentAlignStyle } from './link-popup-content-align-style'
 
 export const entry: ComponentEntry = async ({ metadata: { name } }) => {
   // const url = document.URL.replace(location.search, '')
@@ -52,4 +53,5 @@ export const entry: ComponentEntry = async ({ metadata: { name } }) => {
     addComponentListener(`${name}.${style}`, value => customNavbar.toggleStyle(value, style), true)
   })
   setupNotifyStyle()
+  setupLinkPopupContentAlignStyle()
 }

--- a/registry/lib/components/style/custom-navbar/index.ts
+++ b/registry/lib/components/style/custom-navbar/index.ts
@@ -95,7 +95,7 @@ const options = defineOptionsMetadata({
   linkPopupContentAlignStyle: {
     defaultValue: NavbarLinkPopupContentAlignStyle.Left,
     dropdownEnum: NavbarLinkPopupContentAlignStyle,
-    displayName: '仅包含链接的导航栏弹窗文字对齐样式',
+    displayName: '链接对齐样式',
   },
   searchBarWidth: {
     defaultValue: 15,

--- a/registry/lib/components/style/custom-navbar/index.ts
+++ b/registry/lib/components/style/custom-navbar/index.ts
@@ -8,6 +8,7 @@ import { urlInclude, urlExclude } from './urls'
 import { entry } from './entry'
 import { getNumberValidator } from '@/core/utils'
 import { NavbarNotifyStyle } from './notify-style'
+import { NavbarLinkPopupContentAlignStyle } from './link-popup-content-align-style'
 
 const styleID = 'custom-navbar-style'
 const options = defineOptionsMetadata({
@@ -90,6 +91,11 @@ const options = defineOptionsMetadata({
     defaultValue: NavbarNotifyStyle.Number,
     dropdownEnum: NavbarNotifyStyle,
     displayName: '消息提醒样式',
+  },
+  linkPopupContentAlignStyle: {
+    defaultValue: NavbarLinkPopupContentAlignStyle.Left,
+    dropdownEnum: NavbarLinkPopupContentAlignStyle,
+    displayName: '仅包含链接的导航栏弹窗文字对齐样式',
   },
   searchBarWidth: {
     defaultValue: 15,

--- a/registry/lib/components/style/custom-navbar/link-popup-content-align-style.ts
+++ b/registry/lib/components/style/custom-navbar/link-popup-content-align-style.ts
@@ -1,0 +1,25 @@
+import { addComponentListener } from '@/core/settings'
+
+export enum NavbarLinkPopupContentAlignStyle {
+  Left = '左侧对齐',
+  Center = '居中对齐',
+  Right = '右侧对齐',
+}
+
+export const setupLinkPopupContentAlignStyle = () => {
+  const map = {
+    [NavbarLinkPopupContentAlignStyle.Left]: 'left',
+    [NavbarLinkPopupContentAlignStyle.Center]: 'center',
+    [NavbarLinkPopupContentAlignStyle.Right]: 'right',
+  }
+  addComponentListener(
+    'customNavbar.linkPopupContentAlignStyle',
+    (value: NavbarLinkPopupContentAlignStyle) => {
+      document.documentElement.setAttribute(
+        'data-navbar-link-popup-content-align-style',
+        map[value],
+      )
+    },
+    true,
+  )
+}


### PR DESCRIPTION
Complete #4255

为导航栏使用 `nav-link` style 的弹窗增加更多的对齐样式

另外想问一下，这个设置描述应该写什么最为恰当，现在的总感觉有些词不达意 🤔

设置入口：
![图片](https://github.com/the1812/Bilibili-Evolved/assets/81268244/fcab4bae-fa0e-456f-9332-a6f69a76e69e)

左侧对齐：
![图片](https://github.com/the1812/Bilibili-Evolved/assets/81268244/400dac02-a734-4409-88ff-c2555811448e)

居中对齐：
![图片](https://github.com/the1812/Bilibili-Evolved/assets/81268244/661b2bbc-6cf9-4416-a5ac-02c5f2b7adfe)

右侧对齐：
![图片](https://github.com/the1812/Bilibili-Evolved/assets/81268244/550fe10e-47dc-4957-976e-6f221c354004)

_额外提一嘴，这次细细倒腾了一下，感觉之前开发版本 (Local) 没法用的问题，可能是由于长时间连接不上 raw.githubusercontent.com 导致无法加载 lodash.min.js 引起的，或许未来可以在 [CONTRIBUTING.md](https://github.com/the1812/Bilibili-Evolved/blob/master/CONTRIBUTING.md) 加一条关于它的提醒，以方便排查问题_