### PR TITLE
修复页面加载后立即查询 .s-space 可能查询失败的问题

### DIFF
--- a/registry/lib/components/utils/album-time-show/index.ts
+++ b/registry/lib/components/utils/album-time-show/index.ts
@@ -36,9 +36,7 @@ const observeAlbum = async (node: Element) => {
   addImportantStyle(style, 'album-pub-time-style')
 }
 const entry = async () => {
-  albumList = dq('.album-list__content')
-
-  const spaceContainer = dq('.s-space')
+  const spaceContainer = await select('.s-space')
   childList(spaceContainer, async () => {
     if (!document.URL.match(/^https:\/\/space\.bilibili\.com\/\d+\/album/)) {
       return

--- a/registry/lib/components/utils/subscribe-time-show/index.ts
+++ b/registry/lib/components/utils/subscribe-time-show/index.ts
@@ -1,5 +1,6 @@
 import { defineComponentMetadata } from '@/components/define'
 import { childList } from '@/core/observer'
+import { select } from '@/core/spin-query'
 
 let relationList: Element
 let oldObserver: MutationObserver
@@ -39,14 +40,12 @@ const observeFans = async (node: Element) => {
   addImportantStyle(style, 'subscribe-time-style')
 }
 const entry = async () => {
-  relationList = dq('.relation-list')
-
-  const spaceContainer = dq('.s-space')
-  childList(spaceContainer, () => {
+  const spaceContainer = await select('.s-space')
+  childList(spaceContainer, async () => {
     if (!document.URL.match(/^https:\/\/space\.bilibili\.com\/\d+\/fans/)) {
       return
     }
-    relationList = dq('.relation-list')
+    relationList = await select('.relation-list')
     observeFans(relationList)
   })
 }


### PR DESCRIPTION
组件运行后立即查询 `.s-space` 可能会在元素加载完成之前就查询，导致组件查询不到元素报错

参照 https://github.com/the1812/Bilibili-Evolved/pull/4352 底下的评论

还得是await select