### PR TITLE
[组件-返回原版直播间] feat: 增加默认返回原版直播间功能

### DIFF
--- a/registry/lib/components/live/original/Widget.vue
+++ b/registry/lib/components/live/original/Widget.vue
@@ -5,20 +5,15 @@
 </template>
 <script lang="ts">
 import { DefaultWidget } from '@/ui'
+import { getOriginalLiveroomUrl } from './get-original-liveroom-url'
 
 export default Vue.extend({
   components: {
     DefaultWidget,
   },
   data() {
-    const match = document.URL.match(/^https:\/\/live\.bilibili\.com\/([\d]+)/)
-    if (!match) {
-      return {
-        href: document.URL,
-      }
-    }
     return {
-      href: `https://live.bilibili.com/blanc/${match[1]}`,
+      href: getOriginalLiveroomUrl(document.URL),
     }
   },
 })

--- a/registry/lib/components/live/original/get-original-liveroom-url.ts
+++ b/registry/lib/components/live/original/get-original-liveroom-url.ts
@@ -1,0 +1,8 @@
+/**
+ * 如果成功从参数 url 中捕获到直播间号，那么返回原版直播间页面链接，否则返回参数 url
+ * @param url 直播间页面链接
+ */
+export const getOriginalLiveroomUrl = (url: string): string => {
+  const match = url.match(/^https:\/\/live\.bilibili\.com\/([\d]+)/)
+  return match ? `https://live.bilibili.com/blanc/${match[1]}` : url
+}

--- a/registry/lib/components/live/original/index.ts
+++ b/registry/lib/components/live/original/index.ts
@@ -1,5 +1,6 @@
 import { defineComponentMetadata } from '@/components/define'
-import { matchUrlPattern } from '@/core/utils'
+import { isIframe, isNotHtml, matchUrlPattern } from '@/core/utils'
+import { getOriginalLiveroomUrl } from './get-original-liveroom-url'
 
 export const component = defineComponentMetadata({
   name: 'originalLiveroom',
@@ -7,7 +8,20 @@ export const component = defineComponentMetadata({
   description:
     '在直播间中提供返回原版直播间的按钮, 原版直播间将无视活动皮肤, 强制使用标准的直播页面.',
   tags: [componentsTags.live],
-  entry: none,
+  entry: ({ settings }) => {
+    if (isNotHtml() || isIframe()) {
+      return
+    }
+    if (settings.options.defaultBack) {
+      window.location.assign(getOriginalLiveroomUrl(document.URL))
+    }
+  },
+  options: {
+    defaultBack: {
+      displayName: '默认返回原版直播间',
+      defaultValue: false,
+    },
+  },
   urlInclude: [
     // 不能直接用 liveUrls, 那个是带 blanc 检测的
     /^https:\/\/live\.bilibili\.com\/[\d]+/,


### PR DESCRIPTION
complete #4399

功能默认关闭。在组件设置中开启后，当直播间页面不是原版（blanc）时，会自动跳转至原版直播间。