### PR TITLE
[组件-极简首页] fix: 修复 `ScrollTrigger` 在特定情况下无法触发加载的问题

### DIFF
--- a/registry/lib/components/style/home-redesign/minimal/tabs/Feeds.vue
+++ b/registry/lib/components/style/home-redesign/minimal/tabs/Feeds.vue
@@ -4,7 +4,7 @@
       <VideoCard v-for="c of cards" :key="c.id" :data="c" />
     </div>
     <VEmpty v-if="!loading && cards.length === 0" />
-    <ScrollTrigger v-if="!error" @trigger="loadCards" />
+    <ScrollTrigger v-if="!error" ref="scrollTrigger" detect-viewport @trigger="loadCards" />
     <MinimalHomeOperations v-if="cards.length > 0" @refresh="refresh" />
   </div>
 </template>
@@ -43,6 +43,7 @@ export default Vue.extend({
       try {
         this.error = false
         this.loading = true
+        this.$refs.scrollTrigger.setLoadState('loading')
         this.cards = lodash.uniqBy(
           [...this.cards, ...(await getVideoFeeds('video', this.lastID))],
           it => it.id,
@@ -50,12 +51,17 @@ export default Vue.extend({
       } catch (error) {
         logError(error)
         this.error = true
+        this.$refs.scrollTrigger.setLoadState('error')
       } finally {
         this.loading = false
+        if (this.loaded) {
+          this.$refs.scrollTrigger.setLoadState('loaded')
+        }
       }
     },
     async refresh() {
       this.cards = []
+      this.$refs.scrollTrigger.resetIsFirstLoad()
     },
   },
 })

--- a/src/ui/ScrollTrigger.vue
+++ b/src/ui/ScrollTrigger.vue
@@ -7,23 +7,89 @@
 </template>
 <script lang="ts">
 import { useScopedConsole } from '@/core/utils/log'
+import { delay } from '@/core/utils/'
 
 export default Vue.extend({
   components: {
     VLoading: () => import('./VLoading.vue').then(m => m.default),
   },
+  props: {
+    detectViewport: {
+      type: Boolean,
+      required: false,
+      default: false,
+    },
+  },
+  data() {
+    return {
+      isFirstLoad: true,
+      isViewportTriggerRunning: false,
+      parentLoadState: 'none',
+    }
+  },
   async mounted() {
     const console = useScopedConsole('ScrollTrigger')
     const element = this.$el as HTMLElement
     const { visible } = await import('@/core/observer')
-    visible(element, records => {
+    visible(element, async records => {
       if (records.some(r => r.intersectionRatio > 0)) {
         console.log('Intersection Observer trigger')
         this.trigger()
+
+        if (!this.detectViewport && !this.isFirstLoad && this.isViewportTriggerRunning) {
+          return
+        }
+
+        this.isViewportTriggerRunning = true
+        while (this.getVisibleStateByViewport(element)) {
+          await delay(500)
+
+          // 需要父组件配合 setLoadState，不然会一直 continue
+          // 确认父组件加载状态，等待加载完成后再继续执行，否则会出现多次加载的情况
+          if (this.parentLoadState !== 'loaded') {
+            continue
+          }
+
+          // 再次确认元素可视情况，避免当元素已不可视时仍然触发加载
+          if (!this.getVisibleStateByViewport(element)) {
+            break
+          }
+
+          console.log('is first load & viewport trigger')
+          this.trigger()
+        }
+        this.isFirstLoad = false
       }
     })
   },
   methods: {
+    /**
+     * 当元素顶部位于视口内部时返回为正数，位于视口外部时返回为负数，正好位于视口底部时返回为零。
+     * @param element HTML 元素
+     * @returns 元素顶部到视口底部的距离
+     */
+    getElementToViewportBottomDistance(element: HTMLElement): number {
+      return document.documentElement.clientHeight - element.getBoundingClientRect().top
+    },
+
+    /**
+     * 当元素顶部在视口内部时返回 true。
+     * 为避免极端情况，当元素顶部到视口底部的距离大于 -20 时同样返回 true。
+     * @param element HTML 元素
+     * @returns 元素可视情况
+     */
+    getVisibleStateByViewport(element: HTMLElement): boolean {
+      return Boolean(this.getElementToViewportBottomDistance(element) > -20)
+    },
+
+    setLoadState(loadState: 'loading' | 'error' | 'loaded') {
+      this.parentLoadState = loadState
+    },
+
+    resetIsFirstLoad() {
+      this.isFirstLoad = true
+    },
+
     trigger() {
       this.$emit('trigger')
     },


### PR DESCRIPTION
fix #4302

如题，当 `ScrollTrigger` 初次触发加载且父级组件完成加载后，如果因为高分屏、低缩放比例等原因，使 `ScrollTrigger` 仍在视口内部的话，将会导致 `IntersectionObserver` 无法继续触发，接着导致组件无法自动触发加载，最后导致受影响用户遇到父级组件不会自动继续加载的问题。

无法继续触发 `IntersectionObserver` 的原因是，此时页面滚动不了，`ScrollTrigger` 无法离开和进入视口。

这个 PR 通过为 `ScrollTrigger` 增加可视判断逻辑来修复上述问题，同时可以解决 #4302 报告的情况。

由于问题描述有点区别，可能没有解决[这条回复](https://github.com/the1812/Bilibili-Evolved/issues/4302#issuecomment-1712458025)和 #4428 遇到的问题，需要后续反馈才能确认具体情况。

另外，为了避免可视判断逻辑造成的重复加载情况，这个修复方法还需要修改用到 `ScrollTrigger` 并且需要它的可视判断逻辑的组件代码，使其能够向 `ScrollTrigger` 传递加载状态。

考虑到一次性全改了可能会出现奇奇怪怪的问题，所以这个 PR 只调整了有问题报告的极简首页组件，可以先看看效果。