### PR TITLE
[组件-动态过滤器] 修复图文动态关键词过滤失效的问题

### DIFF
--- a/registry/lib/components/feeds/filter/pattern.ts
+++ b/registry/lib/components/feeds/filter/pattern.ts
@@ -1,3 +1,5 @@
+import { FeedsCardType, feedsCardTypes } from '@/components/feeds/api'
+
 const testPattern = (pattern: string, text: string) => {
   if (!pattern || !text) {
     return false
@@ -11,11 +13,17 @@ export interface BlockableCard {
   text: string
   username: string
   // [key: string]: string
+  type: FeedsCardType
+  element: HTMLElement
 }
 export const hasBlockedPattern = (pattern: string, card: BlockableCard) => {
   const upNameMatch = pattern.match(/(.+) up:([^ ]+)/)
   if (upNameMatch) {
     return testPattern(upNameMatch[1], card.text) && testPattern(upNameMatch[2], card.username)
+  }
+  // FIXME: 图文动态的 text 为空，应该是 card 相关的 API 有 bug。这里只做简单的判断
+  if (card.type === feedsCardTypes.textWithImages) {
+    card.text = card.element.innerText
   }
   return testPattern(pattern, card.text)
 }

--- a/registry/lib/components/feeds/filter/plugin.ts
+++ b/registry/lib/components/feeds/filter/plugin.ts
@@ -49,7 +49,9 @@ export const feedsFilterPlugin: PluginMetadata = {
                 return [key, item[value].trim() as string]
               }),
             ) as Record<keyof BlockableCard, string>
-            return patterns.every(p => !hasBlockedPattern(p, card as BlockableCard))
+            return patterns.every(
+              p => !hasBlockedPattern(p, { ...card, type: item.type, element: item.element }),
+            )
           })
         },
       })


### PR DESCRIPTION
简单的修复了 https://github.com/the1812/Bilibili-Evolved/issues/4409 的图文动态关键字过滤失效的问题

似乎是 [API](https://github.com/the1812/Bilibili-Evolved/blob/602a80dd007340cbb61328442dd5cf2098f49cb7/src/components/feeds/api/manager/v2.ts#L32) 没能正确的获取 text 内容，我只简单的加了条件判断