### PR TITLE
feat: 允许配置视频下载文件拓展名

### DIFF
--- a/registry/lib/components/video/download/apis/dash.ts
+++ b/registry/lib/components/video/download/apis/dash.ts
@@ -11,9 +11,11 @@ import {
   DownloadVideoInputItem,
 } from '../types'
 import { bangumiApi, videoApi } from './url'
+import { Options } from '..'
+import { getComponentSettings } from '@/core/settings'
 
 /** dash 格式更明确的扩展名 */
-export const DashExtensions = {
+export const DefaultDashExtensions = {
   video: '.mp4',
   audio: '.m4a',
   flacAudio: '.flac',
@@ -27,7 +29,7 @@ export enum DashCodec {
   Av1 = 'AV1',
 }
 export interface Dash {
-  type: keyof typeof DashExtensions
+  type: keyof typeof DefaultDashExtensions
   bandWidth: number
   codecs: string
   codecId: number
@@ -50,12 +52,25 @@ export interface DashFilters {
   video?: (dash: VideoDash) => boolean
   audio?: (dash: AudioDash) => boolean
 }
+const getDashExtensions = (type: keyof typeof DefaultDashExtensions): string => {
+  const { options } = getComponentSettings<Options>('downloadVideo')
+  if (type === 'video') {
+    return options.dashVideoExtension
+  }
+  if (type === 'audio') {
+    return options.dashAudioExtension
+  }
+  if (type === 'flacAudio') {
+    return options.dashFlacAudioExtension
+  }
+  return DefaultDashExtensions[type] ?? DashFragmentExtension
+}
 const dashToFragment = (dash: Dash): DownloadVideoFragment => ({
   url: dash.downloadUrl,
   backupUrls: dash.backupUrls,
   length: dash.duration,
   size: Math.trunc((dash.bandWidth * dash.duration) / 8),
-  extension: DashExtensions[dash.type] ?? DashFragmentExtension,
+  extension: getDashExtensions(dash.type),
 })
 export const dashToFragments = (info: {
   videoDashes: VideoDash[]

--- a/registry/lib/components/video/download/index.ts
+++ b/registry/lib/components/video/download/index.ts
@@ -1,6 +1,31 @@
-import { defineComponentMetadata } from '@/components/define'
+import {
+  OptionsOfMetadata,
+  defineComponentMetadata,
+  defineOptionsMetadata,
+} from '@/components/define'
 import { hasVideo } from '@/core/spin-query'
+import { DefaultDashExtensions } from './apis/dash'
 
+const options = defineOptionsMetadata({
+  basicConfig: {
+    defaultValue: {},
+    displayName: '基础配置',
+    hidden: true,
+  },
+  dashVideoExtension: {
+    defaultValue: DefaultDashExtensions.video,
+    displayName: 'DASH 视频扩展名',
+  },
+  dashAudioExtension: {
+    defaultValue: DefaultDashExtensions.audio,
+    displayName: 'DASH 普通音频扩展名',
+  },
+  dashFlacAudioExtension: {
+    defaultValue: DefaultDashExtensions.flacAudio,
+    displayName: 'DASH FLAC 音频扩展名',
+  },
+})
+export type Options = OptionsOfMetadata<typeof options>
 export const component = defineComponentMetadata({
   name: 'downloadVideo',
   displayName: '下载视频',
@@ -12,12 +37,6 @@ export const component = defineComponentMetadata({
     condition: () => hasVideo(),
   },
   tags: [componentsTags.video],
-  options: {
-    basicConfig: {
-      defaultValue: {},
-      displayName: '基础配置',
-      hidden: true,
-    },
-  },
+  options,
   // plugin,
 })


### PR DESCRIPTION
<!-- 可以参考下代码贡献指南: https://github.com/the1812/Bilibili-Evolved/blob/preview/CONTRIBUTING.md -->

允许配置 DASH 下载的文件拓展名。

![设置的屏幕截图](https://vip2.loli.io/2023/09/22/57oSECeqvs8y1za.png)

![效果演示](https://vip2.loli.io/2023/09/22/6QWxDvdthaXCKer.png)

主要的目的是如果用户希望下载后使用 ffmpeg 合并下载后的视频和音频并生成 MP4 封装文件时，可以将视频下载为 `.m4v` 文件，从而避免文件命名的拓展名冲突。

现在下载后的文件：

```
DemoFoobar_哔哩哔哩bilibili_APEX英雄.m4a
DemoFoobar_哔哩哔哩bilibili_APEX英雄.mp4
```

用户需要使用命令

```
ffmpeg -i DemoFoobar_哔哩哔哩bilibili_APEX英雄.m4a \
       -i DemoFoobar_哔哩哔哩bilibili_APEX英雄.mp4 \
       -codec copy \
       DemoFoobar_哔哩哔哩bilibili_APEX英雄.full.mp4
rm -rf DemoFoobar_哔哩哔哩bilibili_APEX英雄.m4a
rm -rf DemoFoobar_哔哩哔哩bilibili_APEX英雄.mp4
mv DemoFoobar_哔哩哔哩bilibili_APEX英雄.full.mp4 DemoFoobar_哔哩哔哩bilibili_APEX英雄.mp4
```

如果允许用户自定义拓展名，则用户可以设置视频文件下载拓展名为 `.m4v`，将文件下载为

```
DemoFoobar_哔哩哔哩bilibili_APEX英雄.m4a
DemoFoobar_哔哩哔哩bilibili_APEX英雄.m4v
```

这样合并文件后只需要删除 `.m4a` 和 `.m4v` 即可，生成的 `.mp4` 文件的文件名则可以和原来的 `.m4v`/`.m4a` 文件保持一致。