### PR TITLE
fix: 修复被转发图文动态的 `详情 >` 功能失效

### DIFF
--- a/registry/lib/components/feeds/disable-details/index.ts
+++ b/registry/lib/components/feeds/disable-details/index.ts
@@ -69,7 +69,10 @@ const entry = async () => {
       return
     }
     if (postContent.classList.contains('repost') || card.type === feedsCardTypes.repost) {
-      const contents = dq(postContent, '.content, .bili-dyn-content__orig__desc') as HTMLElement
+      const contents = dq(
+        postContent,
+        '.content, .bili-dyn-content__orig__desc, .dyn-card-opus__summary',
+      ) as HTMLElement
       if (!contents) {
         return
       }


### PR DESCRIPTION
图文动态找不到 `.bili-dyn-content__orig__desc`
新增 `.dyn-card-opus__summary` 即可修复

目前图文动态内容部分的完整选择器
```javascript
document.querySelector(
  `.bili-dyn-item__main > .bili-dyn-item__body >
  .bili-dyn-content > .bili-dyn-content__orig.reference > .bili-dyn-content__orig__major >
  .dyn-card-opus > .dyn-card-opus__summary`
)
```