### PR TITLE
在下载视频插件的选择器中引入了虚拟列表来改善列表太长时操作卡顿的问题

### DIFF
--- a/registry/lib/components/video/download/inputs/EpisodesPicker.vue
+++ b/registry/lib/components/video/download/inputs/EpisodesPicker.vue
@@ -32,13 +32,15 @@
         </VButton>
       </div>
     </div>
-    <VirtualList class="episodes-picker-items" 
+    <VirtualList
+      class="episodes-picker-items"
       :items="episodeItems"
       :item-height="24"
       :stage-item-count="100"
       :buffer-item-count="40"
       :update-required-item-count="20"
-      :focuse-item-index="currentEpisodeIndex">
+      :focuse-item-index="currentEpisodeIndex"
+    >
       <template #item="{ item, index }">
         <div class="episodes-picker-item">
           <CheckBox
@@ -71,7 +73,7 @@ export default Vue.extend({
     VButton,
     VIcon,
     CheckBox,
-    VirtualList
+    VirtualList,
   },
   props: {
     api: {
@@ -84,7 +86,7 @@ export default Vue.extend({
       episodeItems: [],
       maxCheckedItems: 32,
       lastCheckedEpisodeIndex: -1,
-      currentEpisodeIndex: 0 // 当前页面的剧集 index
+      currentEpisodeIndex: 0, // 当前页面的剧集 index
     }
   },
   computed: {
@@ -102,9 +104,9 @@ export default Vue.extend({
   },
   async created() {
     await this.getEpisodeItems()
-    const aid = unsafeWindow.aid
+    const { aid } = unsafeWindow
     if (aid) {
-      this.currentEpisodeIndex = this.episodeItems.findIndex(ep => ep.inputItem.aid == aid) ?? 0
+      this.currentEpisodeIndex = this.episodeItems.findIndex(ep => ep.inputItem.aid === +aid) ?? 0
       this.episodeItems[this.currentEpisodeIndex].isChecked = true
     }
     // console.log('dididi', this.episodeItems)

--- a/registry/lib/components/video/download/inputs/VirtualList.vue
+++ b/registry/lib/components/video/download/inputs/VirtualList.vue
@@ -1,0 +1,152 @@
+<script setup lang="ts">
+import { ref, computed, watch, onMounted } from 'vue'
+
+type PropsType = {
+  items: any[]
+  itemHeight: number
+  stageItemCount?: number // 容器容纳的列表项数量
+  bufferItemCount?: number // 边缘预留缓冲的列表项数量
+  updateRequiredItemCount?: number // 缓冲列表项低于此数时触发更新
+  focuseItemIndex?: number // 初始聚焦的列表项
+}
+
+const props = withDefaults(defineProps<PropsType>(), {
+  stageItemCount: 50,
+  bufferItemCount: 5,
+  updateRequiredItemCount: 5,
+  focuseItemIndex: 0
+})
+
+const container = ref<HTMLDivElement>()
+const stageHeight = computed(() => props.stageItemCount * props.itemHeight)
+const clientHeight = computed(() => container.value?.clientHeight ?? 0)
+const scrollHeight = computed(() => container.value?.scrollHeight ?? 0)
+
+const ptr = ref(0)
+const appendPaddingTop = computed(() => ptr.value * props.itemHeight)
+const appendPaddingBottom = computed(() => (props.items.length - ptr.value - props.stageItemCount) * props.itemHeight)
+const activatedItems = computed(() => props.items.slice(ptr.value, ptr.value + props.stageItemCount))
+
+const forceScrolling = ref(false)
+const lastScrollTop = ref(0)
+
+onMounted(() => {
+  setTimeout(() => focus(props.focuseItemIndex))
+})
+
+watch(
+  () => props.focuseItemIndex,
+  (newv, oldv) => {
+    focus(newv)
+  }
+)
+
+/**
+ * 将 viewport 对齐到指定元素
+ * @param index 
+ * @param alignment 决定用顶部还是底部对齐
+ */
+const focus = (index: number, alignment: 'top' | 'bottom' = 'top') => {
+  if (alignment === 'top') {
+    const offset = index - moveStage(index - props.bufferItemCount)
+    moveViewport(offset * props.itemHeight)
+  } else if (alignment === 'bottom') {
+    const offset = index - moveStage(index + props.bufferItemCount - props.stageItemCount)
+    moveViewport(offset * props.itemHeight)
+  }
+}
+
+/**
+ * 在 stage 之内移动 viewport，不引起数据变化
+ * @param top float
+ */
+const moveViewport = (top: number) => {
+  if (top < 0) {
+    top = 0
+  } else if (top > (stageHeight.value - clientHeight.value)) {
+    top = stageHeight.value - clientHeight.value
+  }
+  // 滚动列表
+  forceScrolling.value = true
+  container.value?.scrollTo({
+    top: appendPaddingTop.value + top,
+    behavior: 'instant'
+  })
+
+  return top
+}
+
+/**
+ * 在虚拟列表之内移动 stage，引起数据变化
+ * @param index int
+ */
+const moveStage = (index: number) => {
+  if (index < 0) {
+    index = 0
+  } else if (index > props.items.length - props.stageItemCount) {
+    index = props.items.length - props.stageItemCount
+  }
+  // 触发内容变化并推动列表
+  return ptr.value = index
+}
+
+const onScroll = lodash.throttle((event: Event) => {
+  if (forceScrolling.value) {
+    // 手动触发滚动时不做处理
+    forceScrolling.value = false
+    return
+  }
+
+  const tar = event.currentTarget as HTMLDivElement
+  const step = tar.scrollTop - lastScrollTop.value
+  // console.log(tar.scrollHeight, tar.scrollTop, step)
+  lastScrollTop.value = tar.scrollTop
+  if (step > 0) {
+    // 向下滚动
+    const actualBottomHeight = tar.scrollTop + tar.clientHeight,
+      contentBottomHeight = appendPaddingTop.value + stageHeight.value
+    const buffer = contentBottomHeight - actualBottomHeight,
+      min = props.itemHeight * props.updateRequiredItemCount
+    if (buffer < min) {
+      const offset = props.bufferItemCount - Math.round(buffer / props.itemHeight)
+      moveStage(ptr.value + offset)
+    }
+  } else if (step < 0) {
+    // 向上滚动
+    const actualTopHeight = tar.scrollHeight - tar.scrollTop,
+      contentTopHeight = tar.scrollHeight - appendPaddingTop.value
+    const buffer = contentTopHeight - actualTopHeight,
+      min = props.itemHeight * props.updateRequiredItemCount
+    if (buffer < min) {
+      const offset = props.bufferItemCount - Math.round(buffer / props.itemHeight)
+      moveStage(ptr.value - offset)
+    }
+  }
+}, 33)
+
+</script>
+
+<template>
+  <div class="virtual-list" ref="container" @scroll.self="onScroll">
+    <ul class="scroll-box">
+      <li class="list-item" v-for="(item, index) in activatedItems" :key="index">
+        <slot name="item" :item="item" :index="index"></slot>
+      </li>
+    </ul>
+  </div>
+</template>
+
+<style scoped>
+.virtual-list {
+  overflow-x: hidden;
+  overflow-y: auto;
+
+  >.scroll-box {
+    list-style: none;
+    padding-top: v-bind('`${appendPaddingTop}px`');
+    padding-bottom: v-bind('`${appendPaddingBottom}px`');
+
+    >.list-item {}
+  }
+}
+</style>

--- a/registry/lib/components/video/download/inputs/bangumi/batch.ts
+++ b/registry/lib/components/video/download/inputs/bangumi/batch.ts
@@ -45,7 +45,7 @@ export const bangumiBatchInput: DownloadVideoInput = {
           return {
             key: it.cid,
             title: `${nText} - ${title}`,
-            isChecked: index < instance.maxCheckedItems,
+            isChecked: index < instance.maxCheckedItems && totalLength <= instance.maxCheckedItems,
             inputItem: {
               aid: it.aid,
               cid: it.cid,


### PR DESCRIPTION
### features
- 新增 VirtualList.vue，将原来 v-for 渲染的列表项放到 VirtualList 下渲染
- 虚拟列表需要每一项高度一致，所以为 .episode-title 设置了最大宽度 250px，超出时显示省略号
- 列表加载时通过全局 aid 找到当前页面的剧集项，列表将自动聚焦到当前剧集项并自动选中
- 修改了原有的自动选中逻辑，剧集数超过 maxCheckedItems = 32 时，将不再自动选择前 32 项

### 原来的选择器演示，有 1000 个列表项时操作有明显的迟滞感，连续选择多个选项时十分难受
https://github.com/the1812/Bilibili-Evolved/assets/24503369/c64235b7-b4fa-4607-88cc-5cfd1db0a5d8

### 使用虚拟列表后
https://github.com/the1812/Bilibili-Evolved/assets/24503369/ce87d656-302b-41dd-aadf-6da6da4f4b75

### 存在的问题
- 滚动太快时出现空白区域，用鼠标快速移动滚动条时容易遇到
- 滚动会使每一个元素显示的数据变化，选中状态变化时对应的选择框会有闪烁现象