### PR TITLE
[组件-禁止跳转动态详情] fix: 修复带图转发动态的 `查看图片` 失效

### DIFF
--- a/registry/lib/components/feeds/disable-details/index.ts
+++ b/registry/lib/components/feeds/disable-details/index.ts
@@ -32,6 +32,9 @@ const entry = async () => {
         if (target.hasAttribute('click-title')) {
           return
         }
+        if (target.hasAttribute('data-pics')) {
+          return
+        }
         if (
           [
             'bili-rich-text__action',


### PR DESCRIPTION
例如 https://t.bilibili.com/904142297159958549