### PR TITLE
[组件-网址参数清理] 修复重新打开关闭的搜索页时跳转至 https://search.bilibili.com/undefined

### DIFF
--- a/registry/lib/components/utils/url-params-clean/index.ts
+++ b/registry/lib/components/utils/url-params-clean/index.ts
@@ -141,6 +141,9 @@ const entry = async () => {
       url: string,
       ...restArgs: unknown[]
     ) {
+      if (url === undefined || url === null) {
+        return original.call(this, data, unused, url, ...restArgs)
+      }
       const resolvedUrl = (() => {
         try {
           return new URL(url, location.origin + location.pathname).toString()


### PR DESCRIPTION
https://github.com/the1812/Bilibili-Evolved/issues/4656
