### PR TITLE
fix: 为视频播放页的两个 popover 适配深色模式

### DIFF
--- a/registry/lib/components/style/dark-mode/dark-slice-13.scss
+++ b/registry/lib/components/style/dark-mode/dark-slice-13.scss
@@ -681,7 +681,8 @@ html {
     @include background-color('3');
   }
   .note-container {
-    border: none;
+    overflow: hidden; // B 站写的 .note-detail 容器溢出了
+    @include border-color();
     @include background-color('3'); // 修复上述圆角对齐问题
     .note-header {
       @include background-color('3');
@@ -711,7 +712,6 @@ html {
         }
       }
       .note-detail {
-        border-radius: 10px; // B 站写的容器溢出了
         @include background-color('3');
         @include color('e');
         .up-desc-container .desc-top .up-name {

--- a/registry/lib/components/style/dark-mode/dark-slice-13.scss
+++ b/registry/lib/components/style/dark-mode/dark-slice-13.scss
@@ -676,6 +676,76 @@ html {
       }
     }
   }
+  // B 站的父容器和 note-container 圆角没对齐，会漏一点白色出来
+  &.note-pc {
+    @include background-color('3');
+  }
+  .note-container {
+    border: none;
+    @include background-color('3'); // 修复上述圆角对齐问题
+    .note-header {
+      @include background-color('3');
+      .note-title,
+      .back-note-list,
+      .jump-note-package,
+      .close-note {
+        @include color('e');
+        @include background-color('3');
+        svg {
+          @include to-white();
+        }
+        &:active {
+          @include background-color('2');
+        }
+      }
+      .note-operation {
+        @include background-color('4');
+      }
+    }
+    .note-content {
+      @include background-color('3');
+      .note-card-container .note-card {
+        @include background-color('2');
+        .note-content {
+          @include background-color('2');
+          @include color('e');
+        }
+      }
+      .note-detail {
+        @include background-color('3');
+        @include color('e');
+        .up-desc-container .desc-top .up-name {
+          @include to-white();
+        }
+        .preview-editor {
+          @include color('e');
+        }
+        .note-operation .sanlian-box {
+          @include background-color('4');
+          @include border-color('3');
+        }
+      }
+      .note-editor {
+        .ql-editor,
+        .ql-toolbar,
+        .ql-picker-options,
+        .ql-picker-label {
+          @include background-color('2');
+          @include color('e');
+        }
+        // 对于编辑器的格式按钮，未选中时设为白色。选中后是蓝色，不需要修改
+        .ql-bar:not(.ql-active) {
+          i,
+          svg {
+            cursor: pointer;
+            &:not(:hover) {
+              @include to-white();
+            }
+          }
+        }
+      }
+    }
+  }
 }
 .bili-note {
   @include background-color('3');

--- a/registry/lib/components/style/dark-mode/dark-slice-13.scss
+++ b/registry/lib/components/style/dark-mode/dark-slice-13.scss
@@ -652,6 +652,30 @@ html {
       }
     }
   }
+
+  .ai-summary-popup {
+    @include border-color('3');
+    @include background-color('2');
+    .ai-summary-popup-tips-text {
+      @include color('e');
+    }
+    .ai-summary-popup-header {
+      &::after {
+        @include background-color('e');
+      }
+      .ai-summary-popup-header-clickable-area {
+        @include to-gray();
+      }
+    }
+    .ai-summary-popup-body {
+      .ai-summary-popup-body-abstracts {
+        @include color('e');
+      }
+      .ai-summary-popup-body-outline .section:hover {
+        @include background-color('3');
+      }
+    }
+  }
 }
 .bili-note {
   @include background-color('3');

--- a/registry/lib/components/style/dark-mode/dark-slice-13.scss
+++ b/registry/lib/components/style/dark-mode/dark-slice-13.scss
@@ -703,7 +703,6 @@ html {
       }
     }
     .note-content {
-      @include background-color('3');
       .note-card-container .note-card {
         @include background-color('2');
         .note-content {
@@ -712,6 +711,7 @@ html {
         }
       }
       .note-detail {
+        border-radius: 10px; // B 站写的容器溢出了
         @include background-color('3');
         @include color('e');
         .up-desc-container .desc-top .up-name {

--- a/registry/lib/components/style/dark-mode/dark-slice-13.scss
+++ b/registry/lib/components/style/dark-mode/dark-slice-13.scss
@@ -733,13 +733,20 @@ html {
           @include background-color('2');
           @include color('e');
         }
-        // 对于编辑器的格式按钮，未选中时设为白色。选中后是蓝色，不需要修改
-        .ql-bar:not(.ql-active) {
-          i,
-          svg {
-            cursor: pointer;
-            &:not(:hover) {
-              @include to-white();
+        .ql-bar {
+          &:not(.ql-active) {
+            i,
+            svg {
+              cursor: pointer;
+              &:not(:hover) {
+                @include to-white();
+              }
+            }
+          }
+          &.ql-active {
+            i,
+            svg {
+              @include theme-color();
             }
           }
         }

--- a/registry/lib/components/style/dark-mode/dark-slice-18.scss
+++ b/registry/lib/components/style/dark-mode/dark-slice-18.scss
@@ -871,7 +871,7 @@
 
 .ai-summary-van-popover {
   &.van-popover {
-    background-color: transparent !important; // 移除超出圆角的黑色背景
+    @include background-color(); // 移除超出圆角的黑色背景
   }
   .tips-panel {
     @include background-color('3');

--- a/registry/lib/components/style/dark-mode/dark-slice-18.scss
+++ b/registry/lib/components/style/dark-mode/dark-slice-18.scss
@@ -869,10 +869,15 @@
   }
 }
 
-.ai-summary-van-popover .tips-panel {
-  @include background-color('3');
-  @include color('e');
-  .tips-panel-title {
+.ai-summary-van-popover {
+  &.van-popover {
+    background-color: transparent !important; // 移除超出圆角的黑色背景
+  }
+  .tips-panel {
+    @include background-color('3');
     @include color('e');
+    .tips-panel-title {
+      @include color('e');
+    }
   }
 }

--- a/registry/lib/components/style/dark-mode/dark-slice-18.scss
+++ b/registry/lib/components/style/dark-mode/dark-slice-18.scss
@@ -708,7 +708,9 @@
   @include set-color('border-top-color', '4');
 }
 #{contains('mediainfo_mediaRight')} {
-  #{contains('mediainfo_media_desc_section')} #{contains('mediainfo_display_area')} #{contains('mediainfo_ellipsis')} {
+  #{contains('mediainfo_media_desc_section')}
+    #{contains('mediainfo_display_area')}
+    #{contains('mediainfo_ellipsis')} {
     background: linear-gradient(90deg, hsla(0, 0%, 100%, 0), #222 20%, #222);
     @include theme-color();
   }
@@ -864,5 +866,13 @@
     .media-card-content-head-desc {
       @include color('8');
     }
+  }
+}
+
+.ai-summary-van-popover .tips-panel {
+  @include background-color('3');
+  @include color('e');
+  .tips-panel-title {
+    @include color('e');
   }
 }

--- a/registry/lib/components/style/dark-mode/dark-slice-9.scss
+++ b/registry/lib/components/style/dark-mode/dark-slice-9.scss
@@ -993,6 +993,7 @@ $highlight-map: (
 .hover-panel-wrapper,
 .van-popper-login .btn-box .btn,
 .van-popper-history .view-all,
+.van-popper .tips-panel,
 .at-popup,
 .chat-popups-section .draw-full-ctnr,
 #gift-package-item-box .panel-wrapper::before,


### PR DESCRIPTION
此 PR 为视频播放页的两个 popover 适配了深色模式：

- AI 视频总结

<details>
<summary>截图</summary>
<img src="https://github.com/the1812/Bilibili-Evolved/assets/62269186/0d15faa9-ced9-4e21-ac94-ba086134d431" width="300">
</details>

- 视频笔记

<details>
<summary>截图</summary>
<p float="left">
    <img src="https://github.com/the1812/Bilibili-Evolved/assets/62269186/7e24c6d6-bb48-447c-b1c5-b9705a45df84" alt="Image 1" width="230">
    <img src="https://github.com/the1812/Bilibili-Evolved/assets/62269186/1a1a0de4-c2d3-4733-9031-3c7933de3c0d" alt="Image 2" width="230">
    <img src="https://github.com/the1812/Bilibili-Evolved/assets/62269186/55d0a5a7-b8cc-433f-8135-78ce38e461c9" width="230">
</p>
</details>

