### PR TITLE
feat: 复制动态链接改用`opus`

### DIFF
--- a/registry/lib/components/feeds/copy-link/index.ts
+++ b/registry/lib/components/feeds/copy-link/index.ts
@@ -9,7 +9,7 @@ const entry = async () => {
       className: 'copy-link',
       text: '复制链接',
       action: async () => {
-        await navigator.clipboard.writeText(`https://t.bilibili.com/${card.id}`)
+        await navigator.clipboard.writeText(`https://www.bilibili.com/opus/${card.id}`)
       },
     })
   }

--- a/src/components/feeds/api/manager/index.ts
+++ b/src/components/feeds/api/manager/index.ts
@@ -14,7 +14,8 @@ export const isV2Feeds = () => {
   return [
     't.bilibili.com',
     'space.bilibili.com',
-    /^https:\/\/www\.bilibili\.com\/opus\/[\d]+$/,
+    /^https:\/\/www\.bilibili\.com\/opus\/\d+$/,
+    /^https:\/\/www\.bilibili\.com\/v\/topic\/detail\/\?topic_id=\d+$/,
   ].some(pattern => matchUrlPattern(pattern))
 }
 export const feedsCardsManager = (() => {

--- a/src/components/feeds/api/manager/index.ts
+++ b/src/components/feeds/api/manager/index.ts
@@ -14,8 +14,7 @@ export const isV2Feeds = () => {
   return [
     't.bilibili.com',
     'space.bilibili.com',
-    /^https:\/\/www\.bilibili\.com\/opus\/\d+$/,
-    /^https:\/\/www\.bilibili\.com\/v\/topic\/detail\/\?topic_id=\d+$/,
+    /^https:\/\/www\.bilibili\.com\/opus\/[\d]+$/,
   ].some(pattern => matchUrlPattern(pattern))
 }
 export const feedsCardsManager = (() => {


### PR DESCRIPTION
若为直发图文动态，opus格式链接有收藏按钮，t没有。
若为转发类动态，会自动跳转到t。
故改用opus
![image](https://github.com/the1812/Bilibili-Evolved/assets/69918945/5713cc06-78e7-4405-969e-4987db7b7f3c)

