### PR TITLE
fix: 同时安装了pakku时下载处理后的弹幕

### DIFF
--- a/registry/lib/components/video/danmaku/converter/danmaku-segment.ts
+++ b/registry/lib/components/video/danmaku/converter/danmaku-segment.ts
@@ -286,9 +286,9 @@ const decode = lodash.curry(async (type: string, blob: Blob) => {
 export const decodeDanmakuSegment = decode('DmSegMobileReply')
 export const decodeDanmakuView = decode('DmWebViewReply')
 
-// 这里为了兼容 pakku, 只能用 fetch https://github.com/xmcp/pakku.js/issues/153
+// 同时安装了 pakku 时，unsafeWindow.fetch 将调用 hook 过的 fetch 来获取修改后的弹幕
 const fetchBlob = async (url: string) => {
-  const response = await fetch(url, { mode: 'cors', credentials: 'include' })
+  const response = await unsafeWindow.fetch(url, { mode: 'cors', credentials: 'include' })
   return response.blob()
 }
 export const getDanmakuView = async (aid: string | number, cid: string | number) => {


### PR DESCRIPTION
有用户 [向 pakku 反映](https://github.com/xmcp/pakku.js/issues/274) 开启 pakku 之后用 Bilibili-Evolved 下载的仍然是处理之前的原始弹幕，导致他还要手工处理一下，比较麻烦。

这是因为 pakku 曾经 hook 了 XMLHttpRequest，而且处理得有问题，导致 [Bilibili-Evolved 改用 fetch 来下载（未经 pakku 修改的）弹幕](https://github.com/xmcp/pakku.js/issues/153)。

刚更新的 pakku v2024.4.3 版本解决了兼容性问题，同时也 hook 了 `fetch` 函数，这样两个插件就可以共存了。可以 [安装新版 pakku 试一下效果](https://s.xmcp.ltd/pakkujs/)。

我本地测试了一下，把 Bilibili-Evolved 下载弹幕代码的  `fetch()`  改成 `unsafeWindow.fetch()` 即可下载 pakku 处理之后的弹幕（如未安装新版 pakku 时则会正常调用原始的 `fetch`）。