### PR TITLE
为传统连播模式组件添加识别和处理视频列表的播放网页的相关功能。

### DIFF
--- a/registry/lib/components/video/player/legacy-auto-play/index.ts
+++ b/registry/lib/components/video/player/legacy-auto-play/index.ts
@@ -60,7 +60,7 @@ export const component = defineComponentMetadata({
     }
 
     const checkPlayListPlayMode = async () => {
-      // 检查是不是播放列表中的最后一个分 P 的最后一个视频
+      // 检查是不是播放列表中的最后一个视频或者最后一个分 P 视频的最后一个视频
       const videoSequentialNumber = dq('.list-count')
       const sequentialNumbers = videoSequentialNumber.innerHTML.split('/')
       // 检查最后一个元素是单个视频还是多 P 视频
@@ -81,8 +81,8 @@ export const component = defineComponentMetadata({
       const shouldContinue = !(sequentialNumbers[0] >= sequentialNumbers[1] && isLastVideo)
 
       const app = document.getElementById('app')
-      // 不用判断当前状态是什么，直接将将是否需要继续播放赋值 vue 实例中的 continuousPlay
       const vueInstance = getVueData(app)
+      // 不用判断当前状态是什么，直接将将是否需要继续播放赋值 vue 实例中的 continuousPlay
       vueInstance.setContinuousPlay(shouldContinue)
     }
 
@@ -105,18 +105,18 @@ export const component = defineComponentMetadata({
       }
     }
 
-    const checkRightPanelPlyMode = async () => {
+    const checkRightPanelPlayMode = async () => {
       rightPanel.classList.contains('right-container-inner')
         ? checkPlayMode()
         : checkPlayListPlayMode()
     }
 
     videoChange(async () => {
-      checkRightPanelPlyMode()
+      checkRightPanelPlayMode()
       const video = (await playerAgent.query.video.element()) as HTMLVideoElement
-      video?.addEventListener('play', checkRightPanelPlyMode, { once: true })
+      video?.addEventListener('play', checkRightPanelPlayMode, { once: true })
     })
 
-    childListSubtree(rightPanel, () => checkRightPanelPlyMode())
+    childListSubtree(rightPanel, () => checkRightPanelPlayMode())
   },
 })


### PR DESCRIPTION
目前，传统连播模式组件仅支持带有自动连播按钮的相关网页。在特殊情况下会导致某些不存在自动连播按钮的网页的连播设置被篡改，例如，视频列表的播放网页。此 PR 修复了传统连播模式组件无法处理视频列表的播放页面的情况。主要用于增加传统连播模式组件的兼容性。
注意：如果 B 站的播放页面出现变动，则组件也需要做出相应的变动。如果出现新的播放形式的页面，也可能需要对组件进行更新。
#4699