### PR TITLE
显示视频投稿时间——修复时间显示错误及不显示时间问题

### DIFF
--- a/registry/lib/components/video/player/show-upload-time/index.ts
+++ b/registry/lib/components/video/player/show-upload-time/index.ts
@@ -1,5 +1,5 @@
 import { defineComponentMetadata } from '@/components/define'
-import { childList, urlChange } from '@/core/observer'
+import { urlChange } from '@/core/observer'
 import { playerReady, getVue2Data } from '@/core/utils'
 import { videoUrls } from '@/core/utils/urls'
 import { VideoInfo } from '@/components/video/video-info'
@@ -9,6 +9,7 @@ import desc from './desc.md'
 
 interface RecommendList extends Vue {
   isOpen: boolean
+  mark: boolean
   related: {
     aid: string
     title: string
@@ -168,23 +169,24 @@ export const component = defineComponentMetadata({
     )
 
     urlChange(async () => {
+      console.debug('urlChange now url is', document.URL)
       await playerReady()
       const recoList: RecommendList = getRecoList()
-      const relist: VideoPageCard[] = recoList.$children.filter(
-        video => video.$el.className.indexOf('special') === -1,
-      )
-      showUploadTime(relist)
-    })
-
-    await playerReady()
-    // 监视推荐列表是否打开，如果打开则更新
-    childList(dq('#reco_list .rec-list'), async () => {
-      const recoList: RecommendList = getRecoList()
-      if (recoList.isOpen) {
-        const relist: VideoPageCard[] = recoList.$children.filter(
-          video => video.$el.className.indexOf('special') === -1,
+      console.debug('urlChange recoList.mark', recoList.mark)
+      if (!recoList.mark) {
+        recoList.mark = true
+        // 使用vue组件自带的$watch方法监视推荐列表信息是否变更，如果变更则更新
+        recoList.$watch(
+          'recListItems',
+          () => {
+            console.debug('recoListItems changed, now url is', document.URL)
+            const relist = recoList.$children.filter(
+              video => video.$el.className.indexOf('special') === -1,
+            )
+            showUploadTime(relist)
+          },
+          { deep: true, immediate: true },
         )
-        showUploadTime(relist)
       }
     })
   },

--- a/registry/lib/components/video/player/show-upload-time/index.ts
+++ b/registry/lib/components/video/player/show-upload-time/index.ts
@@ -12,7 +12,7 @@ interface RecommendList extends Vue {
   related: {
     aid: string
     title: string
-    ctime: number
+    pubdate: number
     owner: {
       name: string
     }
@@ -28,7 +28,7 @@ interface VideoPageCard extends Vue {
   oldname: string
   item: {
     aid: string
-    ctime: number
+    pubdate: number
     owner: {
       // 组件添加元素，非b站自有元素
       mark: boolean
@@ -123,16 +123,13 @@ export const component = defineComponentMetadata({
           // 确认推荐视频卡片是否被更新
           if (forceUpdate || !video.mark) {
             video.mark = true
-            let createTime: Date
-            if (video.item.ctime) {
-              createTime = new Date(video.item.ctime * 1000)
-            } else {
-              const videoinfo = new VideoInfo(video.item.aid)
-              await videoinfo.fetchInfo()
-              createTime = videoinfo.createTime
-              // 保存查询到的ctime，以便后续使用
-              video.item.ctime = createTime.getTime() / 1000
+            if (!video.item.pubdate) {
+              const info = new VideoInfo(video.item.aid)
+              await info.fetchInfo()
+              // 保存查询到的pubdate，以便后续使用
+              video.item.pubdate = info.pubdate
             }
+            const createTime: Date = new Date(video.item.pubdate * 1000)
             if (!video.oldname) {
               video.oldname = video.name
             }

--- a/src/components/video/video-info.ts
+++ b/src/components/video/video-info.ts
@@ -4,6 +4,8 @@ export class VideoInfo {
   aid: string
   bvid: string
   cid: number
+  pubdate: number
+  ctime: number
   createTime: Date
   pageCount: number
   coverUrl: string
@@ -47,7 +49,8 @@ export class VideoInfo {
     this.aid = data.aid
     this.bvid = data.bvid
     this.cid = data.cid
-    this.createTime = new Date(data.ctime * 1000)
+    this.pubdate = data.pubdate
+    this.ctime = data.ctime
     this.pageCount = data.videos
     this.coverUrl = data.pic.replace('http:', 'https:')
     this.tagId = data.tid


### PR DESCRIPTION
## 更改内容
1. 修复显示时间错误问题（对于2017年前的视频大概率时间显示为2017年）
2. 修复不刷新页面切换视频时部分视频投稿时间不显示问题
