### PR TITLE
[组件-下载视频][插件-下载视频 - aria2 输出支持][组件-查看封面] 为aria2提供可下载封面的功能

### DIFF
--- a/registry/lib/components/utils/view-cover/index.ts
+++ b/registry/lib/components/utils/view-cover/index.ts
@@ -1,5 +1,5 @@
 import { defineComponentMetadata } from '@/components/define'
-import { getBlobByAid } from '@/components/video/video-cover'
+import { getVideoCoverUrlByAid, getBlobByAid } from '@/components/video/video-cover'
 import { PackageEntry } from '@/core/download'
 import { videoAndBangumiUrls } from '@/core/utils/urls'
 import { Toast } from '@/core/toast'
@@ -54,6 +54,26 @@ export const component = defineComponentMetadata({
             const fail = results.filter(it => it.status === 'rejected') as PromiseRejectedResult[]
             toast.message = `获取完成. 成功 ${success.length} 个, 失败 ${fail.length} 个.`
             return success.map(it => it.value)
+          },
+          getUrls: async (
+            infos,
+            instance: {
+              type: CoverDownloadType
+              enabled: boolean
+            },
+          ) => {
+            const { type, enabled } = instance
+            if (!enabled) {
+              return []
+            }
+            return Promise.all(
+              infos.map(async info => {
+                return {
+                  name: `${info.input.title}.${type}`,
+                  url: await getVideoCoverUrlByAid(info.input.aid),
+                }
+              }),
+            )
           },
           component: () => import('./Plugin.vue').then(m => m.default),
         })

--- a/registry/lib/components/video/download/DownloadVideo.vue
+++ b/registry/lib/components/video/download/DownloadVideo.vue
@@ -332,18 +332,16 @@ export default Vue.extend({
           })
         }
         const action = new DownloadVideoAction(videoInfos)
-        const extraAssets = (
-          await Promise.all(
-            assets.map(a =>
-              a.getAssets(
-                videoInfos,
-                this.$refs.assetsOptions.find((c: any) => c.$attrs.name === a.name),
-              ),
-            ),
-          )
-        ).flat()
-        action.extraAssets.push(...extraAssets)
-        await action.downloadExtraAssets()
+        assets.forEach(a => {
+          action.extraAssets.push({
+            asset: a,
+            instance: this.$refs.assetsOptions.find((c: any) => c.$attrs.name === a.name),
+          })
+        })
+        /** 若视频输出的插件设置了proxyExtraAssets，则由插件在runAction中处理 */
+        if (!output?.proxyExtraAssets) {
+          await action.downloadExtraAssets()
+        }
         await output.runAction(action, instance)
       } catch (error) {
         logError(error)

--- a/registry/lib/components/video/download/DownloadVideo.vue
+++ b/registry/lib/components/video/download/DownloadVideo.vue
@@ -333,16 +333,14 @@ export default Vue.extend({
         }
         const action = new DownloadVideoAction(videoInfos)
         assets.forEach(a => {
-          action.extraAssets.push({
+          const assetsType = a?.getUrls ? action.extraOnlineAssets : action.extraAssets
+          assetsType.push({
             asset: a,
             instance: this.$refs.assetsOptions.find((c: any) => c.$attrs.name === a.name),
           })
         })
-        /** 若视频输出的插件设置了proxyExtraAssets，则由插件在runAction中处理 */
-        if (!output?.proxyExtraAssets) {
-          await action.downloadExtraAssets()
-        }
         await output.runAction(action, instance)
+        await action.downloadExtraAssets()
       } catch (error) {
         logError(error)
       } finally {

--- a/registry/lib/components/video/download/types.ts
+++ b/registry/lib/components/video/download/types.ts
@@ -114,6 +114,5 @@ export class DownloadVideoAction<AssetsParameter = any> {
 /** 下载视频的最终输出处理 */
 export interface DownloadVideoOutput<OutputParameter = any> extends VueInstanceInput, WithName {
   runAction: (action: DownloadVideoAction, instance: OutputParameter) => Promise<void>
-  /** 是否需要代理下载assets */
   description?: string
 }

--- a/registry/lib/components/video/download/types.ts
+++ b/registry/lib/components/video/download/types.ts
@@ -77,11 +77,17 @@ export interface DownloadVideoApi extends WithName {
 /** 表示下载时额外附带的产物, 如弹幕 / 字幕等 */
 export interface DownloadVideoAssets<AssetsParameter = any> extends VueInstanceInput, WithName {
   getAssets: (infos: DownloadVideoInfo[], instance: AssetsParameter) => Promise<PackageEntry[]>
+  /** 获取可直接下载的链接 */
+  getUrls?: (
+    infos: DownloadVideoInfo[],
+    instance: AssetsParameter,
+  ) => Promise<{ name: string; url: string }[]>
 }
 /** 表示视频的下载信息以及携带的额外产物 */
-export class DownloadVideoAction {
+export class DownloadVideoAction<AssetsParameter = any> {
   readonly inputs: DownloadVideoInputItem[] = []
-  extraAssets: PackageEntry[] = []
+  /** 可下载的asset和对应的参数 */
+  extraAssets: { asset: DownloadVideoAssets; instance: AssetsParameter }[] = []
 
   constructor(public infos: DownloadVideoInfo[]) {
     this.inputs = infos.map(it => it.input)
@@ -92,11 +98,19 @@ export class DownloadVideoAction {
   async downloadExtraAssets() {
     console.log('[downloadExtraAssets]', this.extraAssets)
     const filename = `${getFriendlyTitle(false)}.zip`
-    await new DownloadPackage(this.extraAssets).emit(filename)
+    const { infos } = this
+    const extraAssetsBlob = (
+      await Promise.all(
+        this.extraAssets.map(({ asset, instance }) => asset.getAssets(infos, instance)),
+      )
+    ).flat()
+    await new DownloadPackage(extraAssetsBlob).emit(filename)
   }
 }
 /** 下载视频的最终输出处理 */
 export interface DownloadVideoOutput<OutputParameter = any> extends VueInstanceInput, WithName {
   runAction: (action: DownloadVideoAction, instance: OutputParameter) => Promise<void>
+  /** 是否需要代理下载assets */
+  proxyExtraAssets?: boolean
   description?: string
 }

--- a/registry/lib/components/video/download/types.ts
+++ b/registry/lib/components/video/download/types.ts
@@ -86,8 +86,10 @@ export interface DownloadVideoAssets<AssetsParameter = any> extends VueInstanceI
 /** 表示视频的下载信息以及携带的额外产物 */
 export class DownloadVideoAction<AssetsParameter = any> {
   readonly inputs: DownloadVideoInputItem[] = []
-  /** 可下载的asset和对应的参数 */
+  /** 可调用处理的asset和对应的参数 */
   extraAssets: { asset: DownloadVideoAssets; instance: AssetsParameter }[] = []
+  /** 可直接下载的asset和对应的参数 */
+  extraOnlineAssets: { asset: DownloadVideoAssets; instance: AssetsParameter }[] = []
 
   constructor(public infos: DownloadVideoInfo[]) {
     this.inputs = infos.map(it => it.input)
@@ -101,7 +103,9 @@ export class DownloadVideoAction<AssetsParameter = any> {
     const { infos } = this
     const extraAssetsBlob = (
       await Promise.all(
-        this.extraAssets.map(({ asset, instance }) => asset.getAssets(infos, instance)),
+        [...this.extraAssets, ...this.extraOnlineAssets].map(({ asset, instance }) =>
+          asset.getAssets(infos, instance),
+        ),
       )
     ).flat()
     await new DownloadPackage(extraAssetsBlob).emit(filename)
@@ -111,6 +115,5 @@ export class DownloadVideoAction<AssetsParameter = any> {
 export interface DownloadVideoOutput<OutputParameter = any> extends VueInstanceInput, WithName {
   runAction: (action: DownloadVideoAction, instance: OutputParameter) => Promise<void>
   /** 是否需要代理下载assets */
-  proxyExtraAssets?: boolean
   description?: string
 }

--- a/registry/lib/plugins/video/download/aria2-output/RpcConfig.vue
+++ b/registry/lib/plugins/video/download/aria2-output/RpcConfig.vue
@@ -1,5 +1,9 @@
 <template>
   <div class="rpc-config download-video-config-section">
+    <div>
+    <div>aria2下载附属资源（若支持）:</div>
+    <SwitchBox v-model="isPluginDownloadAssets" @change="saveSettings"/>
+    </div>
     <div v-if="isRenaming" class="profile-select">
       <div class="profile-item-name">重命名 RPC 预设:</div>
       <TextBox ref="renameInput" v-model="profileRename" />
@@ -69,17 +73,19 @@
 <script lang="ts">
 import { getComponentSettings } from '@/core/settings'
 import { Toast } from '@/core/toast'
-import { TextBox, VButton, VIcon, VDropdown, TextArea } from '@/ui'
+import { TextBox, VButton, VIcon, VDropdown, TextArea, SwitchBox } from '@/ui'
 import { Aria2RpcProfile, defaultProfile } from './rpc-profiles'
 
 interface Options {
   rpcProfiles: Aria2RpcProfile[]
   selectedRpcProfileName: string
+  isPluginDownloadAssets: boolean
 }
 const { options: storedOptions } = getComponentSettings('downloadVideo')
 const defaultOptions: Options = {
   rpcProfiles: [defaultProfile],
   selectedRpcProfileName: defaultProfile.name,
+  isPluginDownloadAssets: false,
 }
 const options = { ...defaultOptions, ...storedOptions }
 const handleMissingProfile = () => {
@@ -99,6 +105,7 @@ export default Vue.extend({
     VIcon,
     VDropdown,
     TextArea,
+    SwitchBox,
   },
   data() {
     return {
@@ -106,12 +113,14 @@ export default Vue.extend({
       profileRename: '',
       rpcProfiles: options.rpcProfiles,
       selectedRpcProfile: lastSelectedProfile,
+      isPluginDownloadAssets: options.isPluginDownloadAssets,
     }
   },
   methods: {
     saveSettings() {
       options.selectedRpcProfileName = this.selectedRpcProfile.name
       options.rpcProfiles = this.rpcProfiles
+      options.isPluginDownloadAssets = this.isPluginDownloadAssets
       Object.assign(storedOptions, options)
     },
     async startRename() {

--- a/registry/lib/plugins/video/download/aria2-output/RpcConfig.vue
+++ b/registry/lib/plugins/video/download/aria2-output/RpcConfig.vue
@@ -1,8 +1,8 @@
 <template>
   <div class="rpc-config download-video-config-section">
     <div>
-    <div>aria2下载附属资源（若支持）:</div>
-    <SwitchBox v-model="isPluginDownloadAssets" @change="saveSettings"/>
+      <div>aria2下载附属资源（若支持）:</div>
+      <SwitchBox v-model="isPluginDownloadAssets" @change="saveSettings" />
     </div>
     <div v-if="isRenaming" class="profile-select">
       <div class="profile-item-name">重命名 RPC 预设:</div>


### PR DESCRIPTION
1. 优化视频下载组件的结构，现在在调用 `downloadExtraAssets` 时候再获取 assets 的 blob 并下载

2. 扩展视频下载组件的接口，插件可以处理 assets 的下载逻辑

3. 扩展视频封面组件和 aria2 插件以支持 aria2 下载封面
