### PR TITLE
[feature] 删除直播马赛克遮罩

### DIFF
--- a/registry/lib/components/live/remove-mask-panel/index.ts
+++ b/registry/lib/components/live/remove-mask-panel/index.ts
@@ -1,0 +1,33 @@
+import { defineComponentMetadata } from '@/components/define'
+import { liveUrls } from '@/core/utils/urls'
+
+const id = 'web-player-module-area-mask-panel'
+const entry = async () => {
+  const observer = new MutationObserver(mutations => {
+    mutations.forEach(mutation => {
+      mutation.addedNodes.forEach(node => {
+        if ((node as Element).id === id) {
+          node.parentNode?.removeChild(node)
+          observer.disconnect()
+        }
+      })
+    })
+  })
+  observer.observe(document.body, { childList: true, subtree: true })
+}
+
+export const component = defineComponentMetadata({
+  name: 'removeLiveMaskPanel',
+  displayName: '删除直播马赛克遮罩',
+  author: {
+    name: 'Liki4',
+    link: 'https://github.com/Liki4',
+  },
+  tags: [componentsTags.live, componentsTags.style],
+  description: {
+    'zh-CN': '删除观看直播时某些分区的马赛克遮罩.',
+  },
+  entry,
+  reload: entry,
+  urlInclude: liveUrls,
+})


### PR DESCRIPTION
<!-- 可以参考下代码贡献指南: https://github.com/the1812/Bilibili-Evolved/blob/preview/CONTRIBUTING.md -->

删除观看直播时某些分区的马赛克遮罩。例如守望先锋分区会自动添加两个马赛克遮罩，pr 提供了去除此类遮罩的能力

删除遮罩前：

![image](https://github.com/the1812/Bilibili-Evolved/assets/36180750/c355f9ee-a2ef-427e-9b38-5b1ddf82e287)

删除遮罩后：

![image](https://github.com/the1812/Bilibili-Evolved/assets/36180750/13d7ed02-4355-44d2-b176-778d24d89878)
