### PR TITLE
Fix: 删除视频弹窗、禁用特殊弹幕样式适配灰测

### DIFF
--- a/registry/lib/components/style/special-danmaku/special-danmaku.scss
+++ b/registry/lib/components/style/special-danmaku/special-danmaku.scss
@@ -1,13 +1,17 @@
 body.disable-highlight-danmaku-style {
+  .bili-danmaku-x-high,
+  .bili-danmaku-x-high-top,
   .bili-dm.bili-high,
   .b-danmaku-high {
     display: block !important;
     padding: 0 !important;
     line-height: 1.125 !important;
+    .bili-danmaku-x-high-icon,
     .bili-high-icon,
     .b-danmaku-high-icon {
       display: none !important;
     }
+    .bili-danmaku-x-high-text,
     .bili-high-text,
     .b-danmaku-high-text {
       margin: 0 !important;
@@ -16,6 +20,7 @@ body.disable-highlight-danmaku-style {
   }
 }
 body.disable-up-danmaku-style {
+  .bili-danmaku-x-up,
   .bili-dm.bili-up,
   .b-danmaku-up {
     padding: 0 !important;
@@ -29,15 +34,17 @@ body.disable-up-danmaku-style {
   }
 }
 body.disable-vip-danmaku-style {
+  .bili-danmaku-x-dm-vip,
   .bili-dm-vip {
     display: contents !important;
     text-shadow: inherit !important;
   }
-  .bili-dm:not([style*='--textShadow']) {
+  :where(.bili-dm, .bili-danmaku-x-dm):not([style*='--textShadow']) {
     --textShadow: var(--danmaku-text-shadow);
   }
 }
 body.disable-upSlogan-danmaku-style {
+  .bili-danmaku-x-upslogan,
   .bili-upslogan {
     padding: 0 !important;
     opacity: var(--opacity) !important;

--- a/registry/lib/components/video/player/remove-popup/remove-popup.scss
+++ b/registry/lib/components/video/player/remove-popup/remove-popup.scss
@@ -1,11 +1,13 @@
 body {
   &.remove-player-popup {
     // https://www.bilibili.com/video/BV1WA4m1L7xa/
+    .bili-danmaku-x-cmd-shrink,
     .bili-cmd-shrink {
       display: none !important;
     }
-    // https://www.bilibili.com/video/BV1V54y1b7yW/
+    // https://www.bilibili.com/video/BV1V54y1b7yW/?t=58
     &-combo-likes {
+      .bili-danmaku-x-guide,
       .bili-guide,
       .bilibili-player-video-popup-three,
       .bilibili-player-video-popup-three-animate,
@@ -18,8 +20,9 @@ body {
         display: none !important;
       }
     }
-    // https://www.bilibili.com/video/BV11h411k72c/
+    // https://www.bilibili.com/video/BV11h411k72c/?t=90
     &-related-videos {
+      .bili-danmaku-x-link,
       .bili-link,
       .bilibili-player-video-link,
       .bilibili-player-link,
@@ -27,8 +30,9 @@ body {
         display: none !important;
       }
     }
-    // https://www.bilibili.com/video/BV12Y4y1L7SR/
+    // https://www.bilibili.com/video/BV12Y4y1L7SR/?t=230
     &-votes {
+      .bili-danmaku-x-vote,
       .bili-vote,
       .bilibili-player-video-popup-vote,
       .bpx-player-popup-dm-close,
@@ -37,8 +41,9 @@ body {
         display: none !important;
       }
     }
-    // https://www.bilibili.com/video/BV1V54y1b7yW/
+    // https://www.bilibili.com/video/BV1V54y1b7yW/?t=48
     &-rates {
+      .bili-danmaku-x-score,
       .bili-score,
       .bilibili-player-score,
       .bpx-player-popup-dm-close,
@@ -50,6 +55,7 @@ body {
     }
     // https://www.bilibili.com/video/BV1fe4y1b7NE/
     &-reservations {
+      .bili-danmaku-x-reserve,
       .bili-reserve,
       .bpx-player-reserve {
         display: none !important;
@@ -57,6 +63,7 @@ body {
     }
     // https://www.bilibili.com/video/BV1Qe411d7LM/?t=221
     &-promotions {
+      .bili-danmaku-x-cmtime,
       .bili-cmtime,
       .bpx-player-cmtime,
       .bpx-player-skipcard {


### PR DESCRIPTION
fix #4831 , fix #4823 

目前部分设备**删除视频弹窗失效、禁用特殊弹幕样式失效**，像灰测，已知 Safari 会出现这一情况，可尝试在 Chrome 复现：

1. 用 Safari 的 UA 访问视频页，head 内会出现与 Chrome 不同哈希值的 core.js （要看运气）

![image](https://github.com/user-attachments/assets/3432f9b7-51ef-4e22-9812-74d3032216fd)

2. 在 Chrome 内使用 https://github.com/fengyc/URLRedirector 对 core.js 链接进行重定向，即可获得带有 `-x-` 特征的弹幕和弹窗

![image](https://github.com/user-attachments/assets/5b3369b7-4163-40cc-b43c-31329db35a58)

3. 分析可知新版弹窗样式在 widget js 文件内 [样本链接](https://s1.hdslb.com/bfs/static/player/main/widgets/npd.579.b4368336.js)

4. 不知道 B 站什么时候继续改类名（或者放弃铺开测试），但愿多生效一阵

PS.
1. 弹窗屏蔽 scss 代码里视频预告的测试链接失效了，暂未找到替代链接
2. 禁用特殊弹幕样式，大会员弹幕可以在描边类型修改时实时变化，但普通弹幕不会变，原因是官方没做