### PR TITLE
Fix deleteFeeds

### DIFF
--- a/registry/lib/components/feeds/del-feeds/check-in-item.ts
+++ b/registry/lib/components/feeds/del-feeds/check-in-item.ts
@@ -131,4 +131,4 @@ const builtInItems: CheckInItem[] = [
   },
 ]
 
-export const [checkInItems] = registerAndGetData('checkInCenter.items', builtInItems)
+export const [checkInItems] = registerAndGetData('deleteFeeds.items', builtInItems)


### PR DESCRIPTION
修复`registerAndGetData`的`key`错误使用导致同时开启`签到助手`时, 显示两次`签到助手`的按钮
