### PR TITLE
[组件-禁止跳转动态详情] fix: 修复带图转发动态二次转发后，`查看图片` 失效

### DIFF
--- a/registry/lib/components/feeds/disable-details/index.ts
+++ b/registry/lib/components/feeds/disable-details/index.ts
@@ -41,6 +41,7 @@ const entry = async () => {
             'bili-rich-text-topic',
             'bili-rich-text-module',
             'bili-rich-text-link',
+            'bili-rich-text-viewpic',
           ].some(className => target.classList.contains(className))
         ) {
           return


### PR DESCRIPTION
例如 https://t.bilibili.com/991837283011264531
