### PR TITLE
[插件 - 下载视频 - WASM 混流输出] 修复写入元数据选项,  新增混流进度, 优化多集下载

### DIFF
--- a/registry/lib/plugins/video/download/wasm-output/Config.vue
+++ b/registry/lib/plugins/video/download/wasm-output/Config.vue
@@ -33,7 +33,7 @@ export default Vue.extend({
   },
   methods: {
     saveOptions() {
-      options.muxWithMetadata = this.muxExtraAssets
+      options.muxWithMetadata = this.muxWithMetadata
       Object.assign(storedOptions, options)
     },
   },

--- a/registry/lib/plugins/video/download/wasm-output/ffmpeg.ts
+++ b/registry/lib/plugins/video/download/wasm-output/ffmpeg.ts
@@ -17,6 +17,7 @@ enum FFMessageType {
   EXEC = 'EXEC',
   WRITE_FILE = 'WRITE_FILE',
   READ_FILE = 'READ_FILE',
+  DELETE_FILE = 'DELETE_FILE',
   ERROR = 'ERROR',
 }
 
@@ -38,6 +39,7 @@ export class FFmpeg {
           case FFMessageType.EXEC:
           case FFMessageType.WRITE_FILE:
           case FFMessageType.READ_FILE:
+          case FFMessageType.DELETE_FILE:
             this.#resolves[id](data)
             break
           case FFMessageType.ERROR:
@@ -140,6 +142,20 @@ export class FFmpeg {
       undefined,
       signal,
     ) as Promise<Uint8Array>
+
+  public deleteFile = (path: string, signal?: AbortSignal) =>
+    this.#send(
+      {
+        type: FFMessageType.DELETE_FILE,
+        data: { path },
+      },
+      undefined,
+      signal,
+    ) as Promise<boolean>
+
+  public onProgress(callback: (event: ProgressEvent) => void): void {
+    this.#progressEventCallback = callback
+  }
 }
 
 // ========================================================================== //
@@ -165,11 +181,16 @@ interface FFMessageReadFileData {
   encoding: string
 }
 
+interface FFMessageDeleteFileData {
+  path: string
+}
+
 type FFMessageData =
   | FFMessageLoadConfig
   | FFMessageExecData
   | FFMessageWriteFileData
   | FFMessageReadFileData
+  | FFMessageDeleteFileData
 
 interface Message {
   type: string

--- a/registry/lib/plugins/video/download/wasm-output/handler.ts
+++ b/registry/lib/plugins/video/download/wasm-output/handler.ts
@@ -2,6 +2,7 @@ import { DownloadPackage, PackageEntry } from '@/core/download'
 import { meta } from '@/core/meta'
 import { getComponentSettings } from '@/core/settings'
 import { Toast } from '@/core/toast'
+import { formatPercent } from '@/core/utils/formatters'
 import { title as pluginTitle } from '.'
 import type { Options } from '../../../../components/video/download'
 import { DownloadVideoAction } from '../../../../components/video/download/types'
@@ -76,7 +77,9 @@ async function single(
 
   console.debug('FFmpeg commandline args:', args.join(' '))
 
-  toast.message = '混流中……'
+  ffmpeg.onProgress(event => {
+    toast.message = `混流中: ${formatPercent(event.progress)}`
+  })
   await ffmpeg.exec(args)
 
   const output = await ffmpeg.readFile('output')

--- a/registry/lib/plugins/video/download/wasm-output/handler.ts
+++ b/registry/lib/plugins/video/download/wasm-output/handler.ts
@@ -59,13 +59,13 @@ async function single(
     httpGet(audioUrl, progress(1, '正在下载音频流')),
   ])
 
-  ffmpeg.writeFile('video', video)
-  ffmpeg.writeFile('audio', audio)
+  await ffmpeg.writeFile('video', video)
+  await ffmpeg.writeFile('audio', audio)
 
   const args = ['-i', 'video', '-i', 'audio']
 
   if (ffmetadata) {
-    ffmpeg.writeFile('ffmetadata', new TextEncoder().encode(ffmetadata))
+    await ffmpeg.writeFile('ffmetadata', new TextEncoder().encode(ffmetadata))
     args.push('-i', 'ffmetadata', '-map_metadata', '2')
     if (!outputMkv) {
       args.push('-movflags', '+use_metadata_tags')
@@ -86,6 +86,13 @@ async function single(
 
   toast.message = '完成！'
   toast.duration = 1000
+
+  await Promise.all([
+    ffmpeg.deleteFile('video'),
+    ffmpeg.deleteFile('audio'),
+    ffmpeg.deleteFile('output'),
+    ffmetadata ? ffmpeg.deleteFile('ffmetadata') : Promise.resolve(),
+  ])
 
   await DownloadPackage.single(
     name.replace(/.[^/.]+$/, `.${outputMkv ? 'mkv' : 'mp4'}`),


### PR DESCRIPTION
- 修复： `写入元数据` 选项不能保存：https://github.com/the1812/Bilibili-Evolved/pull/4840#issuecomment-2439787447
- 新增：混流进度反馈
  ![gif](https://github.com/user-attachments/assets/e4dfea39-f39c-42d3-b299-e45f60489dc7)
- 优化：混流结束后删除 Web Worker 中的文件，优化多集下载