### PR TITLE
docs: 优化启动 dev-server 的文档

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,20 @@ pnpm install
 
 配置本地调试环境:
 
+**配置开发服务 dev-server**
+1. 确保已安装 `ts-node`，如未安装，可通过 `npm install -g ts-node` 安装
+2. 进入仓库根目录
+3. 运行 `ts-node dev-tools/dev-server/index.ts` 启动开发服务，没问题的话可以看到如下输出
+```bash
+$ ts-node dev-tools/dev-server/index.ts 
+DevServer 已启动, 端口: 23333
+本体编译中...
+(...一长串输出)
+
+本体已编译: （一段 hash）
+```
+
+
 **如果使用的是基于 Chromium 的浏览器**
 1. VS Code 中运行 `启动开发服务 dev-server` 任务, 会在项目的 `dist/` 文件夹下生成一个开发用的脚本 `dist/bilibili-evolved.dev.user.js`.
 2. Chrome 插件管理 `chrome://extensions/` > Tampermonkey > 详细信息

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,15 +30,16 @@ pnpm install
 
 配置本地调试环境:
 
-**配置开发服务 dev-server**
+**启动开发服务 dev-server**
 1. 确保已安装 `ts-node`，如未安装，可通过 `npm install -g ts-node` 安装
-2. 进入仓库根目录
-3. 运行 `ts-node dev-tools/dev-server/index.ts` 启动开发服务，没问题的话可以看到如下输出
+2. 进入项目根目录
+3. 运行 `ts-node dev-tools/dev-server/index.ts` 启动开发服务，没问题的话可以看到类似的输出：
+
 ```bash
 $ ts-node dev-tools/dev-server/index.ts 
 DevServer 已启动, 端口: 23333
 本体编译中...
-(...一长串输出)
+(...可能有一长串输出)
 
 本体已编译: （一段 hash）
 ```

--- a/dev-tools/dev-server/watcher-common.ts
+++ b/dev-tools/dev-server/watcher-common.ts
@@ -21,7 +21,7 @@ export const defaultWatcherHandler = (
           assets: false,
           modules: false,
           chunks: false,
-          color: true,
+          colors: true,
         }),
       )
     }


### PR DESCRIPTION
<!-- 可以参考下代码贡献指南: https://github.com/the1812/Bilibili-Evolved/blob/preview/CONTRIBUTING.md -->
遇到了和 https://github.com/the1812/Bilibili-Evolved/pull/4076#discussion_r1948041407 一样的问题：文档中没有如何启动 dev-server 的内容，于是补上了；顺便修复了一个变量命名问题