### PR TITLE
[组件 - 隐藏热搜] feat: 优化隐藏热搜的显示效果

### DIFF
--- a/registry/lib/components/style/hide/trending-search/hide-trending-search.scss
+++ b/registry/lib/components/style/hide/trending-search/hide-trending-search.scss
@@ -1,5 +1,7 @@
 .search-panel {
-  > .trending {
-    display: none !important;
-  }
+  display: none !important;
+}
+
+#nav-searchform.is-focus {
+  border-radius: 8px !important;
 }

--- a/registry/lib/components/style/hide/trending-search/hide-trending-search.scss
+++ b/registry/lib/components/style/hide/trending-search/hide-trending-search.scss
@@ -1,7 +1,18 @@
 .search-panel {
-  display: none !important;
+
+  > .trending {
+    display: none !important;
+  }
+
+  &:not(:has(.history)) {
+    padding: 0 !important;
+    border: none !important;
+  }
 }
 
 #nav-searchform.is-focus {
-  border-radius: 8px !important;
+  /* 搜索框 focusing 且有关键字列表 or 历史记录列表时不显示低边框*/
+  &:not(:has(+ .search-panel > .suggestions), :has(+ .search-panel > .history))  {
+   border-radius: 8px !important;
+  }
 }

--- a/registry/lib/components/style/hide/trending-search/index.ts
+++ b/registry/lib/components/style/hide/trending-search/index.ts
@@ -2,14 +2,12 @@ import { defineComponentMetadata } from '@/components/define'
 import { allMutations } from '@/core/observer'
 import { select } from '@/core/spin-query'
 
-
 const DEFAULT_PLACEHOLDER = '搜索'
 
-
 const resetPlaceholder = (input: HTMLInputElement) => {
-  input.placeholder = input.title = DEFAULT_PLACEHOLDER
+  input.placeholder = DEFAULT_PLACEHOLDER
+  input.title = DEFAULT_PLACEHOLDER
 }
-
 
 export const component = defineComponentMetadata({
   name: 'hideTrendingSearch',
@@ -23,11 +21,12 @@ export const component = defineComponentMetadata({
   ],
   entry: async () => {
     const input: HTMLInputElement = await select('input.nav-search-input', {
-      queryInterval: 500
-    });
+      queryInterval: 500,
+    })
 
     if (input) {
-      return resetPlaceholder(input)
+      resetPlaceholder(input)
+      return
     }
 
     // Fallback to observer

--- a/registry/lib/components/style/hide/trending-search/index.ts
+++ b/registry/lib/components/style/hide/trending-search/index.ts
@@ -1,5 +1,15 @@
 import { defineComponentMetadata } from '@/components/define'
 import { allMutations } from '@/core/observer'
+import { select } from '@/core/spin-query'
+
+
+const DEFAULT_PLACEHOLDER = '搜索'
+
+
+const resetPlaceholder = (input: HTMLInputElement) => {
+  input.placeholder = input.title = DEFAULT_PLACEHOLDER
+}
+
 
 export const component = defineComponentMetadata({
   name: 'hideTrendingSearch',
@@ -12,14 +22,23 @@ export const component = defineComponentMetadata({
     },
   ],
   entry: async () => {
+    const input: HTMLInputElement = await select('input.nav-search-input', {
+      queryInterval: 500
+    });
+
+    if (input) {
+      return resetPlaceholder(input)
+    }
+
+    // Fallback to observer
     allMutations(records => {
       records.forEach(record => {
         if (
           record.target instanceof HTMLInputElement &&
           record.target.classList.contains('nav-search-input') &&
-          record.target.placeholder !== '搜索'
+          record.target.placeholder !== DEFAULT_PLACEHOLDER
         ) {
-          record.target.placeholder = '搜索'
+          resetPlaceholder(record.target)
         }
       })
     })


### PR DESCRIPTION
<!-- 可以参考下代码贡献指南: https://github.com/the1812/Bilibili-Evolved/blob/preview/CONTRIBUTING.md -->
老版隐藏热搜：
1. 点击搜索框才重置 placeholder 为 “搜索”，默认还是会展示热搜词
2. 没有搜索词的时候，搜索面板的 padding 不为 0 导致会显示一个空白的面板

针对这两点进行了优化，效果 gif：
![ezgif-208383a96139ac](https://github.com/user-attachments/assets/7fa1da9e-8a60-453c-a0c2-c534f4de5388)
