### PR TITLE
fix: 夜间模式二维码扫码登录困难 #5163

### DIFF
--- a/registry/lib/components/style/dark-mode/dark-slice-19.scss
+++ b/registry/lib/components/style/dark-mode/dark-slice-19.scss
@@ -6,3 +6,28 @@
     @include background-color();
   }
 }
+
+.login-scan__qrcode {
+  @include background-color('f');
+  .qrcode__tip {
+    @include background-color('3');
+    img {
+      @include background-color();
+    }
+    span {
+      @include color('a');
+    }
+  }
+}
+
+.scan-tips-icon{
+  @include background-color('2');
+}
+
+.btn_other {
+  @include background-color('3');
+  @include border-color('4');
+  @include color('f');
+}
+
+


### PR DESCRIPTION
#5163  和[本页面](https://passport.bilibili.com/login)其他未适配的元素

<!-- 可以参考下代码贡献指南: https://github.com/the1812/Bilibili-Evolved/blob/preview/CONTRIBUTING.md -->
