### PR TITLE
修复暗黑模式首页右侧 svg 图标颜色

### DIFF
--- a/registry/lib/components/style/dark-mode/dark-slice-15.scss
+++ b/registry/lib/components/style/dark-mode/dark-slice-15.scss
@@ -509,8 +509,8 @@
       }
       .channel-link__right {
         @include color('e');
-        svg path {
-          @include fill('e');
+        svg {
+          filter: invert(1) hue-rotate(180deg) brightness(1.5);
         }
       }
       .channel-entry-more__link,


### PR DESCRIPTION
启用暗黑模式后，当前效果：
![image](https://github.com/user-attachments/assets/62f9d58c-aee5-4b92-8d18-1709f45529a8)

原因是里面有三个图标存在不同颜色的 path 被改了颜色，撤销 `fill('e')` 可以发现这一点：
![image](https://github.com/user-attachments/assets/1e6320c4-39da-4500-9615-00d3382e12f4)

因此这里改成直接对图片反色，并适当调整了色相和亮度：
![image](https://github.com/user-attachments/assets/aef1f062-12b2-478d-a8bd-0c20ebd528ae)

实际上这个方案对大部分 svg 图片来说几乎都是通用的。