### PR TITLE
[组件-自动移出稍后再看] 优化事件监听逻辑，防止重复监听导致重复调用接口

### DIFF
--- a/registry/lib/components/video/auto-remove-watchlater/index.ts
+++ b/registry/lib/components/video/auto-remove-watchlater/index.ts
@@ -4,6 +4,7 @@ import { videoUrls, watchlaterUrls } from '@/core/utils/urls'
 import { playerAgent } from '@/components/video/player-agent'
 import { getWatchlaterList, toggleWatchlater } from '@/components/video/watchlater'
 
+let listener: (() => Promise<void>) | null = null
 export const component = defineComponentMetadata({
   name: 'autoRemoveWatchlater',
   displayName: '自动移出稍后再看',
@@ -12,12 +13,16 @@ export const component = defineComponentMetadata({
   entry: () => {
     videoChange(async ({ aid }) => {
       const videoElement = await playerAgent.query.video.element()
-      videoElement.addEventListener('ended', async () => {
+      if (listener !== null) {
+        videoElement.removeEventListener('ended', listener)
+      }
+      listener = async () => {
         const list = await getWatchlaterList()
         if (list.includes(parseInt(aid))) {
           await toggleWatchlater(aid)
         }
-      })
+      }
+      videoElement.addEventListener('ended', listener)
     })
   },
 })


### PR DESCRIPTION
测试方法：稍后再看切换上一个下一个n次，就会重复监听n次（可以查看video标签的ended事件），导致重复调用接口n次
![image](https://github.com/user-attachments/assets/543ba204-cca0-44db-8c64-adb83086c22a)
![image](https://github.com/user-attachments/assets/ac1ebda1-9a9d-4450-a600-026f7c896064)

还有个 跳过充电鸣谢 似乎也有这个问题，但是充电鸣谢好像下线了所以不修了