### PR TITLE
feat: adapt filter for new bilibili search-trendings section

### DIFF
--- a/registry/lib/components/feeds/filter/FeedsFilterCard.vue
+++ b/registry/lib/components/feeds/filter/FeedsFilterCard.vue
@@ -74,10 +74,10 @@ const sideCards: { [id: number]: SideCardType } = {
     className: 'profile',
     displayName: '个人资料',
   },
-  1: {
-    className: 'following-tags',
-    displayName: '话题',
-  },
+  // 1: {
+  //   className: 'following-tags',
+  //   displayName: '话题',
+  // },
   2: {
     className: 'notice',
     displayName: '公告栏',
@@ -97,6 +97,10 @@ const sideCards: { [id: number]: SideCardType } = {
   6: {
     className: 'compose',
     displayName: '发布动态',
+  },
+  7: {
+    className: 'search-trendings',
+    displayName: '热搜',
   },
 }
 if (getComponentSettings('extendFeedsLive').enabled) {

--- a/registry/lib/components/feeds/filter/_blocker.scss
+++ b/registry/lib/components/feeds/filter/_blocker.scss
@@ -92,6 +92,11 @@
       display: none !important;
     }
   }
+  &.#{$side-block}-search-trendings {
+    .bili-dyn-search-trendings {
+      display: none !important;
+    }
+  }
   &.#{$side-block}-most-viewed {
     .bili-dyn-up-list,
     .card-list .most-viewed-panel {


### PR DESCRIPTION
[组件-自动移出稍后再看] 优化事件监听逻辑，防止重复监听导致重复调用接口<!-- 可以参考下代码贡献指南: https://github.com/the1812/Bilibili-Evolved/blob/preview/CONTRIBUTING.md -->

This PR closes #5273 .

Bilibili dynamic page structure update:
- The original topic-related elements (`.tag-panel`, `.dyn-topic-panel`, etc.) have been removed
- A new trending search area uses the `<div class="bili-dyn-search-trendings">` structure

