### PR TITLE
[组件 - 隐藏用户信息卡片] 修复以适配新版评论区

### DIFF
--- a/registry/lib/components/style/hide/user-card/user-card.scss
+++ b/registry/lib/components/style/hide/user-card/user-card.scss
@@ -1,5 +1,6 @@
 .user-card,
 .user-card-m-exp,
-.bili-user-profile {
+.bili-user-profile,
+bili-user-profile {
   display: none !important;
 }


### PR DESCRIPTION
讨论 #5324

(评论区的用户信息卡片用上了 Shadow DOM，但是右上角 UP 主的还是以前的