### PR TITLE
获取room_id兼容blanc原版直播间

### DIFF
--- a/registry/lib/components/live/badge-keepalive/utils.ts
+++ b/registry/lib/components/live/badge-keepalive/utils.ts
@@ -5,7 +5,7 @@ import { getCsrf, getUID } from '@/core/utils'
 export function getLiveRoomId(): string {
   let matched = location.href.match(/live.bilibili.com\/(\d+)/)
   if (matched) {
-      return matched[1]
+    return matched[1]
   }
   matched = location.href.match(/live.bilibili.com\/blanc\/(\d+)/)
   return matched ? matched[1] : ''

--- a/registry/lib/components/live/badge-keepalive/utils.ts
+++ b/registry/lib/components/live/badge-keepalive/utils.ts
@@ -3,7 +3,11 @@ import { getCsrf, getUID } from '@/core/utils'
 
 // 获取当前直播间号
 export function getLiveRoomId(): string {
-  const matched = location.href.match(/live.bilibili.com\/(\d+)/)
+  let matched = location.href.match(/live.bilibili.com\/(\d+)/)
+  if (matched) {
+      return matched[1]
+  }
+  matched = location.href.match(/live.bilibili.com\/blanc\/(\d+)/)
   return matched ? matched[1] : ''
 }
 


### PR DESCRIPTION
<!-- 可以参考下代码贡献指南: https://github.com/the1812/Bilibili-Evolved/blob/preview/CONTRIBUTING.md -->
使用"返回原版直播间"功能情况下，location变为/blanc/{$room_id}，"点亮粉丝勋章"功能无法自动获取room_id，该修复兼容了这种情况