### PR TITLE
【组件-定制自动连播行为】修复部分页面不工作

### DIFF
--- a/registry/lib/components/video/player/custom-auto-play/AutoplayActionType.ts
+++ b/registry/lib/components/video/player/custom-auto-play/AutoplayActionType.ts
@@ -1,0 +1,9 @@
+/** 自动连播行为类型 */
+export enum AutoplayActionType {
+  /** 自动判断，参考《传统连播模式》组件 */
+  AUTO = '自动',
+  /** 禁用自动连播 */
+  DISABLE = '禁用',
+  /** 总是自动连播 */
+  ALWAYS = '总是',
+}

--- a/registry/lib/components/video/player/custom-auto-play/handlers/BangumiAutoplayHandler.ts
+++ b/registry/lib/components/video/player/custom-auto-play/handlers/BangumiAutoplayHandler.ts
@@ -1,0 +1,32 @@
+import { matchUrlPattern } from '@/core/utils'
+import { bangumiUrls } from '@/core/utils/urls'
+import { AutoplayActionType } from '../AutoplayActionType'
+import { BaseAutoplayHandler } from './BaseAutoplayHandler'
+
+/** 自动连播处理器-番剧 */
+export class BangumiAutoplayHandler extends BaseAutoplayHandler {
+  type = '番剧'
+
+  async match() {
+    return bangumiUrls.some(url => matchUrlPattern(url))
+  }
+
+  protected override isLastSequentialNumber(): boolean {
+    // PV、小剧场没有分P序号，因此统一用元素位置判断
+    const el = document
+      .querySelector('.plp-r img[class^=PlayingIcon_playIcon]')
+      .closest('div[class^=imageListItem_wrap]')
+    return !el.nextElementSibling
+  }
+
+  async shouldAutoplay() {
+    return BaseAutoplayHandler.shouldAutoplayWithAutoHandler(
+      BaseAutoplayHandler.settings.options.bangumiAutoplayAction as AutoplayActionType,
+      () => !this.isLastSequentialNumber(),
+    )
+  }
+
+  async setupAutoPlay(enable: boolean) {
+    await this.setupAutoPlay_Player(enable)
+  }
+}

--- a/registry/lib/components/video/player/custom-auto-play/handlers/BangumiAutoplayHandler.ts
+++ b/registry/lib/components/video/player/custom-auto-play/handlers/BangumiAutoplayHandler.ts
@@ -11,7 +11,16 @@ export class BangumiAutoplayHandler extends BaseAutoplayHandler {
     return bangumiUrls.some(url => matchUrlPattern(url))
   }
 
+  protected override getSequentialNumberString(): string {
+    return document.querySelector('.plp-r span[class^=eplist_ep_list_progress]').innerHTML
+  }
+
   protected override isLastSequentialNumber(): boolean {
+    // 正片有分P序号，使用默认逻辑
+    if (this.getSequentialNumberString().length > 0) {
+      return super.isLastSequentialNumber()
+    }
+
     // PV、小剧场没有分P序号，因此统一用元素位置判断
     const el = document
       .querySelector('.plp-r img[class^=PlayingIcon_playIcon]')

--- a/registry/lib/components/video/player/custom-auto-play/handlers/BaseAutoplayHandler.ts
+++ b/registry/lib/components/video/player/custom-auto-play/handlers/BaseAutoplayHandler.ts
@@ -1,0 +1,134 @@
+import { ComponentSettings } from '@/core/settings'
+import { sq, select } from '@/core/spin-query'
+import { getVue2Data as getVueData } from '@/core/utils'
+import { logger } from '..'
+import { AutoplayActionType } from '../AutoplayActionType'
+
+/** 自动连播处理器基类 */
+export abstract class BaseAutoplayHandler {
+  // #region 初始化
+
+  /** 脚本设置 */
+  static settings: ComponentSettings
+
+  /** 自动连播处理器实例列表 */
+  protected static handlers: BaseAutoplayHandler[] = []
+
+  /** 添加自动连播处理器实例到列表 */
+  static register(handler: BaseAutoplayHandler) {
+    BaseAutoplayHandler.handlers.push(handler)
+  }
+
+  /** 获取匹配当前页面的自动连播处理器实例 */
+  static async getHandler(): Promise<BaseAutoplayHandler | null> {
+    for (const handler of BaseAutoplayHandler.handlers) {
+      if (await handler.match()) {
+        return handler
+      }
+    }
+
+    return null
+  }
+
+  // #endregion
+
+  // #region 抽象
+
+  /** 自动连播类型 */
+  abstract type: string
+
+  /** 处理器是否适用当前页面 */
+  abstract match(): Promise<boolean>
+
+  /** 是否应启用自动连播 */
+  abstract shouldAutoplay(): Promise<boolean>
+
+  /**
+   * 设置自动连播状态
+   * @param enable true：启用，false：禁用
+   */
+  abstract setupAutoPlay(enable: boolean): Promise<void>
+
+  // #endregion
+
+  // #region 工具方法
+
+  /**
+   * 默认连播方式判断，自动连播行为类型为AUTO时使用回调处理
+   * @param actionType 自动连播行为类型
+   * @param autoTypeHandler 自动连播行为类型为AUTO时的处理回调
+   * @returns 是否应该自动连播
+   */
+  static shouldAutoplayWithAutoHandler(
+    actionType: AutoplayActionType,
+    autoTypeHandler: () => boolean,
+  ): boolean {
+    switch (actionType) {
+      case AutoplayActionType.ALWAYS:
+        return true
+      case AutoplayActionType.DISABLE:
+        return false
+      case AutoplayActionType.AUTO:
+      default:
+        return autoTypeHandler()
+    }
+  }
+
+  /**
+   * 获取分P序号文本
+   * @returns 例如：'1/10' 或 '（1/10）'
+   */
+  protected getSequentialNumberString(): string {
+    return ''
+  }
+
+  /**
+   * 解析分P序号
+   * @returns 例如：[1,10]
+   */
+  protected parseSequentialNumbers(): number[] {
+    return this.getSequentialNumberString()
+      .replace(/[（）()]/g, '')
+      .split('/')
+      .map(it => parseInt(it))
+  }
+
+  /** 是否最后1P视频 */
+  protected isLastSequentialNumber(): boolean {
+    const sequentialNumbers = this.parseSequentialNumbers()
+    if (!sequentialNumbers || sequentialNumbers.length < 2) {
+      return true
+    }
+    return sequentialNumbers[0] >= sequentialNumbers[1]
+  }
+
+  /** 设置自动连播按钮状态（位于右上角） */
+  protected async setupAutoPlay_SwitchBtn(enableAutoplay: boolean) {
+    sq(() => {
+      try {
+        const app = document.getElementById('app')
+        const vueInstance = getVueData(app)
+        vueInstance.setContinuousPlay(enableAutoplay)
+        return true
+      } catch (e) {
+        logger.debug(`${this.constructor.name}：设置自动连播按钮状态发生错误，错误信息：${e}`)
+        return false
+      }
+    })
+  }
+
+  /** 设置番剧自动连播状态 */
+  protected async setupAutoPlay_Player(enableAutoplay: boolean) {
+    const selector = enableAutoplay
+      ? '.bpx-player-ctrl-setting-handoff input[type="radio"][value="0"]'
+      : '.bpx-player-ctrl-setting-handoff input[type="radio"][value="2"]'
+    const radio = (await select(selector)) as HTMLInputElement
+
+    if (radio === null) {
+      logger.error(`${this.constructor.name}：未找到对应的播放方式按钮`)
+    }
+    radio.click()
+  }
+
+  // #endregion
+}

--- a/registry/lib/components/video/player/custom-auto-play/handlers/FavoriteAutoplayHandler.ts
+++ b/registry/lib/components/video/player/custom-auto-play/handlers/FavoriteAutoplayHandler.ts
@@ -1,0 +1,28 @@
+import { matchUrlPattern } from '@/core/utils'
+import { favoriteListUrls } from '@/core/utils/urls'
+import { AutoplayActionType } from '../AutoplayActionType'
+import { BaseAutoplayHandler } from './BaseAutoplayHandler'
+
+/** 自动连播处理器-收藏夹 */
+export class FavoriteAutoplayHandler extends BaseAutoplayHandler {
+  type = '收藏夹'
+
+  async match() {
+    return favoriteListUrls.some(url => matchUrlPattern(url))
+  }
+
+  protected override getSequentialNumberString(): string {
+    return document.querySelector('.list-count').innerHTML
+  }
+
+  async shouldAutoplay() {
+    return BaseAutoplayHandler.shouldAutoplayWithAutoHandler(
+      BaseAutoplayHandler.settings.options.favoriteAutoplayAction as AutoplayActionType,
+      () => !this.isLastSequentialNumber(),
+    )
+  }
+
+  async setupAutoPlay(enable: boolean) {
+    await this.setupAutoPlay_SwitchBtn(enable)
+  }
+}

--- a/registry/lib/components/video/player/custom-auto-play/handlers/MultipartAutoplayHandler.ts
+++ b/registry/lib/components/video/player/custom-auto-play/handlers/MultipartAutoplayHandler.ts
@@ -2,13 +2,13 @@ import { matchUrlPattern } from '@/core/utils'
 import { AutoplayActionType } from '../AutoplayActionType'
 import { BaseAutoplayHandler } from './BaseAutoplayHandler'
 
-/** 自动连播处理器-视频合集 */
-export class PlaylistAutoplayHandler extends BaseAutoplayHandler {
-  type = '视频合集'
+/** 自动连播处理器-分P视频 */
+export class MultipartAutoplayHandler extends BaseAutoplayHandler {
+  type = '分P视频'
 
   async match() {
     const videoUrl = '//www.bilibili.com/video/'
-    const list = document.querySelector('.video-pod .section')
+    const list = document.querySelector('.video-pod .multip')
     const btn = document.querySelector('.video-pod .auto-play .switch-btn')
     return matchUrlPattern(videoUrl) && list != null && btn != null
   }
@@ -19,7 +19,7 @@ export class PlaylistAutoplayHandler extends BaseAutoplayHandler {
 
   async shouldAutoplay() {
     return BaseAutoplayHandler.shouldAutoplayWithAutoHandler(
-      BaseAutoplayHandler.settings.options.playlistAutoplayAction as AutoplayActionType,
+      BaseAutoplayHandler.settings.options.multipartAutoplayAction as AutoplayActionType,
       () => !this.isLastSequentialNumber(),
     )
   }

--- a/registry/lib/components/video/player/custom-auto-play/handlers/PlaylistAutoplayHandler.ts
+++ b/registry/lib/components/video/player/custom-auto-play/handlers/PlaylistAutoplayHandler.ts
@@ -1,0 +1,29 @@
+import { matchUrlPattern } from '@/core/utils'
+import { AutoplayActionType } from '../AutoplayActionType'
+import { BaseAutoplayHandler } from './BaseAutoplayHandler'
+
+/** 自动连播处理器-分P视频 */
+export class PlaylistAutoplayHandler extends BaseAutoplayHandler {
+  type = '分P视频'
+
+  async match() {
+    const videoUrl = '//www.bilibili.com/video/'
+    const btn = document.querySelector('.video-pod .auto-play .switch-btn')
+    return matchUrlPattern(videoUrl) && btn !== null
+  }
+
+  protected override getSequentialNumberString(): string {
+    return document.querySelector('.video-pod__header .amt').innerHTML
+  }
+
+  async shouldAutoplay() {
+    return BaseAutoplayHandler.shouldAutoplayWithAutoHandler(
+      BaseAutoplayHandler.settings.options.playlistAutoplayAction as AutoplayActionType,
+      () => !this.isLastSequentialNumber(),
+    )
+  }
+
+  async setupAutoPlay(enable: boolean) {
+    await this.setupAutoPlay_SwitchBtn(enable)
+  }
+}

--- a/registry/lib/components/video/player/custom-auto-play/handlers/RecommendAutoplayHandler.ts
+++ b/registry/lib/components/video/player/custom-auto-play/handlers/RecommendAutoplayHandler.ts
@@ -1,0 +1,25 @@
+import { matchUrlPattern } from '@/core/utils'
+import { AutoplayActionType } from '../AutoplayActionType'
+import { BaseAutoplayHandler } from './BaseAutoplayHandler'
+
+/** 自动连播处理器-推荐视频 */
+export class RecommendAutoplayHandler extends BaseAutoplayHandler {
+  type = '推荐视频'
+
+  async match() {
+    const videoUrl = '//www.bilibili.com/video/'
+    const btn = document.querySelector('.recommend-list-v1 .switch-btn')
+    return matchUrlPattern(videoUrl) && btn !== null
+  }
+
+  async shouldAutoplay() {
+    return BaseAutoplayHandler.shouldAutoplayWithAutoHandler(
+      BaseAutoplayHandler.settings.options.recommendAutoplayAction as AutoplayActionType,
+      () => false,
+    )
+  }
+
+  async setupAutoPlay(enable: boolean) {
+    await this.setupAutoPlay_SwitchBtn(enable)
+  }
+}

--- a/registry/lib/components/video/player/custom-auto-play/handlers/WatchLaterAutoplayHandler.ts
+++ b/registry/lib/components/video/player/custom-auto-play/handlers/WatchLaterAutoplayHandler.ts
@@ -1,0 +1,28 @@
+import { matchUrlPattern } from '@/core/utils'
+import { watchlaterUrls } from '@/core/utils/urls'
+import { AutoplayActionType } from '../AutoplayActionType'
+import { BaseAutoplayHandler } from './BaseAutoplayHandler'
+
+/** 自动连播处理器-稍后再看 */
+export class WatchLaterAutoplayHandler extends BaseAutoplayHandler {
+  type = '稍后再看'
+
+  async match() {
+    return watchlaterUrls.some(url => matchUrlPattern(url))
+  }
+
+  protected override getSequentialNumberString(): string {
+    return document.querySelector('.list-count').innerHTML
+  }
+
+  async shouldAutoplay() {
+    return BaseAutoplayHandler.shouldAutoplayWithAutoHandler(
+      BaseAutoplayHandler.settings.options.watchLaterAutoplayAction as AutoplayActionType,
+      () => !this.isLastSequentialNumber(),
+    )
+  }
+
+  async setupAutoPlay(enable: boolean) {
+    await this.setupAutoPlay_SwitchBtn(enable)
+  }
+}

--- a/registry/lib/components/video/player/custom-auto-play/index.ts
+++ b/registry/lib/components/video/player/custom-auto-play/index.ts
@@ -13,6 +13,7 @@ import { FavoriteAutoplayHandler } from './handlers/FavoriteAutoplayHandler'
 import { PlaylistAutoplayHandler } from './handlers/PlaylistAutoplayHandler'
 import { RecommendAutoplayHandler } from './handlers/RecommendAutoplayHandler'
 import { WatchLaterAutoplayHandler } from './handlers/WatchLaterAutoplayHandler'
+import { MultipartAutoplayHandler } from './handlers/MultipartAutoplayHandler'
 
 export const logger = useScopedConsole('定制自动连播行为')
 
@@ -38,6 +39,7 @@ const entry: ComponentEntry = async ({ metadata, settings }) => {
   function registerHandlers() {
     BaseAutoplayHandler.register(new BangumiAutoplayHandler())
     BaseAutoplayHandler.register(new FavoriteAutoplayHandler())
+    BaseAutoplayHandler.register(new MultipartAutoplayHandler())
     BaseAutoplayHandler.register(new PlaylistAutoplayHandler())
     BaseAutoplayHandler.register(new RecommendAutoplayHandler())
     BaseAutoplayHandler.register(new WatchLaterAutoplayHandler())
@@ -97,8 +99,13 @@ export const component = defineComponentMetadata({
       defaultValue: AutoplayActionType.AUTO,
       dropdownEnum: AutoplayActionType,
     },
-    playlistAutoplayAction: {
+    multipartAutoplayAction: {
       displayName: '自动连播行为-分p视频',
+      defaultValue: AutoplayActionType.AUTO,
+      dropdownEnum: AutoplayActionType,
+    },
+    playlistAutoplayAction: {
+      displayName: '自动连播行为-视频合集',
       defaultValue: AutoplayActionType.AUTO,
       dropdownEnum: AutoplayActionType,
     },

--- a/registry/lib/components/video/player/custom-auto-play/index.ts
+++ b/registry/lib/components/video/player/custom-auto-play/index.ts
@@ -1,289 +1,20 @@
 import { defineComponentMetadata } from '@/components/define'
 import { ComponentEntry } from '@/components/types'
-import { bangumiUrls, favoriteListUrls, videoUrls, watchlaterUrls } from '@/core/utils/urls'
+import { bangumiUrls, videoUrls } from '@/core/utils/urls'
 import { useScopedConsole } from '@/core/utils/log'
-import { select, sq } from '@/core/spin-query'
-import { matchUrlPattern, playerReady } from '@/core/utils'
-import { getVueData } from '@/components/feeds/api'
-import { addComponentListener, ComponentSettings } from '@/core/settings'
+import { select } from '@/core/spin-query'
+import { playerReady } from '@/core/utils'
+import { addComponentListener } from '@/core/settings'
 import { childListSubtree } from '@/core/observer'
+import { BaseAutoplayHandler } from './handlers/BaseAutoplayHandler'
+import { AutoplayActionType } from './AutoplayActionType'
+import { BangumiAutoplayHandler } from './handlers/BangumiAutoplayHandler'
+import { FavoriteAutoplayHandler } from './handlers/FavoriteAutoplayHandler'
+import { PlaylistAutoplayHandler } from './handlers/PlaylistAutoplayHandler'
+import { RecommendAutoplayHandler } from './handlers/RecommendAutoplayHandler'
+import { WatchLaterAutoplayHandler } from './handlers/WatchLaterAutoplayHandler'
 
-const logger = useScopedConsole('定制自动连播行为')
-
-/** 自动连播行为类型 */
-enum AutoplayActionType {
-  /** 自动判断，参考《传统连播模式》组件 */
-  AUTO = '自动',
-  /** 禁用自动连播 */
-  DISABLE = '禁用',
-  /** 总是自动连播 */
-  ALWAYS = '总是',
-}
-
-// #region 自动连播处理器
-
-/** 自动连播处理器基类 */
-abstract class BaseAutoplayHandler {
-  // #region 初始化
-
-  /** 脚本设置 */
-  static settings: ComponentSettings
-
-  /** 自动连播处理器实例列表 */
-  protected static handlers: BaseAutoplayHandler[] = []
-
-  /** 添加自动连播处理器实例到列表 */
-  static register(handler: BaseAutoplayHandler) {
-    BaseAutoplayHandler.handlers.push(handler)
-  }
-
-  /** 获取匹配当前页面的自动连播处理器实例 */
-  static async getHandler(): Promise<BaseAutoplayHandler | null> {
-    for (const handler of BaseAutoplayHandler.handlers) {
-      if (await handler.match()) {
-        return handler
-      }
-    }
-
-    return null
-  }
-
-  // #endregion
-
-  // #region 抽象
-
-  /** 自动连播类型 */
-  abstract type: string
-
-  /** 处理器是否适用当前页面 */
-  abstract match(): Promise<boolean>
-
-  /** 是否应启用自动连播 */
-  abstract shouldAutoplay(): Promise<boolean>
-
-  /**
-   * 设置自动连播状态
-   * @param enable true：启用，false：禁用
-   */
-  abstract setupAutoPlay(enable: boolean): Promise<void>
-
-  // #endregion
-
-  // #region 工具方法
-
-  /**
-   * 默认连播方式判断，自动连播行为类型为AUTO时使用回调处理
-   * @param actionType 自动连播行为类型
-   * @param autoTypeHandler 自动连播行为类型为AUTO时的处理回调
-   * @returns 是否应该自动连播
-   */
-  static shouldAutoplayWithAutoHandler(
-    actionType: AutoplayActionType,
-    autoTypeHandler: () => boolean,
-  ): boolean {
-    switch (actionType) {
-      case AutoplayActionType.ALWAYS:
-        return true
-      case AutoplayActionType.DISABLE:
-        return false
-      case AutoplayActionType.AUTO:
-      default:
-        return autoTypeHandler()
-    }
-  }
-
-  /**
-   * 获取分P序号文本
-   * @returns 例如：'1/10' 或 '（1/10）'
-   */
-  protected getSequentialNumberString(): string {
-    return ''
-  }
-
-  /**
-   * 解析分P序号
-   * @returns 例如：[1,10]
-   */
-  protected parseSequentialNumbers(): number[] {
-    return this.getSequentialNumberString()
-      .replace(/[（）()]/g, '')
-      .split('/')
-      .map(it => parseInt(it))
-  }
-
-  /** 是否最后1P视频 */
-  protected isLastSequentialNumber(): boolean {
-    const sequentialNumbers = this.parseSequentialNumbers()
-    if (!sequentialNumbers || sequentialNumbers.length < 2) {
-      return true
-    }
-    return sequentialNumbers[0] >= sequentialNumbers[1]
-  }
-
-  /** 设置自动连播按钮状态（位于右上角） */
-  protected async setupAutoPlay_SwitchBtn(enableAutoplay: boolean) {
-    sq(() => {
-      try {
-        const app = document.getElementById('app')
-        const vueInstance = getVueData(app)
-        vueInstance.setContinuousPlay(enableAutoplay)
-        return true
-      } catch (e) {
-        logger.debug(`${this.constructor.name}：设置自动连播按钮状态发生错误，错误信息：${e}`)
-        return false
-      }
-    })
-  }
-
-  /** 设置番剧自动连播状态 */
-  protected async setupAutoPlay_Player(enableAutoplay: boolean) {
-    const selector = enableAutoplay
-      ? '.bpx-player-ctrl-setting-handoff input[type="radio"][value="0"]'
-      : '.bpx-player-ctrl-setting-handoff input[type="radio"][value="2"]'
-    const radio = (await select(selector)) as HTMLInputElement
-
-    if (radio === null) {
-      logger.error(`${this.constructor.name}：未找到对应的播放方式按钮`)
-    }
-    radio.click()
-  }
-
-  // #endregion
-}
-
-// #region 子类实现
-
-/** 自动连播处理器-番剧 */
-class BangumiAutoplayHandler extends BaseAutoplayHandler {
-  type = '番剧'
-
-  async match() {
-    return bangumiUrls.some(url => matchUrlPattern(url))
-  }
-
-  protected override isLastSequentialNumber(): boolean {
-    // PV、小剧场没有分P序号，因此统一用元素位置判断
-    const el = document
-      .querySelector('.plp-r img[class^=PlayingIcon_playIcon]')
-      .closest('div[class^=imageListItem_wrap]')
-    return !el.nextElementSibling
-  }
-
-  async shouldAutoplay() {
-    return BaseAutoplayHandler.shouldAutoplayWithAutoHandler(
-      BaseAutoplayHandler.settings.options.bangumiAutoplayAction as AutoplayActionType,
-      () => !this.isLastSequentialNumber(),
-    )
-  }
-
-  async setupAutoPlay(enable: boolean) {
-    await this.setupAutoPlay_Player(enable)
-  }
-}
-BaseAutoplayHandler.register(new BangumiAutoplayHandler())
-
-/** 自动连播处理器-推荐视频 */
-class RecommendAutoplayHandler extends BaseAutoplayHandler {
-  type = '推荐视频'
-
-  async match() {
-    const videoUrl = '//www.bilibili.com/video/'
-    const btn = document.querySelector('.recommend-list-v1 .switch-btn')
-    return matchUrlPattern(videoUrl) && btn !== null
-  }
-
-  async shouldAutoplay() {
-    return BaseAutoplayHandler.shouldAutoplayWithAutoHandler(
-      BaseAutoplayHandler.settings.options.recommendAutoplayAction as AutoplayActionType,
-      () => false,
-    )
-  }
-
-  async setupAutoPlay(enable: boolean) {
-    await this.setupAutoPlay_SwitchBtn(enable)
-  }
-}
-BaseAutoplayHandler.register(new RecommendAutoplayHandler())
-
-/** 自动连播处理器-稍后再看 */
-class WatchLaterAutoplayHandler extends BaseAutoplayHandler {
-  type = '稍后再看'
-
-  async match() {
-    return watchlaterUrls.some(url => matchUrlPattern(url))
-  }
-
-  protected override getSequentialNumberString(): string {
-    return document.querySelector('.list-count').innerHTML
-  }
-
-  async shouldAutoplay() {
-    return BaseAutoplayHandler.shouldAutoplayWithAutoHandler(
-      BaseAutoplayHandler.settings.options.watchLaterAutoplayAction as AutoplayActionType,
-      () => !this.isLastSequentialNumber(),
-    )
-  }
-
-  async setupAutoPlay(enable: boolean) {
-    await this.setupAutoPlay_SwitchBtn(enable)
-  }
-}
-BaseAutoplayHandler.register(new WatchLaterAutoplayHandler())
-
-/** 自动连播处理器-分P视频 */
-class PlaylistAutoplayHandler extends BaseAutoplayHandler {
-  type = '分P视频'
-
-  async match() {
-    const videoUrl = '//www.bilibili.com/video/'
-    const btn = document.querySelector('.video-pod .auto-play .switch-btn')
-    return matchUrlPattern(videoUrl) && btn !== null
-  }
-
-  protected override getSequentialNumberString(): string {
-    return document.querySelector('.video-pod__header .amt').innerHTML
-  }
-
-  async shouldAutoplay() {
-    return BaseAutoplayHandler.shouldAutoplayWithAutoHandler(
-      BaseAutoplayHandler.settings.options.playlistAutoplayAction as AutoplayActionType,
-      () => !this.isLastSequentialNumber(),
-    )
-  }
-
-  async setupAutoPlay(enable: boolean) {
-    await this.setupAutoPlay_SwitchBtn(enable)
-  }
-}
-BaseAutoplayHandler.register(new PlaylistAutoplayHandler())
-
-/** 自动连播处理器-收藏夹 */
-class FavoriteAutoplayHandler extends BaseAutoplayHandler {
-  type = '收藏夹'
-
-  async match() {
-    return favoriteListUrls.some(url => matchUrlPattern(url))
-  }
-
-  protected override getSequentialNumberString(): string {
-    return document.querySelector('.list-count').innerHTML
-  }
-
-  async shouldAutoplay() {
-    return BaseAutoplayHandler.shouldAutoplayWithAutoHandler(
-      BaseAutoplayHandler.settings.options.favoriteAutoplayAction as AutoplayActionType,
-      () => !this.isLastSequentialNumber(),
-    )
-  }
-
-  async setupAutoPlay(enable: boolean) {
-    await this.setupAutoPlay_SwitchBtn(enable)
-  }
-}
-BaseAutoplayHandler.register(new FavoriteAutoplayHandler())
-// #endregion
-
-// #endregion
+export const logger = useScopedConsole('定制自动连播行为')
 
 const entry: ComponentEntry = async ({ metadata, settings }) => {
   /** 每次视频切换时的初始化逻辑 */
@@ -303,8 +34,18 @@ const entry: ComponentEntry = async ({ metadata, settings }) => {
     await handler.setupAutoPlay(enable)
   }
 
+  /** 注册自动播放处理器 */
+  function registerHandlers() {
+    BaseAutoplayHandler.register(new BangumiAutoplayHandler())
+    BaseAutoplayHandler.register(new FavoriteAutoplayHandler())
+    BaseAutoplayHandler.register(new PlaylistAutoplayHandler())
+    BaseAutoplayHandler.register(new RecommendAutoplayHandler())
+    BaseAutoplayHandler.register(new WatchLaterAutoplayHandler())
+  }
+
   // 入口代码
 
+  registerHandlers()
   BaseAutoplayHandler.settings = settings
   const debounce = lodash.debounce(initScript, 1000)
 


### PR DESCRIPTION
更新内容如下（按commit先后顺序）：

- 将之前各类型页面逻辑处理的类移动到独立文件，仅import、export之类的必要修改，类内部代码无变更（本来想加个装饰器自动实例化，没有引用的话就触发不了，搞半天终于还是和解了，~~GPT还是救不了菜鸡~~）
- 将视频合集（不同BV号）与分P视频（同一BV号）页面拆分为两个选项独立控制
- 修复番剧正片为纯数字列表（以前好像只有图片列表？记不得了）时自动模式失效