### PR TITLE
【组件-网址参数清理】添加新的清理规则

### DIFF
--- a/registry/lib/components/utils/url-params-clean/anchor.ts
+++ b/registry/lib/components/utils/url-params-clean/anchor.ts
@@ -64,7 +64,11 @@ export const cleanAnchors = async (getCleanUrl: (u: string) => string) => {
     })
 
     // 视频推荐列表
-    observe(dq('.rcmd-tab'), observeChildListSubtreeHref, cleanMutationAnchors)
+    observe(
+      dq('.rcmd-tab,.playlist-container--right'),
+      observeChildListSubtreeHref,
+      cleanMutationAnchors,
+    )
 
     // 评论区
     forEachCommentArea(async area => {

--- a/registry/lib/components/utils/url-params-clean/anchor.ts
+++ b/registry/lib/components/utils/url-params-clean/anchor.ts
@@ -64,8 +64,9 @@ export const cleanAnchors = async (getCleanUrl: (u: string) => string) => {
     })
 
     // 视频推荐列表
+    cleanAll(dqa('.recommend-list-container a'))
     observe(
-      dq('.rcmd-tab,.playlist-container--right'),
+      dq('.rcmd-tab,.recommend-list-container'),
       observeChildListSubtreeHref,
       cleanMutationAnchors,
     )

--- a/registry/lib/components/utils/url-params-clean/index.ts
+++ b/registry/lib/components/utils/url-params-clean/index.ts
@@ -143,13 +143,7 @@ const entry = async () => {
     })
     const query = filteredParamsString ? `?${filteredParamsString}` : ''
     url.search = query
-
-    // 移除末尾'/'
-    const urlString = url.toString()
-    if (urlString.endsWith('/')) {
-      return urlString.slice(0, -1)
-    }
-    return urlString
+    return url.toString()
   }
 
   const createHistoryHook = (

--- a/registry/lib/components/utils/url-params-clean/index.ts
+++ b/registry/lib/components/utils/url-params-clean/index.ts
@@ -71,6 +71,8 @@ const entry = async () => {
     'launch_id',
     'spmid',
     'trackid',
+    'from_avid',
+    'from_comid',
   ]
   const [blockParams] = registerAndGetData('urlParamsClean.params', builtInBlockParams)
   const builtInSiteSpecifiedParams = [

--- a/registry/lib/components/utils/url-params-clean/index.ts
+++ b/registry/lib/components/utils/url-params-clean/index.ts
@@ -143,7 +143,13 @@ const entry = async () => {
     })
     const query = filteredParamsString ? `?${filteredParamsString}` : ''
     url.search = query
-    return url.toString()
+
+    // 移除末尾'/'
+    const urlString = url.toString()
+    if (urlString.endsWith('/')) {
+      return urlString.slice(0, -1)
+    }
+    return urlString
   }
 
   const createHistoryHook = (

--- a/registry/lib/components/utils/url-params-clean/index.ts
+++ b/registry/lib/components/utils/url-params-clean/index.ts
@@ -70,6 +70,7 @@ const entry = async () => {
     'popular_rank',
     'launch_id',
     'spmid',
+    'trackid',
   ]
   const [blockParams] = registerAndGetData('urlParamsClean.params', builtInBlockParams)
   const builtInSiteSpecifiedParams = [


### PR DESCRIPTION
主要修改如下 ：

- 添加新的追踪参数清理（#5401，#5391）
- 收藏、稍后再看页面的推荐列表清理（目前刷新页面有机率清理不掉参数，等后面有空再排查了。。。）
