### PR TITLE
player-on-top-new: handle mini player correctly

### DIFF
--- a/registry/lib/components/style/player-on-top-new/index.ts
+++ b/registry/lib/components/style/player-on-top-new/index.ts
@@ -52,9 +52,11 @@ function sideEffect() {
     (ev: ReturnType<typeof createPlayerModeChangeEvent>) => {
       const { mode } = ev.detail
 
-      currentMode = mode
+      if (mode !== 'mini') {
+        currentMode = mode
+      }
 
-      if (mode === 'wide') {
+      if (currentMode === 'wide') {
         danmuku.style.marginTop = '0px'
         author.style.marginTop = calcMarginTop()
       } else {

--- a/src/components/video/player-adaptor/bpx.ts
+++ b/src/components/video/player-adaptor/bpx.ts
@@ -20,6 +20,7 @@ const playerModePolyfill = async () => {
       PlayerMode.WideScreen,
       PlayerMode.WebFullscreen,
       PlayerMode.Fullscreen,
+      PlayerMode.Mini,
     ].map(it => `${prefix}${it}`)
 
     // clear all class

--- a/src/components/video/player-adaptor/events.ts
+++ b/src/components/video/player-adaptor/events.ts
@@ -3,6 +3,7 @@ export enum PlayerMode {
   WideScreen = 'wide',
   WebFullscreen = 'web',
   Fullscreen = 'full',
+  Mini = 'mini',
 }
 
 export const createPlayerModeChangeEvent = (mode: PlayerMode) =>


### PR DESCRIPTION
你好，

当前该组件可能存在一个问题，即当主播放器是 wide 且启用了小窗（pip）的情况下，在播放器切换到小窗时（例如向下滚动到评论区），右侧边栏的 margin-top 会被错误设置为 0px，导致内容跳跃（突然上移1000px左右）。正确行为应该为遵循之前的模式的位置，例如，之前如果是 wide，则在切换到小窗时继续保持 wide 的 margin。

简单修复了一下。在本地开发测试，修复后行为正常。

第一次PR，如果有问题还请指教。