### PR TITLE
为下载文件自定义文件命名添加了up主的uid选项

### DIFF
--- a/src/components/settings-panel/index.md
+++ b/src/components/settings-panel/index.md
@@ -16,7 +16,7 @@
 - `aid`: AV 号
 - `bvid`: BV 号
 - `cid`: CID (每个视频的唯一编号, AV 号对应的视频可能有多集)
-- `upuid`: 视频UP主的uid
+- `userID`: 视频UP主的uid
 - `lid`: 直播间号
 - `y`/`M`/`d`: 年/月/日
 - `h`/`m`/`s`/`ms`: 时/分/秒/毫秒

--- a/src/core/utils/title.ts
+++ b/src/core/utils/title.ts
@@ -104,9 +104,26 @@ export const formatTitle = (
       }
       return undefined
     })(),
-    upuid: (() => {
-      const link = (dq('a.avatar') || dq('a.up-avatar')) as HTMLAnchorElement
-      return link?.href?.replace(/.*space\.bilibili\.com\/(\d+).*/, '$1') || '未知UID'
+    userID: (() => {
+      // 先按照单人投稿获取userID
+      const normalLink = dq('a.up-name') as HTMLAnchorElement
+      if (normalLink?.href) {
+        return normalLink.href.replace(/.*space\.bilibili\.com\/(\d+).*/, '$1')
+      }
+      // 联合投稿userID通过staff-info中text对比单独获取
+      const upStaffInfo = Array.from(document.querySelectorAll<HTMLDivElement>('.staff-info')).find(
+        div => {
+          const tag = div.querySelector<HTMLSpanElement>('.info-tag')
+          return tag?.textContent?.trim() === 'UP主'
+        },
+      )
+      if (upStaffInfo) {
+        const link = upStaffInfo.querySelector<HTMLAnchorElement>('a.staff-name')
+        if (link?.href) {
+          return link.href.replace(/.*space\.bilibili\.com\/(\d+).*/, '$1')
+        }
+      }
+      return undefined
     })(),
     aid: unsafeWindow.aid,
     bvid: unsafeWindow.bvid,


### PR DESCRIPTION
为通用设置中的：自定义文件命名格式 添加了视频UP主的uid变量，方便通过文件名记录视频的作者是谁，并且在说明文件中添加了新变量的说明。
考虑到有单人投稿和联合投稿，使用avatar up-avatar标签下的头像链接提取uid
本地工程测试功能正常，代码变更点ESLint检测正常
<img width="945" height="165" alt="image" src="https://github.com/user-attachments/assets/d2896820-8c32-4d85-94f5-200950059bee" />
