### PR TITLE
feat(快捷键扩展): 添加视频进度按百分比跳转

### DIFF
--- a/registry/lib/components/utils/keymap/actions.ts
+++ b/registry/lib/components/utils/keymap/actions.ts
@@ -234,10 +234,6 @@ export const builtInActions: Record<string, KeyBindingAction> = {
       return true
     },
   },
-  seekBegin: {
-    displayName: '回开头',
-    run: () => playerAgent.seek(0),
-  },
   sendComment: {
     displayName: '发送评论',
     ignoreTyping: false,
@@ -274,5 +270,22 @@ export const builtInActions: Record<string, KeyBindingAction> = {
       return true
     },
   },
+  seekBegin: {
+    displayName: '回开头',
+    run: () => playerAgent.seek(0),
+  },
+  /** 10% - 90% 的跳转动作 */
+  ...lodash.fromPairs(
+    lodash.range(1, 10).map(i => [
+      `seekProgress${i}0`,
+      {
+        displayName: `跳转到 ${i}0%`,
+        run: () => {
+          const duration = (playerAgent.query.video.element.sync() as HTMLVideoElement)?.duration
+          return duration ? (playerAgent.seek(duration * i * 0.1), true) : null
+        },
+      } as KeyBindingAction,
+    ]),
+  ),
 }
 export const [actions] = registerAndGetData('keymap.actions', builtInActions)

--- a/registry/lib/components/utils/keymap/index.ts
+++ b/registry/lib/components/utils/keymap/index.ts
@@ -22,6 +22,11 @@ const options = defineOptionsMetadata({
     displayName: '音量调整幅度',
     validator: getNumberValidator(1, 100),
   },
+  /** 是否显示跳转快捷键 */
+  showSeekShortcuts: {
+    defaultValue: true,
+    displayName: '显示跳转快捷键',
+  },
   customKeyBindings: {
     defaultValue: {} as Record<string, string>,
     displayName: '自定义键位',

--- a/registry/lib/components/utils/keymap/presets.ts
+++ b/registry/lib/components/utils/keymap/presets.ts
@@ -19,6 +19,10 @@ export const presetBase: Record<string, string> = {
   jumpForward: '',
   danmaku: 'd',
   seekBegin: '0',
+  // 1-9 跳转到对应百分比
+  ...lodash.fromPairs(
+    lodash.range(1, 10).map(i => [`seekProgress${i}0`, String(i)]),
+  ),
   sendComment: 'ctrl enter',
 }
 export const builtInPresets: Record<string, Record<string, string>> = {
@@ -29,6 +33,10 @@ export const builtInPresets: Record<string, Record<string, string>> = {
     longJumpForward: 'l',
     longJumpBackward: 'j',
     seekBegin: '0 Home',
+    // 1-9 跳转到对应百分比
+    ...lodash.fromPairs(
+      lodash.range(1, 10).map(i => [`seekProgress${i}0`, String(i)])
+    ),
   },
   HTML5Player: {
     coin: 'shift c',

--- a/registry/lib/components/utils/keymap/settings/KeymapSettings.vue
+++ b/registry/lib/components/utils/keymap/settings/KeymapSettings.vue
@@ -89,10 +89,19 @@ export default Vue.extend({
       },
     },
     rows() {
-      return Object.entries(this.actions).map(([name, action]) => ({
-        name,
-        ...(action as KeyBindingAction),
-      }))
+      const { showSeekShortcuts } = keymapOptions
+      return Object.entries(this.actions)
+        .map(([name, action]) => ({
+          name,
+          ...(action as KeyBindingAction),
+        }))
+        .filter(action => {
+          // 如果是跳转百分比的动作，仅在开启显示时显示
+          if (action.name.startsWith('seekProgress')) {
+            return showSeekShortcuts
+          }
+          return true
+        })
     },
     presetOptions() {
       return Object.keys(this.presets)


### PR DESCRIPTION
feat(快捷键扩展): 添加视频进度百分比跳转

- 受 youtube 启发，添加了按百分比跳转视频进度的快捷键（默认为 0-9）。
- 为了防止过多键位设置干扰用户视线，将跳转相关键位设置移到了最后，并添加了显示/隐藏跳转快捷键的开关（隐藏后按键仍然生效）。

<img width="572" height="918" alt="image" src="https://github.com/user-attachments/assets/ecadce90-d678-454f-898c-44c79be692a3" />
<img width="275" height="354" alt="image" src="https://github.com/user-attachments/assets/7ed3b637-b68c-4857-a20c-227fce3cfd9f" />
