### PR TITLE
Fix regex pattern for roomId in Widget.vue

### DIFF
--- a/registry/lib/components/utils/download-emoticons/Widget.vue
+++ b/registry/lib/components/utils/download-emoticons/Widget.vue
@@ -23,7 +23,7 @@ export default Vue.extend({
   data() {
     return {
       downloading: false,
-      roomIdRegex: /^https:\/\/live\.bilibili\.com\/(?:blanc\/)?(\d+)(?:\?\.*?)?$/,
+      roomIdRegex: /^https:\/\/live\.bilibili\.com\/(?:blanc\/)?(\d+)(?:\?.*?)?$/,
     }
   },
   methods: {


### PR DESCRIPTION
原先情况下，\\.*  匹配  "." , 不匹配任意字符，按照b站url的情况下，它应该是匹配任意字符，所以我去掉了 “\”

<!-- 可以参考下代码贡献指南: https://github.com/the1812/Bilibili-Evolved/blob/preview/CONTRIBUTING.md -->
