### PR TITLE
feat: 个人空间查看头像

### DIFF
--- a/registry/lib/components/utils/view-avatar/ViewAvatar.vue
+++ b/registry/lib/components/utils/view-avatar/ViewAvatar.vue
@@ -1,0 +1,109 @@
+<template>
+  <DefaultWidget
+    name="查看头像"
+    icon="mdi-account-circle-outline"
+    @click="viewAvatar()"
+  ></DefaultWidget>
+</template>
+
+<script lang="ts">
+import { getJson } from '@/core/ajax'
+import { select } from '@/core/spin-query'
+import { Toast } from '@/core/toast'
+import { DefaultWidget, showImage } from '@/ui'
+
+type SpaceCardResponse = {
+  data?: {
+    card?: {
+      face?: string
+    }
+  }
+}
+
+const getUid = () => {
+  const match = location.href.match(/space\.bilibili\.com\/(\d+)/)
+  return match?.[1] ?? null
+}
+
+const normalizeAvatarUrl = (url: string) => {
+  const httpsUrl = url.startsWith('//') ? `https:${url}` : url.replace('http:', 'https:')
+  return httpsUrl.replace(/@[^/?]+(?=($|[?#]))/, '')
+}
+
+const avatarSelectors = ['.space-header img[src*="/bfs/face/"]', '.h-avatar img']
+
+const getAvatarUrlFromDom = () => {
+  for (const selector of avatarSelectors) {
+    const element = document.querySelector(selector)
+    if (!(element instanceof HTMLImageElement)) {
+      continue
+    }
+    if (element.src) {
+      return normalizeAvatarUrl(element.src)
+    }
+  }
+  return ''
+}
+
+const getAvatarUrlFromApi = async (uid: string) => {
+  const cardJson = await getJson<SpaceCardResponse>(
+    `https://api.bilibili.com/x/web-interface/card?mid=${uid}`,
+  )
+  const cardFace = cardJson.data?.card?.face
+  return cardFace ? normalizeAvatarUrl(cardFace) : ''
+}
+
+export default Vue.extend({
+  components: {
+    DefaultWidget,
+  },
+  data() {
+    return {
+      imageUrl: '',
+      loading: true,
+    }
+  },
+  async mounted() {
+    await this.resolveImageUrl()
+  },
+  methods: {
+    async resolveImageUrl() {
+      const uid = getUid()
+      if (!uid) {
+        this.loading = false
+        return
+      }
+      try {
+        this.loading = true
+        this.imageUrl = getAvatarUrlFromDom()
+        if (this.imageUrl) {
+          return
+        }
+
+        const domAvatar = await select(() => getAvatarUrlFromDom() || null, {
+          maxRetry: 8,
+          queryInterval: 300,
+        })
+        this.imageUrl = domAvatar ?? ''
+        if (this.imageUrl) {
+          return
+        }
+
+        this.imageUrl = await getAvatarUrlFromApi(uid)
+      } finally {
+        this.loading = false
+      }
+    },
+    async viewAvatar() {
+      if (!this.imageUrl) {
+        await this.resolveImageUrl()
+      }
+      if (!this.imageUrl) {
+        Toast.error('未能获取当前用户头像地址', '查看头像', 3000)
+        return
+      }
+      showImage(this.imageUrl)
+    },
+  },
+})
+</script>

--- a/registry/lib/components/utils/view-avatar/index.ts
+++ b/registry/lib/components/utils/view-avatar/index.ts
@@ -1,0 +1,21 @@
+import { defineComponentMetadata } from '@/components/define'
+
+export const component = defineComponentMetadata({
+  name: 'viewAvatar',
+  displayName: '查看头像',
+  author: {
+    name: 'Chains.Z',
+    link: 'https://github.com/Chains-Z',
+  },
+  tags: [componentsTags.utils],
+  entry: none,
+  reload: none,
+  unload: none,
+  widget: {
+    component: () => import('./ViewAvatar.vue').then(m => m.default),
+  },
+  description: {
+    'zh-CN': '在个人空间页面中, 可从功能面板中查看当前用户的高分辨率头像.',
+  },
+  urlInclude: [/^https:\/\/space\.bilibili\.com\/\d+(?:[/?#]|$)/],
+})


### PR DESCRIPTION
## 简介

  新增 `view-avatar` 组件，在个人空间页面的功能面板中提供“查看头像”按钮。

  ## 实现

  - 优先读取空间页头像 DOM
  - DOM 未就绪时短暂等待异步渲染
  - DOM 仍不可用时回退到 `x/web-interface/card?mid=` 的 `data.card.face`
  - 点击后使用内置图片查看器展示高清头像

  ## 验证

  - `pnpm exec eslint registry/lib/components/utils/view-avatar/index.ts registry/lib/components/utils/view-avatar/ViewAvatar.vue --ext .ts,.vue`
  - `pnpm exec tsc -p tsconfig.type-check.json --noEmit`
  - 本地开发环境下手动验证个人空间页按钮显示与头像预览正常