### PR TITLE
记忆合集内置快捷键功能等功能改进

### DIFF
--- a/registry/lib/components/video/player/remember-video-collection/Widget.vue
+++ b/registry/lib/components/video/player/remember-video-collection/Widget.vue
@@ -187,14 +187,14 @@ export default Vue.extend({
     this.unsubscribe = null
   },
   methods: {
-    handleJumpLast() {
-      if (jumpToRememberedVideo()) {
+    async handleJumpLast() {
+      if (await jumpToRememberedVideo()) {
         this.confirmClearAll = false
         this.open = false
       }
     },
-    handleJumpNext() {
-      if (jumpToRememberedNextVideo()) {
+    async handleJumpNext() {
+      if (await jumpToRememberedNextVideo()) {
         this.confirmClearAll = false
         this.open = false
       }

--- a/registry/lib/components/video/player/remember-video-collection/Widget.vue
+++ b/registry/lib/components/video/player/remember-video-collection/Widget.vue
@@ -6,9 +6,9 @@
       :trigger-element="$refs.button"
     >
       <div class="be-rvc-widget-panel">
-        <div class="be-rvc-widget-title">播放记忆</div>
+        <div class="be-rvc-widget-title">合集记忆</div>
 
-        <div class="be-rvc-widget-tabs" role="tablist" aria-label="播放记忆功能页签">
+        <div class="be-rvc-widget-tabs" role="tablist" aria-label="合集记忆功能页签">
           <button
             type="button"
             class="be-rvc-widget-tab"
@@ -77,7 +77,7 @@
             </VButton>
             <template v-if="confirmClearAll">
               <div class="be-rvc-widget-danger-tip">
-                这是危险操作，会清除所有播放记忆。确认后无法恢复。
+                这是危险操作，会清除所有合集记忆。确认后无法恢复。
               </div>
               <div class="be-rvc-widget-danger-actions">
                 <VButton
@@ -104,7 +104,7 @@
       </div>
     </VPopup>
     <DefaultWidget ref="button" icon="mdi-history" @click="open = !open">
-      <span>播放记忆</span>
+      <span>合集记忆</span>
     </DefaultWidget>
   </div>
 </template>
@@ -143,13 +143,13 @@ export default Vue.extend({
       if (this.state.lastPlayedLabel) {
         return this.state.lastPlayedLabel
       }
-      return this.state.available ? '当前作用域暂无上次播放记录' : '当前页面没有可用的播放记忆'
+      return this.state.available ? '当前作用域暂无上次播放记录' : '当前页面没有可用的合集记忆'
     },
     nextText(): string {
       if (this.state.nextLabel) {
         return this.state.nextLabel
       }
-      return this.state.available ? '没有可跳转的下一个视频' : '当前页面没有可用的播放记忆'
+      return this.state.available ? '没有可跳转的下一个视频' : '当前页面没有可用的合集记忆'
     },
     scopeSummaryPrefixText(): string {
       if (this.state.scopeTitle) {

--- a/registry/lib/components/video/player/remember-video-collection/dom.ts
+++ b/registry/lib/components/video/player/remember-video-collection/dom.ts
@@ -1,8 +1,12 @@
 import { childListSubtree } from '@/core/observer'
+import { sq } from '@/core/spin-query'
 import type { MarkingInstruction } from './types'
 
 const SELECTOR_VIDEO_POD_LIST = '.video-pod__list'
 const SELECTOR_VIDEO_POD = '.video-pod'
+const SELECTOR_VIDEO_POD_SLIDE = '.video-pod__slide'
+const SELECTOR_VIDEO_POD_SLIDE_ITEM = '.slide-item[data-slide-value]'
+const SELECTOR_VIDEO_POD_SLIDE_ITEM_ACTIVE = '.slide-item.active[data-slide-value]'
 
 export const getVideoPodElement = () => dq(SELECTOR_VIDEO_POD)
 
@@ -12,6 +16,14 @@ export const getPodItemElement = (key: string) =>
 export const getMarkedElements = (classes: string[]) => dqa(`.${classes.join(', .')}`)
 
 export const getPodItemById = (id: string) => getPodItemElement(id)
+
+const getSlideItemElement = (id: string) =>
+  dq(
+    `${SELECTOR_VIDEO_POD_SLIDE} ${SELECTOR_VIDEO_POD_SLIDE_ITEM}[data-slide-value="${id}"]`,
+  ) as HTMLElement | null
+
+const getActiveSlideItemElement = () =>
+  dq(`${SELECTOR_VIDEO_POD_SLIDE} ${SELECTOR_VIDEO_POD_SLIDE_ITEM_ACTIVE}`) as HTMLElement | null
 
 export const isHasMultiPagePodItem = (element: Element) =>
   element.firstElementChild ? element.firstElementChild.classList.contains('multi-p') : false
@@ -50,12 +62,15 @@ export const clickPodItemById = (id: string) => {
   return true
 }
 
-export const clickInstructionTarget = (
-  instruction: Pick<MarkingInstruction, 'bvid' | 'cid' | 'page'>,
-) => {
-  const ids = [instruction.bvid, instruction.cid]
+const getInstructionIds = (instruction: Pick<MarkingInstruction, 'bvid' | 'cid'>) =>
+  [instruction.bvid, instruction.cid]
     .filter((id): id is string | number => id !== undefined && id !== null)
     .map(String)
+
+const getInstructionClickableElementInCurrentTab = (
+  instruction: Pick<MarkingInstruction, 'bvid' | 'cid' | 'page'>,
+) => {
+  const ids = getInstructionIds(instruction)
 
   for (const id of ids) {
     const podItemElement = getPodItemById(id)
@@ -65,18 +80,76 @@ export const clickInstructionTarget = (
     if (isHasMultiPagePodItem(podItemElement)) {
       const clickableElement = getMultiPageClickableTitleElement(podItemElement, instruction.page)
       if (clickableElement) {
-        clickableElement.click()
-        return true
+        return clickableElement
       }
       continue
     }
     const clickableElement = getClickableTitleElement(podItemElement)
     if (clickableElement) {
-      clickableElement.click()
-      return true
+      return clickableElement
     }
   }
-  return false
+  return null
+}
+
+const clickInstructionTargetInCurrentTab = (
+  instruction: Pick<MarkingInstruction, 'bvid' | 'cid' | 'page'>,
+) => {
+  const clickableElement = getInstructionClickableElementInCurrentTab(instruction)
+  if (!clickableElement) {
+    return false
+  }
+  clickableElement.click()
+  return true
+}
+
+const switchToTargetSlide = async (sectionId?: number) => {
+  if (sectionId === undefined) {
+    return false
+  }
+  const slideItem = getSlideItemElement(String(sectionId))
+  if (!(slideItem instanceof HTMLElement)) {
+    return false
+  }
+  const activeSlideItem = getActiveSlideItemElement()
+  if (activeSlideItem?.dataset.slideValue === String(sectionId)) {
+    return true
+  }
+  slideItem.click()
+  const switchedSlideItem = await sq(
+    () => getActiveSlideItemElement(),
+    item => item?.dataset.slideValue === String(sectionId),
+    {
+      maxRetry: 8,
+      queryInterval: 50,
+    },
+  )
+  return Boolean(switchedSlideItem)
+}
+
+export const clickInstructionTarget = async (
+  instruction: Pick<MarkingInstruction, 'bvid' | 'cid' | 'page' | 'sectionId'>,
+) => {
+  if (clickInstructionTargetInCurrentTab(instruction)) {
+    return true
+  }
+  const switched = await switchToTargetSlide(instruction.sectionId)
+  if (!switched) {
+    return false
+  }
+  const clickableElement = await sq(
+    () => getInstructionClickableElementInCurrentTab(instruction),
+    element => element instanceof HTMLElement,
+    {
+      maxRetry: 8,
+      queryInterval: 50,
+    },
+  )
+  if (!(clickableElement instanceof HTMLElement)) {
+    return false
+  }
+  clickableElement.click()
+  return true
 }
 
 export const observeVideoPod = (callback: () => void) => {

--- a/registry/lib/components/video/player/remember-video-collection/history.ts
+++ b/registry/lib/components/video/player/remember-video-collection/history.ts
@@ -306,11 +306,20 @@ const getMemoryKey = (
     memory.sectionRootId ?? '',
   ].join('|')
 
+export const clearHistoryByMemory = (
+  history: ComponentHistory,
+  memory?: Pick<ComponentMemory, 'bvid' | 'cid' | 'page' | 'sectionId' | 'sectionRootId'> | null,
+) => {
+  if (!memory) {
+    return history
+  }
+  const memoryKey = getMemoryKey(memory)
+  return history.filter(item => getMemoryKey(item) !== memoryKey)
+}
+
 export const upsertHistory = (
   history: ComponentOptions['history'],
   memory: ComponentMemory,
 ): ComponentOptions['history'] => {
-  const memoryKey = getMemoryKey(memory)
-  const filtered = history.filter(item => getMemoryKey(item) !== memoryKey)
-  return [...filtered, memory]
+  return [...clearHistoryByMemory(history, memory), memory]
 }

--- a/registry/lib/components/video/player/remember-video-collection/history.ts
+++ b/registry/lib/components/video/player/remember-video-collection/history.ts
@@ -247,19 +247,19 @@ export const getClearHistoryDescription = (
   currentMemory?: Pick<ComponentMemory, 'sectionId'> | null,
 ) => {
   if (!scope) {
-    return '当前页面没有可管理的播放记忆'
+    return '当前页面没有可管理的合集记忆'
   }
   if (
     sectionMode === SectionMode.Split &&
     scope.type === 'multi-sections' &&
     currentMemory?.sectionId !== undefined
   ) {
-    return '将清除当前 TAB 下的播放记忆'
+    return '将清除当前 TAB 下的合集记忆'
   }
   if (scope.type === 'multi-p') {
-    return '将清除当前视频的播放记忆'
+    return '将清除当前视频的合集记忆'
   }
-  return '将清除当前合集的播放记忆'
+  return '将清除当前合集的合集记忆'
 }
 
 export const getHistoryScopeLabel = (

--- a/registry/lib/components/video/player/remember-video-collection/index.ts
+++ b/registry/lib/components/video/player/remember-video-collection/index.ts
@@ -90,17 +90,17 @@ const getRememberVideoCollectionUnavailableMessage = () => {
 
 const createRememberVideoCollectionKeyAction = (
   displayName: string,
-  action: () => boolean,
+  action: () => boolean | Promise<boolean>,
   getFailureMessage: () => string,
 ): KeyBindingAction => ({
   displayName,
-  run: () => {
+  run: async () => {
     const unavailableMessage = getRememberVideoCollectionUnavailableMessage()
     if (unavailableMessage) {
       Toast.error(unavailableMessage, componentDisplayName, 5e3)
       return true
     }
-    if (action()) {
+    if (await action()) {
       return true
     }
     Toast.info(getFailureMessage(), componentDisplayName, 3e3)

--- a/registry/lib/components/video/player/remember-video-collection/index.ts
+++ b/registry/lib/components/video/player/remember-video-collection/index.ts
@@ -17,13 +17,7 @@ import {
   getHistoryVisitKey,
   upsertHistory,
 } from './history'
-import {
-  clearMarkings,
-  getMarkedInstructions,
-  renderMarkings,
-  setMarkingStyle,
-  startMarkingObserver,
-} from './marking'
+import { clearMarkings, getMarkedInstructions, syncMarkings, startMarkingObserver } from './marking'
 import { handleFirstLoadPrompt } from './prompt'
 import {
   clearRememberVideoCollectionPendingJumpTargets,
@@ -58,12 +52,11 @@ let currentDetail: VideoInfo | null = null
 let currentHistoryScope: HistoryScope | null = null
 let currentMemory: ComponentMemory | null = null
 
-const rerenderMarkings = () => {
+const rerenderMarkings = (overrides?: { markingStyle?: MarkingStyle }) => {
   if (!currentSettings) {
     return
   }
-  setMarkingStyle(currentSettings.options.markingStyle)
-  renderMarkings(currentInstructions)
+  syncMarkings(currentInstructions, overrides?.markingStyle ?? currentSettings.options.markingStyle)
 }
 
 const syncRuntimeState = () => {
@@ -130,7 +123,7 @@ const restartMarkingObserver = () => {
   })
 }
 
-const markingStyleListener = (style: MarkingStyle) => setMarkingStyle(style)
+const markingStyleListener = (style: MarkingStyle) => rerenderMarkings({ markingStyle: style })
 const historyListener = () => updateInstructionsForCurrentScope()
 const sectionModeListener = () => updateInstructionsForCurrentScope()
 

--- a/registry/lib/components/video/player/remember-video-collection/index.ts
+++ b/registry/lib/components/video/player/remember-video-collection/index.ts
@@ -47,7 +47,7 @@ import {
 
 const logger = useScopedConsole('rememberVideoCollection')
 const componentName = 'rememberVideoCollection'
-const componentDisplayName = '记忆合集进度'
+const componentDisplayName = '记忆合集'
 
 let currentInstructions: MarkingInstruction[] = []
 let currentSettings: { options: ComponentOptions } | null = null
@@ -79,11 +79,11 @@ const syncRuntimeState = () => {
 const getRememberVideoCollectionUnavailableMessage = () => {
   const settings = getComponentSettings<ComponentOptions>(componentName)
   if (!settings.enabled) {
-    return '组件已禁用，不能使用播放记忆快捷键'
+    return '组件已禁用，不能使用合集记忆快捷键'
   }
   const state = getRememberVideoCollectionRuntimeState()
   if (!state.available) {
-    return '当前页面没有可用的播放记忆'
+    return '当前页面没有可用的合集记忆'
   }
   return undefined
 }
@@ -299,11 +299,11 @@ export const component = defineComponentMetadata<ComponentOptions>({
     component: () => import('./Widget.vue').then(m => m.default),
   },
   plugin: {
-    displayName: '播放记忆 - 快捷键支持',
+    displayName: '合集记忆 - 快捷键支持',
     setup: ({ addData }) => {
       addData('keymap.actions', (actions: Record<string, KeyBindingAction>) => {
         actions.rememberVideoCollectionJumpLast = createRememberVideoCollectionKeyAction(
-          '播放记忆：跳转到上次播放',
+          '合集记忆：跳转到上次播放',
           () => {
             const state = getRememberVideoCollectionRuntimeState()
             if (!state.canJumpLast) {
@@ -317,7 +317,7 @@ export const component = defineComponentMetadata<ComponentOptions>({
           },
         )
         actions.rememberVideoCollectionJumpNext = createRememberVideoCollectionKeyAction(
-          '播放记忆：跳转到下一个',
+          '合集记忆：跳转到下一个',
           () => {
             const state = getRememberVideoCollectionRuntimeState()
             if (!state.canJumpNext) {
@@ -328,9 +328,9 @@ export const component = defineComponentMetadata<ComponentOptions>({
           () => '没有可跳转的下一个视频',
         )
         actions.rememberVideoCollectionClearCurrent = createRememberVideoCollectionKeyAction(
-          '播放记忆：清除当前视频记忆',
+          '合集记忆：清除当前视频记忆',
           clearCurrentRememberedVideoHistory,
-          () => '当前视频暂无可清除的播放记忆',
+          () => '当前视频暂无可清除的合集记忆',
         )
       })
       addData('keymap.presets', (presetBase: Record<string, string>) => {

--- a/registry/lib/components/video/player/remember-video-collection/index.ts
+++ b/registry/lib/components/video/player/remember-video-collection/index.ts
@@ -1,10 +1,15 @@
 import { defineComponentMetadata } from '@/components/define'
 import { VideoInfo } from '@/components/video/video-info'
 import { videoChange } from '@/core/observer'
-import { addComponentListener, removeComponentListener } from '@/core/settings'
+import {
+  addComponentListener,
+  getComponentSettings,
+  removeComponentListener,
+} from '@/core/settings'
 import { Toast } from '@/core/toast'
 import { useScopedConsole } from '@/core/utils/log'
 import { playerUrls } from '@/core/utils/urls'
+import type { KeyBindingAction } from '../../../utils/keymap/bindings'
 import {
   buildCurrentMemory,
   filterHistory,
@@ -22,6 +27,10 @@ import {
 import { handleFirstLoadPrompt } from './prompt'
 import {
   clearRememberVideoCollectionPendingJumpTargets,
+  clearCurrentRememberedVideoHistory,
+  getRememberVideoCollectionRuntimeState,
+  jumpToRememberedNextVideo,
+  jumpToRememberedVideo,
   resetRememberVideoCollectionRuntime,
   setRememberVideoCollectionPendingJumpTargets,
   updateRememberVideoCollectionRuntime,
@@ -66,6 +75,38 @@ const syncRuntimeState = () => {
     sectionMode: currentSettings?.options.sectionMode ?? SectionMode.Split,
   })
 }
+
+const getRememberVideoCollectionUnavailableMessage = () => {
+  const settings = getComponentSettings<ComponentOptions>(componentName)
+  if (!settings.enabled) {
+    return '组件已禁用，不能使用播放记忆快捷键'
+  }
+  const state = getRememberVideoCollectionRuntimeState()
+  if (!state.available) {
+    return '当前页面没有可用的播放记忆'
+  }
+  return undefined
+}
+
+const createRememberVideoCollectionKeyAction = (
+  displayName: string,
+  action: () => boolean,
+  getFailureMessage: () => string,
+): KeyBindingAction => ({
+  displayName,
+  run: () => {
+    const unavailableMessage = getRememberVideoCollectionUnavailableMessage()
+    if (unavailableMessage) {
+      Toast.error(unavailableMessage, componentDisplayName, 5e3)
+      return true
+    }
+    if (action()) {
+      return true
+    }
+    Toast.info(getFailureMessage(), componentDisplayName, 3e3)
+    return true
+  },
+})
 
 const updateInstructionsForCurrentScope = () => {
   if (!currentSettings || !currentHistoryScope) {
@@ -256,6 +297,48 @@ export const component = defineComponentMetadata<ComponentOptions>({
   ],
   widget: {
     component: () => import('./Widget.vue').then(m => m.default),
+  },
+  plugin: {
+    displayName: '播放记忆 - 快捷键支持',
+    setup: ({ addData }) => {
+      addData('keymap.actions', (actions: Record<string, KeyBindingAction>) => {
+        actions.rememberVideoCollectionJumpLast = createRememberVideoCollectionKeyAction(
+          '播放记忆：跳转到上次播放',
+          () => {
+            const state = getRememberVideoCollectionRuntimeState()
+            if (!state.canJumpLast) {
+              return false
+            }
+            return jumpToRememberedVideo()
+          },
+          () => {
+            const state = getRememberVideoCollectionRuntimeState()
+            return state.lastPlayedLabel ? '当前已经位于上次播放位置' : '当前作用域暂无上次播放记录'
+          },
+        )
+        actions.rememberVideoCollectionJumpNext = createRememberVideoCollectionKeyAction(
+          '播放记忆：跳转到下一个',
+          () => {
+            const state = getRememberVideoCollectionRuntimeState()
+            if (!state.canJumpNext) {
+              return false
+            }
+            return jumpToRememberedNextVideo()
+          },
+          () => '没有可跳转的下一个视频',
+        )
+        actions.rememberVideoCollectionClearCurrent = createRememberVideoCollectionKeyAction(
+          '播放记忆：清除当前视频记忆',
+          clearCurrentRememberedVideoHistory,
+          () => '当前视频暂无可清除的播放记忆',
+        )
+      })
+      addData('keymap.presets', (presetBase: Record<string, string>) => {
+        presetBase.rememberVideoCollectionJumpLast = 'shift h'
+        presetBase.rememberVideoCollectionJumpNext = 'shift n'
+        presetBase.rememberVideoCollectionClearCurrent = 'shift delete'
+      })
+    },
   },
   options: {
     history: {

--- a/registry/lib/components/video/player/remember-video-collection/marking.ts
+++ b/registry/lib/components/video/player/remember-video-collection/marking.ts
@@ -1,4 +1,5 @@
 import { useScopedConsole } from '@/core/utils/log'
+import { sq } from '@/core/spin-query'
 import { sortHistory } from './history'
 import { MarkingStyle, SectionMode } from './types'
 import type { ComponentHistory, ComponentMemory, MarkingInstruction } from './types'
@@ -18,12 +19,12 @@ const watchedClass = 'be-rvc-watched'
 const lastClass = 'be-rvc-last'
 const multiPagePodItemClass = 'be-rvc-multi-page'
 const multiPageAllWatchedClass = 'be-rvc-multi-page-all-watched'
-// const gridWatchedClass = 'be-rvc-grid-watched'
-// const gridLastClass = 'be-rvc-grid-last'
 const styleDefaultClass = 'be-rvc-style-default'
 const styleDistinguishClass = 'be-rvc-style-distinguish'
 
 let frame = 0
+let renderToken = 0
+let styleToken = 0
 
 const clearMarks = () => {
   getMarkedElements([
@@ -54,13 +55,53 @@ const applyMultiPageCompletionState = () => {
   })
 }
 
+const getInstructionIds = (instruction: Pick<MarkingInstruction, 'bvid' | 'cid'>) =>
+  [instruction.bvid, instruction.cid]
+    .filter((id): id is string | number => id !== undefined && id !== null)
+    .map(String)
+
+const canRenderInstruction = (instruction: MarkingInstruction) => {
+  const ids = getInstructionIds(instruction)
+  for (const id of ids) {
+    const podItemElement = getPodItemById(id)
+    if (!podItemElement) {
+      continue
+    }
+    if (isHasMultiPagePodItem(podItemElement) && instruction.page !== undefined) {
+      return getMultiPagePodItemPageItem(podItemElement, instruction.page) !== null
+    }
+    return true
+  }
+  return false
+}
+
+const waitForRenderableMarkings = async (instructions: MarkingInstruction[]) => {
+  if (instructions.length === 0) {
+    return
+  }
+  await sq(
+    () => {
+      const root = getVideoPodElement()
+      if (!root) {
+        return null
+      }
+      return instructions.some(canRenderInstruction) ? root : null
+    },
+    root => root !== null,
+    {
+      maxRetry: 8,
+      queryInterval: 50,
+    },
+  )
+}
+
 const applyInstruction = (instruction: MarkingInstruction) => {
   const ids = [instruction.bvid, instruction.cid]
     .filter((id): id is string | number => id !== undefined && id !== null)
     .map(String)
   if (ids.length === 0) {
     logger.warn('applyInstruction skipped: empty instruction id.', instruction)
-    return
+    return false
   }
   let podItemElement: HTMLElement | null = null
   for (const id of ids) {
@@ -71,31 +112,43 @@ const applyInstruction = (instruction: MarkingInstruction) => {
   }
   if (!podItemElement) {
     logger.warn('applyInstruction skipped: target not found.', { ids, instruction })
-    return
+    return false
   }
 
   const markingClass = instruction.type === 'last-played' ? lastClass : watchedClass
   if (isHasMultiPagePodItem(podItemElement) && instruction.page !== undefined) {
-    podItemElement.classList.add(multiPagePodItemClass)
+    podItemElement.classList.add(multiPagePodItemClass, markingClass)
+    logger.log('multipage podItemElement', podItemElement)
     const pageItemElement = getMultiPagePodItemPageItem(podItemElement, instruction.page)
     if (pageItemElement) {
       pageItemElement.classList.add(markingClass)
+      return true
     }
+    return false
   }
 
   podItemElement.classList.add(markingClass)
+  return true
 }
 
 const runRender = (instructions: MarkingInstruction[]) => {
   frame = 0
   clearMarks()
+  let appliedCount = 0
   for (const instruction of instructions) {
-    applyInstruction(instruction)
+    if (applyInstruction(instruction)) {
+      appliedCount++
+    }
   }
   applyMultiPageCompletionState()
+  return {
+    appliedCount,
+    totalCount: instructions.length,
+  }
 }
 
 const abortRunningRender = () => {
+  renderToken++
   if (frame !== 0) {
     cancelAnimationFrame(frame)
     frame = 0
@@ -104,24 +157,62 @@ const abortRunningRender = () => {
 
 export const clearMarkings = () => {
   abortRunningRender()
+  styleToken++
   clearMarks()
   const root = getVideoPodElement()
   root?.classList.remove(styleDefaultClass, styleDistinguishClass)
 }
 
 export const setMarkingStyle = (style: MarkingStyle) => {
-  const root = getVideoPodElement()
-  if (!root) {
-    return
-  }
-  root.classList.remove(styleDefaultClass, styleDistinguishClass)
-  root.classList.add(style === MarkingStyle.Distinguish ? styleDistinguishClass : styleDefaultClass)
+  const currentStyleToken = ++styleToken
+  sq(
+    () => getVideoPodElement(),
+    root => root !== null,
+    {
+      maxRetry: 8,
+      queryInterval: 100,
+    },
+  ).then(root => {
+    if (!root || currentStyleToken !== styleToken) {
+      return
+    }
+    root.classList.remove(styleDefaultClass, styleDistinguishClass)
+    root.classList.add(
+      style === MarkingStyle.Distinguish ? styleDistinguishClass : styleDefaultClass,
+    )
+    logger.log('setMarkingStyle root', root)
+  })
 }
 
 export const renderMarkings = (instructions: MarkingInstruction[]) => {
   abortRunningRender()
-  frame = requestAnimationFrame(() => {
-    runRender(instructions)
+  const currentRenderToken = renderToken
+  waitForRenderableMarkings(instructions).then(async () => {
+    if (currentRenderToken !== renderToken) {
+      return
+    }
+    await sq(
+      () => {
+        if (currentRenderToken !== renderToken) {
+          return {
+            appliedCount: 0,
+            totalCount: 0,
+          }
+        }
+        return runRender(instructions)
+      },
+      (result, stop) => {
+        if (currentRenderToken !== renderToken) {
+          stop()
+          return true
+        }
+        return result.totalCount === 0 || result.appliedCount > 0
+      },
+      {
+        maxRetry: 8,
+        queryInterval: 100,
+      },
+    )
   })
 }
 

--- a/registry/lib/components/video/player/remember-video-collection/marking.ts
+++ b/registry/lib/components/video/player/remember-video-collection/marking.ts
@@ -21,25 +21,37 @@ const multiPagePodItemClass = 'be-rvc-multi-page'
 const multiPageAllWatchedClass = 'be-rvc-multi-page-all-watched'
 const styleDefaultClass = 'be-rvc-style-default'
 const styleDistinguishClass = 'be-rvc-style-distinguish'
+const renderedMarkClasses = [
+  watchedClass,
+  lastClass,
+  multiPagePodItemClass,
+  multiPageAllWatchedClass,
+] as const
+const markingStyleClasses = [styleDefaultClass, styleDistinguishClass] as const
+const markingRetryConfig = {
+  maxRetry: 15,
+  queryInterval: 200,
+} as const
 
 let frame = 0
-let renderToken = 0
-let styleToken = 0
+let markingLifecycleToken = 0
 
-const clearMarks = () => {
-  getMarkedElements([
-    watchedClass,
-    lastClass,
-    multiPagePodItemClass,
-    multiPageAllWatchedClass,
-  ]).forEach(element => {
-    element.classList.remove(
-      watchedClass,
-      lastClass,
-      multiPagePodItemClass,
-      multiPageAllWatchedClass,
-    )
+const clearElementMarkingStyle = (element?: Element | null) => {
+  element?.classList.remove(...markingStyleClasses)
+}
+
+const clearRenderedMarks = () => {
+  getMarkedElements([...renderedMarkClasses]).forEach(element => {
+    element.classList.remove(...renderedMarkClasses)
   })
+}
+
+const clearMarkingDomState = ({ includeStyle }: { includeStyle: boolean }) => {
+  clearRenderedMarks()
+  if (!includeStyle) {
+    return
+  }
+  clearElementMarkingStyle(getVideoPodElement())
 }
 
 const applyMultiPageCompletionState = () => {
@@ -88,10 +100,7 @@ const waitForRenderableMarkings = async (instructions: MarkingInstruction[]) => 
       return instructions.some(canRenderInstruction) ? root : null
     },
     root => root !== null,
-    {
-      maxRetry: 8,
-      queryInterval: 50,
-    },
+    markingRetryConfig,
   )
 }
 
@@ -133,7 +142,7 @@ const applyInstruction = (instruction: MarkingInstruction) => {
 
 const runRender = (instructions: MarkingInstruction[]) => {
   frame = 0
-  clearMarks()
+  clearMarkingDomState({ includeStyle: false })
   let appliedCount = 0
   for (const instruction of instructions) {
     if (applyInstruction(instruction)) {
@@ -147,36 +156,26 @@ const runRender = (instructions: MarkingInstruction[]) => {
   }
 }
 
-const abortRunningRender = () => {
-  renderToken++
+const isLifecycleCurrent = (token: number) => token === markingLifecycleToken
+
+const invalidateMarkingLifecycle = () => {
+  markingLifecycleToken++
   if (frame !== 0) {
     cancelAnimationFrame(frame)
     frame = 0
   }
 }
 
-export const clearMarkings = () => {
-  abortRunningRender()
-  styleToken++
-  clearMarks()
-  const root = getVideoPodElement()
-  root?.classList.remove(styleDefaultClass, styleDistinguishClass)
-}
-
-export const setMarkingStyle = (style: MarkingStyle) => {
-  const currentStyleToken = ++styleToken
+const applyMarkingStyle = (style: MarkingStyle, lifecycleToken: number) => {
   sq(
     () => getVideoPodElement(),
     root => root !== null,
-    {
-      maxRetry: 8,
-      queryInterval: 100,
-    },
+    markingRetryConfig,
   ).then(root => {
-    if (!root || currentStyleToken !== styleToken) {
+    if (!root || !isLifecycleCurrent(lifecycleToken)) {
       return
     }
-    root.classList.remove(styleDefaultClass, styleDistinguishClass)
+    clearElementMarkingStyle(root)
     root.classList.add(
       style === MarkingStyle.Distinguish ? styleDistinguishClass : styleDefaultClass,
     )
@@ -184,16 +183,14 @@ export const setMarkingStyle = (style: MarkingStyle) => {
   })
 }
 
-export const renderMarkings = (instructions: MarkingInstruction[]) => {
-  abortRunningRender()
-  const currentRenderToken = renderToken
+const scheduleMarkingRender = (instructions: MarkingInstruction[], lifecycleToken: number) => {
   waitForRenderableMarkings(instructions).then(async () => {
-    if (currentRenderToken !== renderToken) {
+    if (!isLifecycleCurrent(lifecycleToken)) {
       return
     }
     await sq(
       () => {
-        if (currentRenderToken !== renderToken) {
+        if (!isLifecycleCurrent(lifecycleToken)) {
           return {
             appliedCount: 0,
             totalCount: 0,
@@ -202,18 +199,26 @@ export const renderMarkings = (instructions: MarkingInstruction[]) => {
         return runRender(instructions)
       },
       (result, stop) => {
-        if (currentRenderToken !== renderToken) {
+        if (!isLifecycleCurrent(lifecycleToken)) {
           stop()
           return true
         }
         return result.totalCount === 0 || result.appliedCount > 0
       },
-      {
-        maxRetry: 8,
-        queryInterval: 100,
-      },
+      markingRetryConfig,
     )
   })
+}
+
+export const clearMarkings = () => {
+  invalidateMarkingLifecycle()
+  clearMarkingDomState({ includeStyle: true })
+}
+
+export const syncMarkings = (instructions: MarkingInstruction[], style: MarkingStyle) => {
+  const lifecycleToken = ++markingLifecycleToken
+  applyMarkingStyle(style, lifecycleToken)
+  scheduleMarkingRender(instructions, lifecycleToken)
 }
 
 const mapGroupToInstructions = (history: ComponentHistory): MarkingInstruction[] => {

--- a/registry/lib/components/video/player/remember-video-collection/navigation.ts
+++ b/registry/lib/components/video/player/remember-video-collection/navigation.ts
@@ -7,7 +7,7 @@ import { clickInstructionTarget } from './dom'
 import { getLastPlayedInstruction } from './marking'
 import { SectionMode, type ComponentMemory, type MarkingInstruction } from './types'
 
-export type JumpInstruction = Pick<MarkingInstruction, 'bvid' | 'cid' | 'page'>
+export type JumpInstruction = Pick<MarkingInstruction, 'bvid' | 'cid' | 'page' | 'sectionId'>
 type CollectionTarget = {
   episode?: VideoSeasonEpisodeInfo
   page?: VideoPageInfo
@@ -56,15 +56,17 @@ export const isSameInstruction = (
 ) =>
   currentInstruction?.bvid === targetInstruction?.bvid &&
   currentInstruction?.cid === targetInstruction?.cid &&
-  currentInstruction?.page === targetInstruction?.page
+  currentInstruction?.page === targetInstruction?.page &&
+  currentInstruction?.sectionId === targetInstruction?.sectionId
 
 export const isSameAsCurrentMemory = (
-  currentMemory: Pick<ComponentMemory, 'bvid' | 'cid' | 'page'>,
+  currentMemory: Pick<ComponentMemory, 'bvid' | 'cid' | 'page' | 'sectionId'>,
   instruction?: JumpInstruction,
 ) =>
   currentMemory.bvid === instruction?.bvid &&
   currentMemory.cid === instruction?.cid &&
-  currentMemory.page === instruction?.page
+  currentMemory.page === instruction?.page &&
+  currentMemory.sectionId === instruction?.sectionId
 
 export const isJumpInstructionValid = (instruction?: JumpInstruction) =>
   instruction !== undefined && (instruction.bvid !== undefined || instruction.cid !== undefined)
@@ -196,6 +198,7 @@ const getNextInstructionInCollection = (
       bvid: episode.bvid ?? instruction.bvid,
       cid: nextPage.cid,
       page: currentPageIndex + 2,
+      sectionId: episode.section_id,
     }
   }
 
@@ -212,6 +215,7 @@ const getNextInstructionInCollection = (
     bvid: nextEpisode.bvid,
     cid: firstPage?.cid,
     page: nextEpisodePages.length > 1 ? 1 : undefined,
+    sectionId: nextEpisode.section_id,
   }
 }
 
@@ -238,8 +242,8 @@ const redirectToInstruction = (instruction: JumpInstruction) => {
   return true
 }
 
-export const jumpToInstruction = (instruction: JumpInstruction) => {
-  const clickSucceeded = clickInstructionTarget(instruction)
+export const jumpToInstruction = async (instruction: JumpInstruction) => {
+  const clickSucceeded = await clickInstructionTarget(instruction)
   if (clickSucceeded) {
     return true
   }

--- a/registry/lib/components/video/player/remember-video-collection/prompt.ts
+++ b/registry/lib/components/video/player/remember-video-collection/prompt.ts
@@ -151,7 +151,7 @@ export const handleFirstLoadPrompt = async ({
   const jumpInstruction: JumpInstruction =
     action === 'jump-next' && canJumpNext ? nextInstruction : lastPlayedInstruction
 
-  const jumpSucceeded = jumpToInstruction(jumpInstruction)
+  const jumpSucceeded = await jumpToInstruction(jumpInstruction)
   return {
     action,
     lastPlayedInstruction,

--- a/registry/lib/components/video/player/remember-video-collection/runtime.ts
+++ b/registry/lib/components/video/player/remember-video-collection/runtime.ts
@@ -2,6 +2,7 @@ import { getComponentSettings } from '@/core/settings'
 import { Toast } from '@/core/toast'
 import type { VideoInfo } from '@/components/video/video-info'
 import {
+  clearHistoryByMemory,
   clearHistoryInScope,
   getClearHistoryDescription,
   getHistoryInScope,
@@ -182,7 +183,7 @@ export const clearRememberVideoCollectionPendingJumpTargets = () => {
   setRememberVideoCollectionPendingJumpTargets(undefined)
 }
 
-const runJump = (instruction?: JumpInstruction) => {
+const runJump = (instruction: JumpInstruction | undefined, successMessage: string) => {
   if (!instruction) {
     return false
   }
@@ -192,12 +193,31 @@ const runJump = (instruction?: JumpInstruction) => {
     return false
   }
   clearRememberVideoCollectionPendingJumpTargets()
+  Toast.success(successMessage, componentDisplayName, 3e3)
   return true
 }
 
-export const jumpToRememberedVideo = () => runJump(runtimeState.lastPlayedInstruction)
+export const jumpToRememberedVideo = () =>
+  runJump(runtimeState.lastPlayedInstruction, '已跳转到上次播放')
 
-export const jumpToRememberedNextVideo = () => runJump(runtimeState.nextInstruction)
+export const jumpToRememberedNextVideo = () =>
+  runJump(runtimeState.nextInstruction, '已跳转到下一个视频')
+
+export const clearCurrentRememberedVideoHistory = () => {
+  const { currentMemory } = runtimeContext
+  if (!currentMemory) {
+    return false
+  }
+  const settings = getComponentSettings<ComponentOptions>(componentName)
+  const nextHistory = clearHistoryByMemory(settings.options.history, currentMemory)
+  if (nextHistory.length === settings.options.history.length) {
+    return false
+  }
+  settings.options.history = nextHistory
+  clearRememberVideoCollectionPendingJumpTargets()
+  Toast.success('已清除当前视频记忆', componentDisplayName, 3e3)
+  return true
+}
 
 export const clearRememberedHistory = () => {
   const { historyScope, currentMemory, sectionMode } = runtimeContext

--- a/registry/lib/components/video/player/remember-video-collection/runtime.ts
+++ b/registry/lib/components/video/player/remember-video-collection/runtime.ts
@@ -183,11 +183,11 @@ export const clearRememberVideoCollectionPendingJumpTargets = () => {
   setRememberVideoCollectionPendingJumpTargets(undefined)
 }
 
-const runJump = (instruction: JumpInstruction | undefined, successMessage: string) => {
+const runJump = async (instruction: JumpInstruction | undefined, successMessage: string) => {
   if (!instruction) {
     return false
   }
-  const jumpSucceeded = jumpToInstruction(instruction)
+  const jumpSucceeded = await jumpToInstruction(instruction)
   if (!jumpSucceeded) {
     Toast.error('跳转失败', componentDisplayName, 3e3)
     return false

--- a/registry/lib/components/video/player/remember-video-collection/runtime.ts
+++ b/registry/lib/components/video/player/remember-video-collection/runtime.ts
@@ -72,7 +72,7 @@ let runtimeState: RememberVideoCollectionRuntimeState = {
   canJumpNext: false,
   canClear: false,
   canClearAll: false,
-  clearDescription: '当前页面没有可管理的播放记忆',
+  clearDescription: '当前页面没有可管理的合集记忆',
   clearScopeButtonText: '清除当前作用域记忆',
   scopeLabel: '当前作用域',
   scopeTitle: undefined,
@@ -236,7 +236,7 @@ export const clearRememberedHistory = () => {
   }
   settings.options.history = nextHistory
   clearRememberVideoCollectionPendingJumpTargets()
-  Toast.success('已清除当前作用域的播放记忆', componentDisplayName, 3e3)
+  Toast.success('已清除当前作用域的合集记忆', componentDisplayName, 3e3)
   return true
 }
 
@@ -247,6 +247,6 @@ export const clearAllRememberedHistory = () => {
   }
   settings.options.history = []
   clearRememberVideoCollectionPendingJumpTargets()
-  Toast.success('已清除全部播放记忆', componentDisplayName, 3e3)
+  Toast.success('已清除全部合集记忆', componentDisplayName, 3e3)
   return true
 }


### PR DESCRIPTION
<!-- 可以参考下代码贡献指南: https://github.com/the1812/Bilibili-Evolved/blob/preview/CONTRIBUTING.md -->

1. 新加了快捷键来快速进行某些操作
  - `合集记忆：跳转到上次播放`：<kbd>shift + h</kbd>
  - `合集记忆：跳转到下一个`：<kbd>shift+n</kbd>
  - `合集记忆：清除当前视频记忆`：<kbd>shift+delete</kbd>
2. 优化多TAB合集下，跨标签页的跳转操作，优先以模拟点击标签页的形式完成跳转，而不是链接跳转
3. 修改一些文案，现在将「播放记忆」改为「合集记忆」统一表述
4. 增强了 marking 的稳定性，现在不容易出现 marking 错误的问题
