### PR TITLE
[组件 - 保存视频元数据] 修复重复标题, 新增合集信息、小组件显示开关

### DIFF
--- a/registry/lib/components/video/metadata/index.ts
+++ b/registry/lib/components/video/metadata/index.ts
@@ -32,7 +32,12 @@ export const component = defineComponentMetadata({
   urlInclude: videoAndBangumiUrls,
   options,
   widget: {
-    condition: hasVideo,
+    condition: async () => {
+      return (
+        (await hasVideo()) &&
+        Boolean((await import('@/core/settings')).getComponentSettings(name).options.showWidget)
+      )
+    },
     component: () => import('./SaveMetadata.vue').then(m => m.default),
   },
   plugin: {

--- a/registry/lib/components/video/metadata/metadata.ts
+++ b/registry/lib/components/video/metadata/metadata.ts
@@ -10,6 +10,7 @@ import { MetadataType, Tag, ViewPoint } from './types'
 import {
   bangumiSkipToViewPoints,
   escape,
+  findCidInUgcSeason,
   fixBgmTag,
   formatStaffs,
   formatTime,
@@ -137,6 +138,15 @@ async function generateFFMetadata(aid: string = unsafeWindow.aid, cid: string = 
       ff('category_id', basic.tagId),
       ff('category_name', basic.tagName),
     )
+    if (basic.ugcSeason) {
+      const d = findCidInUgcSeason(basic.ugcSeason, data.page.cid)
+      if (d) {
+        lines.push(ff('collection_id', d.seasonId))
+        lines.push(ff('collection_title', d.seasonTitle))
+        lines.push(ff('collection_section_id', d.sectionId))
+        lines.push(ff('collection_section_title', d.sectionTitle))
+      }
+    }
     if (data.tags.tag) {
       lines.push(ff('tags', tagWithId(data.tags.tag)))
     }

--- a/registry/lib/components/video/metadata/metadata.ts
+++ b/registry/lib/components/video/metadata/metadata.ts
@@ -105,7 +105,11 @@ async function generateFFMetadata(aid: string = unsafeWindow.aid, cid: string = 
       { timeZoneName: 'short' },
     )}`,
     // Standard fields
-    ff('title', `${basic.title} - ${data.page.title}`, false),
+    ff(
+      'title',
+      `${basic.title}${basic.title !== data.page.title ? ` - ${data.page.title}` : ''}`,
+      false,
+    ),
     ff('description', basic.description, false),
     ff('artist', basic.up.name, false),
   ]

--- a/registry/lib/components/video/metadata/options.ts
+++ b/registry/lib/components/video/metadata/options.ts
@@ -30,6 +30,10 @@ export const options = defineOptionsMetadata({
     displayName: '包含状态数（播放数、点赞数等）', //
     defaultValue: true,
   },
+  showWidget: {
+    displayName: '显示小组件（刷新后生效）',
+    defaultValue: true,
+  },
 })
 
 export type Options = OptionsOfMetadata<typeof options>

--- a/registry/lib/components/video/metadata/utils.ts
+++ b/registry/lib/components/video/metadata/utils.ts
@@ -1,4 +1,4 @@
-import { EpisodeInfo, UpInfo } from '@/components/video/video-info'
+import { EpisodeInfo, UpInfo, VideoSeasonInfo } from '@/components/video/video-info'
 import { TimeFormat } from './options'
 import { Tag, ViewPoint } from './types'
 
@@ -14,6 +14,25 @@ export function fixBgmTag(bgmTags: Tag[]) {
   return bgmTags.map(
     x => `${x.tag_name.match(/^发现《([^》]+)》/)?.[1] ?? x.tag_name}(${x.music_id})`,
   )
+}
+
+export function findCidInUgcSeason(season: VideoSeasonInfo, cid: number) {
+  for (const section of season.sections) {
+    for (const ep of section.episodes) {
+      for (const page of ep.pages) {
+        if (page.cid === cid) {
+          return {
+            ...page,
+            seasonId: season.id,
+            seasonTitle: season.title,
+            sectionId: section.id,
+            sectionTitle: section.title,
+          }
+        }
+      }
+    }
+  }
+  return null
 }
 
 export function formatStaffs(staffs: UpInfo[]) {


### PR DESCRIPTION
- 修复：议题 #5524
  - 仅当稿件标题和分页标题不同时才将其组合起来

- 新增：合集及合集分节信息
  - 示例（[BV1VQDLBhE2a](https://www.bilibili.com/video/BV1VQDLBhE2a/)）：
    ```
    bilibili_collection_id=6460825
    bilibili_collection_title=学园偶像大师
    bilibili_collection_section_id=7137332
    bilibili_collection_section_title=MV
    ```
  - 示例（[BV1d8411e7LV](https://www.bilibili.com/video/BV1d8411e7LV/)）：
    （即使在显示上没有分节，实际上也有一个名为“正片”的默认分节）
    ```
    bilibili_collection_id=697461
    bilibili_collection_title=视频功能操作指南
    bilibili_collection_section_id=807687
    bilibili_collection_section_title=正片
    ```
- 新增：参照 PR #5549 添加了功能面板小组件开关，默认为开
  - 可能在配合插件「WASM 混流输出」时会有用吧，只需要混流进去，没必要单独下载一个元数据文件的话🤔