### PR TITLE
Fix: 快捷键扩展错误忽略播放器内按键焦点

### DIFF
--- a/registry/lib/components/utils/keymap/bindings.ts
+++ b/registry/lib/components/utils/keymap/bindings.ts
@@ -61,39 +61,15 @@ export const loadKeyBindings = lodash.once((bindings: KeyBinding[]) => {
         if (activeElement instanceof HTMLMediaElement) {
           return false
         }
-        // 忽略播放器外显按钮元素的焦点
+        // 播放器内各种控制按钮的焦点
         if (
           activeElement instanceof HTMLDivElement &&
           activeElement.classList.contains('bpx-player-ctrl-btn')
         ) {
           return false
         }
-        // 忽略播放器设置按钮一层开关元素的焦点
-        if (
-          activeElement instanceof HTMLInputElement &&
-          activeElement.classList.contains('bui-switch-input')
-        ) {
-          return false
-        }
-        // 忽略播放器设置-更多播放设置单选按钮元素的焦点
-        if (
-          activeElement instanceof HTMLInputElement &&
-          activeElement.classList.contains('bui-radio-input')
-        ) {
-          return false
-        }
-        // 忽略播放器设置-更多播放设置复选按钮元素的焦点
-        if (
-          activeElement instanceof HTMLInputElement &&
-          activeElement.classList.contains('bui-checkbox-input')
-        ) {
-          return false
-        }
-        // 忽略播放器弹幕开关按钮元素的焦点
-        if (
-          activeElement instanceof HTMLInputElement &&
-          activeElement.classList.contains('bui-danmaku-switch-input')
-        ) {
+        // 播放器内各种设置项按钮的焦点
+        if (activeElement instanceof HTMLInputElement && activeElement.classList.contains('bui')) {
           return false
         }
         return true

--- a/registry/lib/components/utils/keymap/bindings.ts
+++ b/registry/lib/components/utils/keymap/bindings.ts
@@ -61,6 +61,20 @@ export const loadKeyBindings = lodash.once((bindings: KeyBinding[]) => {
         if (activeElement instanceof HTMLMediaElement) {
           return false
         }
+        // 忽略播放器“网页全屏”按钮焦点
+        if (
+          activeElement instanceof HTMLDivElement &&
+          activeElement.classList.contains('bpx-player-ctrl-web')
+        ) {
+          return false
+        }
+        // 忽略播放器“全屏按钮”焦点
+        if (
+          activeElement instanceof HTMLDivElement &&
+          activeElement.classList.contains('bpx-player-ctrl-full')
+        ) {
+          return false
+        }
         return true
       })()
       if (

--- a/registry/lib/components/utils/keymap/bindings.ts
+++ b/registry/lib/components/utils/keymap/bindings.ts
@@ -61,6 +61,13 @@ export const loadKeyBindings = lodash.once((bindings: KeyBinding[]) => {
         if (activeElement instanceof HTMLMediaElement) {
           return false
         }
+        // 忽略播放器“宽屏”按钮焦点
+        if (
+          activeElement instanceof HTMLDivElement &&
+          activeElement.classList.contains('bpx-player-ctrl-wide')
+        ) {
+          return false
+        }
         // 忽略播放器“网页全屏”按钮焦点
         if (
           activeElement instanceof HTMLDivElement &&
@@ -68,7 +75,7 @@ export const loadKeyBindings = lodash.once((bindings: KeyBinding[]) => {
         ) {
           return false
         }
-        // 忽略播放器“全屏按钮”焦点
+        // 忽略播放器“全屏”按钮焦点
         if (
           activeElement instanceof HTMLDivElement &&
           activeElement.classList.contains('bpx-player-ctrl-full')

--- a/registry/lib/components/utils/keymap/bindings.ts
+++ b/registry/lib/components/utils/keymap/bindings.ts
@@ -61,24 +61,10 @@ export const loadKeyBindings = lodash.once((bindings: KeyBinding[]) => {
         if (activeElement instanceof HTMLMediaElement) {
           return false
         }
-        // 忽略播放器“宽屏”按钮焦点
+        // 忽略播放器相关按钮元素的焦点
         if (
           activeElement instanceof HTMLDivElement &&
-          activeElement.classList.contains('bpx-player-ctrl-wide')
-        ) {
-          return false
-        }
-        // 忽略播放器“网页全屏”按钮焦点
-        if (
-          activeElement instanceof HTMLDivElement &&
-          activeElement.classList.contains('bpx-player-ctrl-web')
-        ) {
-          return false
-        }
-        // 忽略播放器“全屏”按钮焦点
-        if (
-          activeElement instanceof HTMLDivElement &&
-          activeElement.classList.contains('bpx-player-ctrl-full')
+          activeElement.classList.contains('bpx-player-ctrl-btn')
         ) {
           return false
         }

--- a/registry/lib/components/utils/keymap/bindings.ts
+++ b/registry/lib/components/utils/keymap/bindings.ts
@@ -61,10 +61,31 @@ export const loadKeyBindings = lodash.once((bindings: KeyBinding[]) => {
         if (activeElement instanceof HTMLMediaElement) {
           return false
         }
-        // 忽略播放器相关按钮元素的焦点
+        // 忽略播放器外显按钮元素的焦点
         if (
           activeElement instanceof HTMLDivElement &&
           activeElement.classList.contains('bpx-player-ctrl-btn')
+        ) {
+          return false
+        }
+        // 忽略播放器设置按钮一层开关元素的焦点
+        if (
+          activeElement instanceof HTMLInputElement &&
+          activeElement.classList.contains('bui-switch-input')
+        ) {
+          return false
+        }
+        // 忽略播放器设置-更多播放设置单选按钮元素的焦点
+        if (
+          activeElement instanceof HTMLInputElement &&
+          activeElement.classList.contains('bui-radio-input')
+        ) {
+          return false
+        }
+        // 忽略播放器设置-更多播放设置复选按钮元素的焦点
+        if (
+          activeElement instanceof HTMLInputElement &&
+          activeElement.classList.contains('bui-checkbox-input')
         ) {
           return false
         }

--- a/registry/lib/components/utils/keymap/bindings.ts
+++ b/registry/lib/components/utils/keymap/bindings.ts
@@ -89,6 +89,13 @@ export const loadKeyBindings = lodash.once((bindings: KeyBinding[]) => {
         ) {
           return false
         }
+        // 忽略播放器弹幕开关按钮元素的焦点
+        if (
+          activeElement instanceof HTMLInputElement &&
+          activeElement.classList.contains('bui-danmaku-switch-input')
+        ) {
+          return false
+        }
         return true
       })()
       if (


### PR DESCRIPTION
修复 https://github.com/the1812/Bilibili-Evolved/issues/5550 

问题组件：
keymap 快捷键扩展。

具体原因：
通过进行相同步骤复现和利用控制台确定当前焦点后，发现鼠标在点击播放器相关按钮后，焦点变到了播放器按钮上。但根据原组件代码的逻辑，当焦点在任意播放器按钮上时，会禁止快捷键的触发，也就是对应issue中提到的设置失效。

具体修复：
基于原代码逻辑，加入对播放器相关按钮的焦点忽略。

修复结果：
经本地编译测试，未再出现快捷键扩展组件“失灵”情况。