### PR TITLE
fix: 完善toggleSubtitle()逻辑，增加无字幕时调用toggleSubtitle()的提示，修复issue#5560

### DIFF
--- a/src/components/video/player-agent/video-player.ts
+++ b/src/components/video/player-agent/video-player.ts
@@ -56,6 +56,29 @@ export class VideoPlayerBpxAgent extends PlayerAgent {
       subtitleOptions.at(0)?.click()
       return
     }
-    subtitleOptions.find(it => it.dataset.lan === subtitleLanguage)?.click()
+    // 优先选择用过的选项，其次选择与用过的选项相近的选项，最后考虑 AI 生成选项，都不满足则尝试选择可选项第一个
+    if (subtitleOptions.find(it => it.dataset.lan === subtitleLanguage)) {
+      subtitleOptions.find(it => it.dataset.lan === subtitleLanguage)?.click()
+    } else if (
+      subtitleOptions.find(
+        it =>
+          !it.dataset.lan?.startsWith('ai-') &&
+          it.dataset.lan?.includes(subtitleLanguage.split('-')[0]),
+      )
+    ) {
+      subtitleOptions
+        .find(
+          it =>
+            !it.dataset.lan?.startsWith('ai-') &&
+            it.dataset.lan?.includes(subtitleLanguage.split('-')[0]),
+        )
+        ?.click()
+    } else if (
+      subtitleOptions.find(it => it.dataset.lan === `ai-${subtitleLanguage.split('-')[0]}`)
+    ) {
+      subtitleOptions.find(it => it.dataset.lan === `ai-${subtitleLanguage.split('-')[0]}`)?.click()
+    } else {
+      subtitleOptions.at(0)?.click()
+    }
   }
 }

--- a/src/components/video/player-agent/video-player.ts
+++ b/src/components/video/player-agent/video-player.ts
@@ -3,6 +3,7 @@ import { PlayerAgent, selectorWrap } from './base'
 import { PlayerQuery, ElementQuery, AgentType } from './types'
 import { select } from '@/core/spin-query'
 import { bpxSelectors } from './bpx'
+import { Toast } from '@/core/toast'
 
 export class VideoPlayerBpxAgent extends PlayerAgent {
   type: AgentType = 'video'
@@ -54,6 +55,11 @@ export class VideoPlayerBpxAgent extends PlayerAgent {
     const subtitleLanguage = this.getPlayerConfig<null, string>('subtitle.lan', null)
     if (subtitleLanguage === null) {
       subtitleOptions.at(0)?.click()
+      return
+    }
+    // 增加无字幕时的提示
+    if (!subtitleOptions?.length) {
+      Toast.info('当前视频没有字幕可供选择', '提示', 5000)
       return
     }
     // 优先选择用过的选项，其次选择与用过的选项相近的选项，最后考虑 AI 生成选项，都不满足则尝试选择可选项第一个

--- a/src/components/video/player-agent/video-player.ts
+++ b/src/components/video/player-agent/video-player.ts
@@ -44,6 +44,11 @@ export class VideoPlayerBpxAgent extends PlayerAgent {
 
   toggleSubtitle(): HTMLElement {
     const closeSwitch = dq('.bpx-player-ctrl-subtitle-close-switch') as HTMLDivElement | null
+    // 增加当前视频无字幕功能时的提示
+    if (!closeSwitch) {
+      Toast.info('当前视频没有提供字幕功能', '提示', 5000)
+      return
+    }
     const isDisabled = closeSwitch?.classList.contains('bpx-state-active')
     if (!isDisabled) {
       closeSwitch?.click()
@@ -52,14 +57,14 @@ export class VideoPlayerBpxAgent extends PlayerAgent {
     const subtitleOptions = dqa(
       '.bpx-player-ctrl-subtitle-major .bpx-player-ctrl-subtitle-language-item',
     ) as HTMLDivElement[]
+    // 增加当前视频无字幕时的提示
+    if (!subtitleOptions?.length) {
+      Toast.info('当前视频没有字幕可供选择', '提示', 5000)
+      return
+    }
     const subtitleLanguage = this.getPlayerConfig<null, string>('subtitle.lan', null)
     if (subtitleLanguage === null) {
       subtitleOptions.at(0)?.click()
-      return
-    }
-    // 增加无字幕时的提示
-    if (!subtitleOptions?.length) {
-      Toast.info('当前视频没有字幕可供选择', '提示', 5000)
       return
     }
     // 优先选择用过的选项，其次选择与用过的选项相近的选项，最后考虑 AI 生成选项，都不满足则尝试选择可选项第一个


### PR DESCRIPTION
修复 https://github.com/the1812/Bilibili-Evolved/issues/5560 

修改原因：
“快捷键扩展-开关 CC 字幕”插件非常直接的调用了 player-agent 下的 toggleSubtitle() 方法以实现 CC 字幕的开和关，为了避免重复造轮子，直接修改这里的代码更好。

主要修改点：
1、调整了原来只能精确匹配最近一次使用过的字幕选项的逻辑，现在会以后文的规则进行逐级匹配，解决了在使用“快捷键扩展-开关 CC 字幕”插件时，虽然字幕有可选选项，但是不能通过快捷键打开关闭字幕的问题。
2、增加当前视频无字幕选项时触发 toggleSubtitle() 的提示，现在在没有字幕但有字幕按钮的视频调用 toggleSubtitle() 会提示“当前视频没有字幕可供选择”，显示时间为 5 秒；在没有字幕按钮的视频调用 toggleSubtitle() 会提示“当前视频没有提供字幕功能”，显示时间为 5 秒。

逐级匹配逻辑：
当 toggleSubtitle() 被调用时，
首先按照最近一次使用的语言精确匹配人工上传字幕（如"zh-CN"，中文；"en-US"，美式英文），
如果没有精确匹配到最近一次使用的语言的人工上传字幕，则尝试模糊匹配相近语言的人工上传字幕（如"zh-Hans"，中文简体； “en-GB”，英式英文），
如果还是失败，则继续按最近一次使用的语言匹配 AI 生成字幕（如"ai-zh"，AI中文；"ai-en"，AI英文），
如果预设的三种情况都不满足，则尝试切换到字幕可选项中第一个字幕（字幕关闭按钮下的第一个选项）。

考虑到早期字幕提交选项会出现包括但不限于：“中文”，“中文（简体）”，“中文（中国）”，但实际上这三个往往都是简体中文的情况，目前这一版逐级匹配应该能比较好处理这个遗留问题。

测试：
测试前最后一次使用的语言为：中文。测试方法是使用“快捷键扩展-开关 CC 字幕”插件，通过在对应视频页按下相应快捷键，测试目标功能是否生效。
1、【【4K60FPS丨Hi-Res】【中日CC/嵌入字幕】死別（死别）】 https://www.bilibili.com/video/BV1yLuwzpEt2
字幕类型：中文（简体）、日语，都是人工上传版本
测试结果：可以正常切换到中文（简体），也可以关闭
2、【《明日方舟：终末地》过场动画 - 却海】 https://www.bilibili.com/video/BV1vgd5BMEsG
字幕类型：中文，AI生成版本
测试结果：可以正常切换到AI中文，也可以关闭
3、【10星罗隐解放大脑，快速启动，贪婪一开直接开打】 https://www.bilibili.com/video/BV1MWdZBEE2t
字幕类型：中文、英语、日语、西班牙语、阿拉伯语、葡萄牙语，都是AI生成版本
测试结果：可以正常切换到AI中文，也可以关闭
4、【日语初级会话视频（无字幕） 日本語スターターA1】 https://www.bilibili.com/video/BV1U4411D7HX/
字幕类型：无 CC 字幕，甚至没有字幕按钮
测试结果：正常提示“当前视频没有提供字幕功能”
5、自己的投稿。
字幕类型：无 CC 字幕，但是有字幕按钮
测试结果：正常提示“当前视频没有字幕可供选择”