### PR TITLE
fix: 修正「移除充电专属动态」插件取反方向 (#5564)

### DIFF
--- a/registry/lib/plugins/feeds/filter/hide-charge-feeds/index.ts
+++ b/registry/lib/plugins/feeds/filter/hide-charge-feeds/index.ts
@@ -19,7 +19,7 @@ export const plugin: PluginMetadata = {
           lodash.get(vueData, 'data.modules.module_dynamic.major.type', null) ===
           'MAJOR_TYPE_UPOWER_COMMON'
 
-        if (isBlockedByCharge || isChargedVideo || isChargedCommonCard) {
+        if (!(isBlockedByCharge || isChargedVideo || isChargedCommonCard)) {
           return
         }
 


### PR DESCRIPTION
修复 #5564

`registry/lib/plugins/feeds/filter/hide-charge-feeds/index.ts` 在 v2.10.7 → v2.10.8 重构时扩展了充电卡片的识别范围，但条件判断的方向被无意中反过来了，导致除了真正的充电卡片以外，所有动态卡片都被加上了 `plugin-block` 类，首页看起来就空了。

把 `if` 整体取反即可恢复原来的「不是充电卡片就跳过，是充电卡片才隐藏」语义：

```diff
-        if (isBlockedByCharge || isChargedVideo || isChargedCommonCard) {
+        if (!(isBlockedByCharge || isChargedVideo || isChargedCommonCard)) {
           return
         }
         card.element.classList.add('plugin-block')
```

> Bug 的定位过程是用 Claude 协助分析 v2.10.7-preview 与 v2.10.8-preview 的源码差异得出的，已在 #5564 评论里贴了详细对比和实测截图，作者也在评论中确认了写反这件事。本 PR 只做最小改动，如果有更合适的处理方式（例如调整变量命名或拆分 `if`），请随意修改或直接关闭本 PR，谢谢作者一直以来的维护 🙏
