### PR TITLE
Encode mpv-ex protocol payload for Chrome

### DIFF
--- a/registry/lib/plugins/video/download/mpv-output-ex/handler.ts
+++ b/registry/lib/plugins/video/download/mpv-output-ex/handler.ts
@@ -31,6 +31,9 @@ const getPastebinUrl = async (str: string, config: ConfigDataType) => {
   return response
 }
 
+const buildMpvUrl = (...args: string[]) => `mpv://${encodeURIComponent(args.join(' '))}`
+const mpvHttpHeaders = '--http-header-fields="referer:https://www.bilibili.com/"'
+
 export const MPV_Ex: DownloadVideoOutput<ConfigDataType> = {
   name: 'mpv-ex',
   displayName: 'MPV 输出支持加强版',
@@ -38,14 +41,13 @@ export const MPV_Ex: DownloadVideoOutput<ConfigDataType> = {
     '多文件时格式选择 flv，使用前请先阅读 <a href="https://github.com/Asukaaaaaa/tricks/blob/main/Bilibili-Evolved%20mpv-ex%20%E6%8F%92%E4%BB%B6.md" target="blank">README</a>',
   runAction: async (action, instance) => {
     let finalURL: string
-    const mpv_protocol = 'mpv://--http-header-fields="referer:https://www.bilibili.com/"'
     if (action.isSingleVideo) {
       // 单文件直接生成 url
       const frag = action.infos[0].fragments
       if (frag.length === 1) {
-        finalURL = `${mpv_protocol} ${frag[0].url}`
+        finalURL = buildMpvUrl(mpvHttpHeaders, `"${frag[0].url}"`)
       } else if (frag.length === 2) {
-        finalURL = `${mpv_protocol} ${frag[0].url} --audio-file=${frag[1].url}`
+        finalURL = buildMpvUrl(mpvHttpHeaders, `"${frag[0].url}"`, `--audio-file="${frag[1].url}"`)
       }
     } else {
       // 多文件生成 .m3u 播放列表
@@ -57,7 +59,7 @@ export const MPV_Ex: DownloadVideoOutput<ConfigDataType> = {
           /^(https:\/\/pastebin.com)\/(.*)/,
           '$1/raw/$2?.m3u',
         )
-        finalURL = `${mpv_protocol} ${playlist}`
+        finalURL = buildMpvUrl(mpvHttpHeaders, `"${playlist}"`)
       } catch (error) {
         logError(error)
         return

--- a/registry/lib/plugins/video/download/mpv-output-ex/handler.ts
+++ b/registry/lib/plugins/video/download/mpv-output-ex/handler.ts
@@ -45,9 +45,9 @@ export const MPV_Ex: DownloadVideoOutput<ConfigDataType> = {
       // 单文件直接生成 url
       const frag = action.infos[0].fragments
       if (frag.length === 1) {
-        finalURL = buildMpvUrl(mpvHttpHeaders, `"${frag[0].url}"`)
+        finalURL = buildMpvUrl(mpvHttpHeaders, frag[0].url)
       } else if (frag.length === 2) {
-        finalURL = buildMpvUrl(mpvHttpHeaders, `"${frag[0].url}"`, `--audio-file="${frag[1].url}"`)
+        finalURL = buildMpvUrl(mpvHttpHeaders, frag[0].url, `--audio-file=${frag[1].url}`)
       }
     } else {
       // 多文件生成 .m3u 播放列表
@@ -59,7 +59,7 @@ export const MPV_Ex: DownloadVideoOutput<ConfigDataType> = {
           /^(https:\/\/pastebin.com)\/(.*)/,
           '$1/raw/$2?.m3u',
         )
-        finalURL = buildMpvUrl(mpvHttpHeaders, `"${playlist}"`)
+        finalURL = buildMpvUrl(mpvHttpHeaders, playlist)
       } catch (error) {
         logError(error)
         return


### PR DESCRIPTION
## Summary
- encode the mpv:// argument payload before calling window.open
- keep compatibility with the documented Windows protocol handler that UrlDecodes %1

## Why
The previous mpv-ex output built raw custom-protocol URLs like mpv://--http-header-fields="..." https://... --audio-file=https://....

That does not adapt to Chrome/Chromium URL validation for custom protocols: raw spaces, quotes, https:// URLs, query strings, ampersands, and --audio-file= can make window.open reject the value as an invalid URL before the registered mpv:// protocol handler is invoked.

Encoding the argument payload keeps the browser-visible URL valid while still letting the existing handler decode and pass the original mpv arguments to mpv.

## Testing
- git diff --check
- locally validated the same encoded mpv:// payload with the documented UrlDecode registry handler