### PR TITLE
给`动态分组过滤`组件添加一个展开收起的功能，并适配`直播信息扩展`组件的高度。

### DIFF
--- a/registry/lib/components/feeds/extend-live/LiveList.vue
+++ b/registry/lib/components/feeds/extend-live/LiveList.vue
@@ -313,9 +313,24 @@ onBeforeUnmount(() => {
       max-height: calc(100vh - 414px);
     }
 
+    // 开启动态分组过滤
+    .group-filter-section ~ .sticky & {
+      max-height: calc(100vh - 414px);
+    }
+
+    // 同时开启动态过滤器和动态分组过滤
+    body.enable-feeds-filter .group-filter-section ~ .sticky & {
+      max-height: calc(100vh - 470px);
+    }
+
     // 禁掉 profile 后
     body.feeds-filter-side-block-profile & {
       max-height: calc(100vh - 218px);
+    }
+
+    // 禁掉 profile 后开启动态分组过滤
+    body.feeds-filter-side-block-profile .group-filter-section ~ .sticky & {
+      max-height: calc(100vh - 274px);
     }
   }
 

--- a/registry/lib/components/feeds/group-filter/FilterPanel.vue
+++ b/registry/lib/components/feeds/group-filter/FilterPanel.vue
@@ -1,8 +1,11 @@
 <template>
-  <div class="group-filter-panel">
-    <div class="group-filter-header">
-      <h1>分组</h1>
-      <switch-box v-model="allChecked" />
+  <div class="group-filter-panel" :class="{ collapse }">
+    <div class="group-filter-header" @click="collapse = !collapse">
+      <h1>动态分组过滤</h1>
+      <VIcon icon="mdi-chevron-up" />
+    </div>
+    <div class="group-item group-select-all">
+      <CheckBox v-model="allChecked"> 全选 </CheckBox>
     </div>
     <div v-for="(group, index) in groups" :key="index" class="group-item">
       <CheckBox v-model="group.checked">
@@ -13,7 +16,7 @@
 </template>
 
 <script lang="ts">
-import { CheckBox, SwitchBox } from '@/ui'
+import { CheckBox, VIcon } from '@/ui'
 import { bilibiliApi, getJsonWithCredentials, getPages } from '@/core/ajax'
 import { FeedsCard, forEachFeedsCard } from '@/components/feeds/api'
 import { getUID } from '@/core/utils'
@@ -28,8 +31,8 @@ let cardsManager: typeof import('@/components/feeds/api').feedsCardsManager
 
 export default Vue.extend({
   components: {
-    SwitchBox,
     CheckBox,
+    VIcon,
   },
   data() {
     return {
@@ -37,11 +40,13 @@ export default Vue.extend({
       followingMap: new Map<string, number[]>(), // username -> tagid[]
       selectedGroupIds: [],
       allChecked: true,
+      collapse: true,
     } as {
       groups: Group[]
       followingMap: Map<string, number[]>
       selectedGroupIds: number[]
       allChecked: boolean
+      collapse: boolean
     }
   },
   watch: {
@@ -123,6 +128,7 @@ export default Vue.extend({
   width: 100%;
   border-radius: 4px;
   box-sizing: border-box;
+  display: flex;
   flex-direction: column;
   padding: 12px 16px;
 
@@ -131,14 +137,29 @@ export default Vue.extend({
     padding-bottom: 14px;
     position: sticky;
     top: 0;
+    background-color: inherit;
     display: flex;
     align-items: center;
     justify-content: space-between;
 
     h1 {
       font-weight: normal;
-      font-size: 16px;
+      font-size: 14px;
       margin: 0;
+    }
+  }
+
+  &.collapse {
+    .group-filter-header {
+      padding-bottom: 0;
+
+      .be-icon {
+        transform: rotate(180deg);
+      }
+    }
+
+    > :not(.group-filter-header) {
+      display: none;
     }
   }
 
@@ -146,6 +167,10 @@ export default Vue.extend({
     display: flex;
     flex-direction: row;
     font-size: 14px;
+  }
+
+  .group-select-all {
+    padding-bottom: 6px;
   }
 
   body.dark & {

--- a/registry/lib/components/feeds/group-filter/FilterPanel.vue
+++ b/registry/lib/components/feeds/group-filter/FilterPanel.vue
@@ -19,7 +19,9 @@
 import { CheckBox, VIcon } from '@/ui'
 import { bilibiliApi, getJsonWithCredentials, getPages } from '@/core/ajax'
 import { FeedsCard, forEachFeedsCard } from '@/components/feeds/api'
+import { getComponentSettings } from '@/core/settings'
 import { getUID } from '@/core/utils'
+import { FeedsGroupFilterOptions } from './options'
 
 interface Group {
   name: string
@@ -27,7 +29,8 @@ interface Group {
   id: number
 }
 
-let cardsManager: typeof import('@/components/feeds/api').feedsCardsManager
+let cardsManager: typeof import('@/components/feeds/api').feedsCardsManager | undefined
+const { options } = getComponentSettings<FeedsGroupFilterOptions>('feedsGroupFilter')
 
 export default Vue.extend({
   components: {
@@ -39,33 +42,41 @@ export default Vue.extend({
       groups: [],
       followingMap: new Map<string, number[]>(), // username -> tagid[]
       selectedGroupIds: [],
-      allChecked: true,
       collapse: true,
+      isRestoringGroups: true,
     } as {
       groups: Group[]
       followingMap: Map<string, number[]>
       selectedGroupIds: number[]
-      allChecked: boolean
       collapse: boolean
+      isRestoringGroups: boolean
     }
+  },
+  computed: {
+    allChecked: {
+      get(): boolean {
+        return this.groups.every(group => group.checked)
+      },
+      set(newChecked: boolean) {
+        for (const group of this.groups) {
+          group.checked = newChecked
+        }
+      },
+    },
   },
   watch: {
     groups: {
       handler(newGroups: Group[]) {
         this.selectedGroupIds = newGroups.filter(group => group.checked).map(group => group.id)
-        cardsManager.cards.forEach(card => {
-          this.updateCard(lodash.clone(card))
-        })
+        this.updateCards()
+        if (!this.isRestoringGroups) {
+          options.disabledGroupIds = newGroups
+            .filter(group => !group.checked)
+            .map(group => group.id)
+        }
       },
       deep: true,
       immediate: true,
-    },
-    allChecked: {
-      handler(newChecked: boolean) {
-        for (const group of this.groups) {
-          group.checked = newChecked
-        }
-      },
     },
   },
   async mounted() {
@@ -75,16 +86,19 @@ export default Vue.extend({
       },
     })
     // fetch groups
+    const disabledGroupIds = options.disabledGroupIds ?? []
+    this.isRestoringGroups = true
     this.groups = await bilibiliApi<Array<any>>(
       getJsonWithCredentials('https://api.bilibili.com/x/relation/tags'),
       '分组信息获取失败',
     ).then(res =>
       res.map(value => ({
         name: value.name,
-        checked: true,
+        checked: !disabledGroupIds.includes(value.tagid),
         id: value.tagid,
       })),
     )
+    this.isRestoringGroups = false
 
     const uid = getUID()
     // fetch following
@@ -99,8 +113,17 @@ export default Vue.extend({
     allPages.forEach(user => {
       this.followingMap.set(user.uname, user.tag)
     })
+    this.updateCards()
   },
   methods: {
+    updateCards() {
+      if (!cardsManager) {
+        return
+      }
+      cardsManager.cards.forEach(card => {
+        this.updateCard(lodash.clone(card))
+      })
+    },
     updateCard(card: FeedsCard) {
       // 从username获得tag
       const userTagIds: number[] = this.followingMap.get(card.username)

--- a/registry/lib/components/feeds/group-filter/index.ts
+++ b/registry/lib/components/feeds/group-filter/index.ts
@@ -1,5 +1,6 @@
 import { defineComponentMetadata } from '@/components/define'
 import { feedsCardsManager } from '@/components/feeds/api'
+import { options } from './options'
 
 const entry = async () => {
   const { select } = await import('@/core/spin-query')
@@ -26,6 +27,7 @@ export const component = defineComponentMetadata({
   entry,
   displayName: '动态分组过滤',
   author: { name: 'Rinne', link: 'https://github.com/OharaRinneY' },
+  options,
   urlInclude: [
     // 仅动态首页
     /^https:\/\/t\.bilibili\.com\/$/,

--- a/registry/lib/components/feeds/group-filter/options.ts
+++ b/registry/lib/components/feeds/group-filter/options.ts
@@ -1,0 +1,11 @@
+import { OptionsOfMetadata, defineOptionsMetadata } from '@/components/define'
+
+export const options = defineOptionsMetadata({
+  disabledGroupIds: {
+    defaultValue: [] as number[],
+    displayName: 'Disabled group IDs',
+    hidden: true,
+  },
+})
+
+export type FeedsGroupFilterOptions = OptionsOfMetadata<typeof options>


### PR DESCRIPTION
给`动态分组过滤`组件添加一个展开收起的功能，同`动态过滤`组件一样。避免高度占用过多。
持久化保存`动态分组过滤`组件的选项值。避免每次刷新都需要重新选择。

给`直播信息扩展`组件的正在直播面板，适配开启`动态分组过滤`组件（收起状态）时的高度。

避免同时开启`强制固定动态侧栏`和这几个组件的时候，正在直播面板被挤到屏幕外去了。

<img width="627" height="1111" alt="image" src="https://github.com/user-attachments/assets/9dc78279-0760-4904-9c7e-5161e226e7b5" />

<img width="605" height="267" alt="image" src="https://github.com/user-attachments/assets/7b212bda-b87b-44c1-ac0d-70fa30c38e6d" />
