### PR TITLE
fix(ColorPicker): hex 输入框无 `#` 时自动补全

### DIFF
--- a/src/ui/ColorPicker.vue
+++ b/src/ui/ColorPicker.vue
@@ -293,8 +293,12 @@ export default Vue.extend({
       this.wrapper.color = new Color(this.color)
     },
     selectHexColor(hex: string) {
+      let normalized = (hex ?? '').trim()
+      if (normalized && !normalized.startsWith('#') && /^[0-9a-fA-F]{3,8}$/.test(normalized)) {
+        normalized = `#${normalized}`
+      }
       try {
-        const newColor = new Color(hex, 'hex')
+        const newColor = new Color(normalized, 'hex')
         this.wrapper.color = newColor
       } catch (error) {
         // Do nothing

--- a/src/ui/ColorPicker.vue
+++ b/src/ui/ColorPicker.vue
@@ -294,7 +294,11 @@ export default Vue.extend({
     },
     selectHexColor(hex: string) {
       let normalized = (hex ?? '').trim()
-      if (normalized && !normalized.startsWith('#') && /^[0-9a-fA-F]{3,8}$/.test(normalized)) {
+      if (
+        normalized
+        && !normalized.startsWith('#')
+        && /^(?:[0-9a-fA-F]{3,4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/.test(normalized)
+      ) {
         normalized = `#${normalized}`
       }
       try {

--- a/src/ui/ColorPicker.vue
+++ b/src/ui/ColorPicker.vue
@@ -295,9 +295,9 @@ export default Vue.extend({
     selectHexColor(hex: string) {
       let normalized = (hex ?? '').trim()
       if (
-        normalized
-        && !normalized.startsWith('#')
-        && /^(?:[0-9a-fA-F]{3,4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/.test(normalized)
+        normalized &&
+        !normalized.startsWith('#') &&
+        /^(?:[0-9a-fA-F]{3,4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/.test(normalized)
       ) {
         normalized = `#${normalized}`
       }


### PR DESCRIPTION
## 问题

`ColorPicker` 的 hex 输入框走 `selectHexColor(hex)`，内部用 `new Color(hex, 'hex')` 解析。当用户从外部复制一段不带 `#` 的纯 hex 字符串（例如`1d2736`）粘贴到这个框里回车，`color` 库会抛 `Unable to parse color from string`，被 `try/catch` 吞掉，颜色不变也没有任何反馈，体感就是"输入了没反应"。

## 修复

在 `selectHexColor` 进入解析前，对输入做一次规整：

- 去首尾空白
- 如果非空、不以 `#` 开头、且整体是 3~8 位纯十六进制（`/^[0-9a-fA-F]{3,8}$/`），自动前置 `#`
- 其它情况保持原样交给 `color` 库，行为不变

```ts
selectHexColor(hex: string) {
  let normalized = (hex ?? '').trim()
  if (normalized && !normalized.startsWith('#') && /^[0-9a-fA-F]{3,8}$/.test(normalized)) {
    normalized = `#${normalized}`
  }
  try {
    const newColor = new Color(normalized, 'hex')
    this.wrapper.color = newColor
  } catch (error) {
    // Do nothing
  }
}
```

## 影响

- 所有使用 `color: true` 选项的组件 / 插件都受益
- 已经带 `#` 的输入不受影响
- 无需引入新依赖

## 自测
在颜色值输入框中：

- [x] 粘贴 `1d2736` 回车：颜色变为 `#1D2736`
- [x] 粘贴 `#1d2736` 回车：颜色变为 `#1D2736`（原有路径）
- [x] 粘贴 `fff` 回车：颜色变为 `#FFFFFF`（3 位短 hex 也支持）
- [x] 粘贴 `xyz` 回车：保持当前颜色不变（非 hex，原有 catch 路径）
- [x] 粘贴空字符串：保持当前颜色不变（非 hex，原有 catch 路径）
- [x] 粘贴 `12345` / `1234567` 回车：保持当前颜色不变（非法长度，不补 `#`，原有 catch 路径）
