### PR TITLE
使点赞直播间时的点赞次数可输入可修改

### DIFF
--- a/registry/lib/components/live/badge-keepalive/BadgeKeepalive.vue
+++ b/registry/lib/components/live/badge-keepalive/BadgeKeepalive.vue
@@ -7,6 +7,12 @@
       :change-on-blur="true"
       @change="handleRoomIdChange"
     ></TextBox>
+    <TextBox
+      placeholder="点赞次数"
+      :text="clickTimes"
+      :change-on-blur="true"
+      @change="handleClickTimesChange"
+    ></TextBox>
     <AsyncButton @click="handleKeepAliveRequest">点亮!</AsyncButton>
   </div>
 </template>
@@ -19,12 +25,19 @@ import { validateRoomId, getLiveRoomId, keepAliveRequest } from './utils'
 import { Toast } from '@/core/toast'
 
 const roomid = ref(getLiveRoomId())
+const clickTimes = ref('300')
 const handleRoomIdChange = (value: string) => {
   if (validateRoomId(value)) {
     roomid.value = value
   } else {
     roomid.value = ''
   }
+}
+const handleClickTimesChange = (value: string) => {
+    const parsedNum = parseInt(value, 10)
+    if (!isNaN(parsedNum)){
+        clickTimes.value = parsedNum.toString()
+    }
 }
 
 const handleKeepAliveRequest = async () => {
@@ -33,7 +46,7 @@ const handleKeepAliveRequest = async () => {
   }
 
   try {
-    await keepAliveRequest(roomid.value)
+    await keepAliveRequest(roomid.value, clickTimes.value)
     Toast.success('发送点亮勋章请求成功', '提示')
   } catch ({ message }) {
     Toast.error(`勋章点亮失败，原因: ${message}`, '提示')

--- a/registry/lib/components/live/badge-keepalive/BadgeKeepalive.vue
+++ b/registry/lib/components/live/badge-keepalive/BadgeKeepalive.vue
@@ -34,10 +34,10 @@ const handleRoomIdChange = (value: string) => {
   }
 }
 const handleClickTimesChange = (value: string) => {
-    const parsedNum = parseInt(value, 10)
-    if (!isNaN(parsedNum)){
-        clickTimes.value = parsedNum.toString()
-    }
+  const parsedNum = parseInt(value)
+  if (!isNaN(parsedNum)){
+    clickTimes.value = parsedNum.toString()
+  }
 }
 
 const handleKeepAliveRequest = async () => {

--- a/registry/lib/components/live/badge-keepalive/BadgeKeepalive.vue
+++ b/registry/lib/components/live/badge-keepalive/BadgeKeepalive.vue
@@ -35,7 +35,7 @@ const handleRoomIdChange = (value: string) => {
 }
 const handleClickTimesChange = (value: string) => {
   const parsedNum = parseInt(value)
-  if (!isNaN(parsedNum)){
+  if (!isNaN(parsedNum)) {
     clickTimes.value = parsedNum.toString()
   }
 }

--- a/registry/lib/components/live/badge-keepalive/BadgeKeepalive.vue
+++ b/registry/lib/components/live/badge-keepalive/BadgeKeepalive.vue
@@ -21,11 +21,11 @@
 import { ref } from 'vue'
 import { TextBox, AsyncButton } from '@/ui'
 
-import { validateRoomId, getLiveRoomId, keepAliveRequest } from './utils'
+import { validateRoomId, getLiveRoomId, keepAliveRequest, defaultClickTimes } from './utils'
 import { Toast } from '@/core/toast'
 
 const roomid = ref(getLiveRoomId())
-const clickTimes = ref('300')
+const clickTimes = ref(defaultClickTimes)
 const handleRoomIdChange = (value: string) => {
   if (validateRoomId(value)) {
     roomid.value = value

--- a/registry/lib/components/live/badge-keepalive/utils.ts
+++ b/registry/lib/components/live/badge-keepalive/utils.ts
@@ -31,7 +31,9 @@ export async function getLiveRoomUserInfo(room_id: string) {
   return validateJSON(data)
 }
 
-export async function keepAliveRequest(room_id: string, click_time = '300') {
+export const defaultClickTimes = '300'
+
+export async function keepAliveRequest(room_id: string, click_time = defaultClickTimes) {
   // 需要先获取直播间房主的 UID
   const data = await getLiveRoomUserInfo(room_id)
 


### PR DESCRIPTION
点亮粉丝勋章功能只需要点赞30次可以达到效果（LikeReportV3接口的参数click_times为30），但目前使用的是默认值300次。考虑到每日点赞次数有上限3000次，提供给用户修改点赞次数的选项
