### PR TITLE
[组件-快速收藏] 快速收藏组件 RBVP 支持

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -87,6 +87,7 @@
     "preload",
     "protobuf",
     "pubdate",
+    "rbvp",
     "rcount",
     "reimu",
     "reloadable",

--- a/registry/lib/components/video/player/rbvp/engine.ts
+++ b/registry/lib/components/video/player/rbvp/engine.ts
@@ -287,7 +287,7 @@ export const executeRbvpRules = async (
       rule.line,
     )
     try {
-      provider.validateAction?.(action.value)
+      await provider.validateAction?.(action.value)
       const resolved = await provider.resolveAction(action.value, context)
       if (!resolved) {
         addDebugStep(

--- a/registry/lib/components/video/player/rbvp/types.ts
+++ b/registry/lib/components/video/player/rbvp/types.ts
@@ -144,7 +144,7 @@ export interface RBVPNamespaceProvider {
   getTakeoverState: () => boolean
   setTakeoverState: (value: boolean) => void
   setup?: (runtime: RBVPRuntime) => Promise<void> | void
-  validateAction?: (rawValue: string) => void
+  validateAction?: (rawValue: string) => Promise<void> | void
   resolveAction: (
     rawValue: string,
     context: RBVPEngineContext,

--- a/registry/lib/components/video/quick-favorite/QuickFavorite.vue
+++ b/registry/lib/components/video/quick-favorite/QuickFavorite.vue
@@ -1,5 +1,6 @@
 <template>
   <span
+    v-show="show"
     class="quick-favorite be-quick-favorite video-toolbar-left-item"
     title="快速收藏"
     :class="{ on: isFavorite, ...displayModeClass }"
@@ -15,7 +16,7 @@
       快速收藏
     </div>
     <div ref="selectList" class="select-list" :class="{ show: listShowing }">
-      <div class="lists">
+      <div v-if="!useRbvp" class="lists">
         选择快速收藏夹:
         <VDropdown
           v-model="selectedFavoriteList"
@@ -24,7 +25,10 @@
           @change="saveFavoriteList"
         />
       </div>
-      <div class="lists-tip" :class="{ show: listShowing }">右键点击快速收藏可再次打开</div>
+      <div v-if="!useRbvp" class="lists-tip">右键点击快速收藏可再次打开</div>
+      <div v-else class="lists-tip">
+        <i>由 RBVP 接管：{{ selectedFavoriteList.displayName }}</i>
+      </div>
     </div>
     <div class="tip" :class="{ show: tipShowing }">{{ tipText }}</div>
   </span>
@@ -37,6 +41,7 @@ import { logError } from '@/core/utils/log'
 import { Toast } from '@/core/toast'
 import { VDropdown } from '@/ui'
 import { DisplayMode, Options } from './options'
+import { componentsMap } from '@/components/component'
 
 const { options } = getComponentSettings('quickFavorite')
 interface RawFavoriteListItem {
@@ -58,8 +63,9 @@ export default Vue.extend({
     VDropdown,
   },
   data() {
-    const { displayMode } = getComponentSettings<Options>('outerWatchlater').options
+    const { displayMode } = getComponentSettings<Options>('quickFavorite').options
     return {
+      show: false,
       aid: unsafeWindow.aid,
       isFavorite: false,
       tipText: '',
@@ -69,6 +75,7 @@ export default Vue.extend({
       selectedFavoriteList: EmptyFavoriteList,
       listShowing: false,
       displayMode,
+      useRbvp: false,
     }
   },
   computed: {
@@ -96,9 +103,28 @@ export default Vue.extend({
     },
   },
   created() {
-    this.loadSavedList()
     addComponentListener('quickFavorite.displayMode', (value: DisplayMode) => {
       this.displayMode = value
+    })
+    addComponentListener(
+      'quickFavorite.useRbvp',
+      (useRbvp: boolean) => {
+        this.useRbvp =
+          Boolean(componentsMap.rbvp) && getComponentSettings('rbvp').enabled && useRbvp
+        if (!this.useRbvp) {
+          this.loadSavedList()
+          this.show = true
+        }
+        // RBVP接管时暂时不显示
+      },
+      true,
+    )
+    addComponentListener('quickFavorite.favoriteFolderID', () => {
+      if (this.useRbvp) {
+        this.syncFavoriteState()
+        // 由RBVP设置完后再显示
+        this.show = true
+      }
     })
   },
   methods: {

--- a/registry/lib/components/video/quick-favorite/index.ts
+++ b/registry/lib/components/video/quick-favorite/index.ts
@@ -1,11 +1,15 @@
 import { defineComponentMetadata } from '@/components/define'
 import { ComponentEntry } from '@/components/types'
+import { addVideoActionButton } from '@/components/video/video-actions'
+import { videoChange } from '@/core/observer'
 import { getUID, matchUrlPattern, mountVueComponent } from '@/core/utils'
 import { favoriteListUrls, videoUrls } from '@/core/utils/urls'
 import { KeyBindingAction } from '../../utils/keymap/bindings'
-import { addVideoActionButton } from '@/components/video/video-actions'
-import { videoChange } from '@/core/observer'
 import { options, Options } from './options'
+import { rbvpNamespaceProvider } from './rbvp-provider'
+
+export const componentName = 'quickFavorite'
+export const displayName = '快速收藏'
 
 const entry: ComponentEntry<Options> = async ({ settings }) => {
   if (favoriteListUrls.some(matchUrlPattern) && !settings.options.showInFavoritePages) {
@@ -26,7 +30,7 @@ const entry: ComponentEntry<Options> = async ({ settings }) => {
   })
 }
 export const component = defineComponentMetadata({
-  name: 'quickFavorite',
+  name: componentName,
   displayName: '启用快速收藏',
   description: {
     'zh-CN':
@@ -43,21 +47,39 @@ export const component = defineComponentMetadata({
   // urlExclude: favoriteListUrls,
   tags: [componentsTags.video],
   options,
-  plugin: {
-    displayName: '快速收藏 - 快捷键支持',
-    setup: ({ addData }) => {
-      addData('keymap.actions', (actions: Record<string, KeyBindingAction>) => {
-        actions.quickFavorite = {
-          displayName: '快速收藏',
-          run: context => {
-            const { clickElement } = context
-            return clickElement('.be-quick-favorite', context)
-          },
-        }
-      })
-      addData('keymap.presets', (presetBase: Record<string, string>) => {
-        presetBase.quickFavorite = 'shift s'
-      })
+  plugin: [
+    {
+      name: `${componentName}.keymap`,
+      displayName: `${displayName} - 快捷键支持`,
+      setup: ({ addData }) => {
+        addData('keymap.actions', (actions: Record<string, KeyBindingAction>) => {
+          actions.quickFavorite = {
+            displayName,
+            run: context => {
+              const { clickElement } = context
+              return clickElement('.be-quick-favorite', context)
+            },
+          }
+        })
+        addData('keymap.presets', (presetBase: Record<string, string>) => {
+          presetBase.quickFavorite = 'shift s'
+        })
+      },
     },
-  },
+    {
+      name: `${componentName}.rbvp`,
+      displayName: `${displayName} - RBVP 兼容`,
+      author: [
+        {
+          name: 'LainIO24',
+          link: 'https://github.com/LainIO24',
+        },
+      ],
+      setup: ({ addData }) => {
+        addData('rbvp.namespaces', namespaces => {
+          namespaces.quickFavorite = rbvpNamespaceProvider
+        })
+      },
+    },
+  ],
 })

--- a/registry/lib/components/video/quick-favorite/options.ts
+++ b/registry/lib/components/video/quick-favorite/options.ts
@@ -6,6 +6,11 @@ export enum DisplayMode {
   IconAndText = '图标 + 文字',
 }
 export const options = defineOptionsMetadata({
+  useRbvp: {
+    defaultValue: false,
+    displayName: '使用 RBVP',
+    hidden: true,
+  },
   favoriteFolderID: {
     defaultValue: 0,
     displayName: '快速收藏夹ID',

--- a/registry/lib/components/video/quick-favorite/rbvp-provider.ts
+++ b/registry/lib/components/video/quick-favorite/rbvp-provider.ts
@@ -1,0 +1,75 @@
+import { getJsonWithCredentials } from '@/core/ajax'
+import { addComponentListener, getComponentSettings } from '@/core/settings'
+import { getUID } from '@/core/utils'
+
+import {
+  RBVPEngineContext,
+  RBVPNamespaceProvider,
+  RBVPResolvedAction,
+  RBVPRuntime,
+} from '../player/rbvp/types'
+import { Options } from './options'
+
+export const componentName = 'quickFavorite'
+export const displayName = '快速收藏'
+const guard = `${componentName}:execute`
+
+const getOption = () => getComponentSettings<Options>(componentName).options
+
+async function parseFavFolder(rawValue: string) {
+  const id = parseInt(rawValue)
+  if (isNaN(id) || id < 0 || String(id) !== rawValue) {
+    throw new Error(`无效的收藏夹ID: ${rawValue}`)
+  }
+  const { code, message, data } = await getJsonWithCredentials(
+    `https://api.bilibili.com/x/v3/fav/folder/info?media_id=${id}`,
+  )
+  if (code !== 0 || !data) {
+    throw new Error(`获取收藏夹失败: ${message}`)
+  }
+  if (data.mid !== parseInt(getUID())) {
+    throw new Error(`只能设置自己创建的收藏夹：${data.title}, ${id}`)
+  }
+  return { id: data.id, title: data.title }
+}
+
+export const rbvpNamespaceProvider: RBVPNamespaceProvider = {
+  displayName,
+  primaryName: componentName,
+  description: `设置「${displayName}」组件的目标收藏夹。值为收藏夹的ID（可在收藏夹页面的URL中查看）`,
+  getTakeoverState: () => getOption().useRbvp,
+  setTakeoverState: (value: boolean) => {
+    getOption().useRbvp = value
+  },
+  isComponentEnabled: () => getComponentSettings(componentName).enabled,
+  setup: async (runtime: RBVPRuntime) => {
+    addComponentListener(`${componentName}.useRbvp`, () => {
+      runtime.requestApplyRules()
+    })
+  },
+  validateAction: rawValue => {
+    parseFavFolder(rawValue)
+  },
+  resolveAction: async rawValue => {
+    const favFolder = await parseFavFolder(rawValue)
+    return {
+      namespace: componentName,
+      displayValue: favFolder.title,
+      value: favFolder.id,
+    }
+  },
+  execute: async (action: RBVPResolvedAction, context: RBVPEngineContext) => {
+    if (context.runtime.hasGuard(guard)) {
+      return undefined
+    }
+    context.runtime.enterGuard(guard)
+    try {
+      getOption().favoriteFolderID = action.value as number
+      return `${displayName}: ${action.displayValue}`
+    } finally {
+      window.setTimeout(() => {
+        context.runtime.leaveGuard(guard)
+      }, 300)
+    }
+  },
+}

--- a/src/components/types.ts
+++ b/src/components/types.ts
@@ -1,9 +1,9 @@
-import { TestPattern, Executable, VueModule, I18nDescription } from '@/core/common-types'
-import { ComponentSettings } from '@/core/settings'
+import { Widget } from '@/components/widget'
+import { Executable, I18nDescription, TestPattern, VueModule } from '@/core/common-types'
 import { CoreApis } from '@/core/core-apis'
+import { ComponentSettings } from '@/core/settings'
 import { PluginMinimalData } from '@/plugins/plugin'
 import { Range } from '@/ui/range'
-import { Widget } from '@/components/widget'
 import { LanguagePack } from './i18n/types'
 
 export type Author = {
@@ -191,7 +191,7 @@ export interface FunctionalMetadata<O extends UnknownOptions = UnknownOptions> {
   /** 关闭时执行 */
   unload?: Executable
   /** 插件化数据定义 */
-  plugin?: Optional<PluginMinimalData, 'name'>
+  plugin?: Optional<PluginMinimalData, 'name'> | Optional<PluginMinimalData, 'name'>[]
   /** 额外想要展示在设置里的选项 UI */
   extraOptions?: () => Promise<VueModule>
   /** 设置匹配的URL, 不匹配则不运行此组件 */

--- a/src/plugins/plugin.ts
+++ b/src/plugins/plugin.ts
@@ -1,6 +1,6 @@
 import { ComponentMetadata, FeatureBase } from '@/components/component'
-import { deleteValue } from '@/core/utils'
 import { CoreApis } from '@/core/core-apis'
+import { deleteValue } from '@/core/utils'
 import { addData, registerAndGetData, registerData } from './data'
 import { addHook, getHook } from './hook'
 
@@ -128,11 +128,14 @@ export const extractPluginFromComponent = (component: ComponentMetadata) => {
   if (!component.plugin) {
     return null
   }
-  return {
-    name: `${component.name}.plugin`,
-    displayName: `${component.displayName} - 附带插件`,
-    ...component.plugin,
-  } as PluginMetadata
+  return (Array.isArray(component.plugin) ? component.plugin : [component.plugin]).map(
+    plugin =>
+      ({
+        name: `${component.name}.plugin`,
+        displayName: `${component.displayName} - 附带插件`,
+        ...plugin,
+      } as PluginMetadata),
+  )
 }
 /**
  * 载入单个插件
@@ -165,7 +168,7 @@ export const loadAllPlugins = async (components: ComponentMetadata[]) => {
   for (const component of components) {
     const plugin = extractPluginFromComponent(component)
     if (plugin) {
-      plugins.push(plugin)
+      plugins.push(...plugin)
     }
   }
   for (const [name, setting] of Object.entries(settings.userPlugins)) {


### PR DESCRIPTION
通过 [RBVP 组件](https://github.com/the1812/Bilibili-Evolved/pull/5577) 设置「快速收藏」组件的目标收藏夹。

- 添加 RBVP 命名空间 `quickFavorite`，值为收藏夹的ID：
    <img height="128" src="https://github.com/user-attachments/assets/b475e340-4568-48b1-9331-d7954d1da784" />

  - 验证收藏夹可用性：
      <img height="64" src="https://github.com/user-attachments/assets/d53cff03-6811-4796-94c9-60df9a214da1" /><img height="64" src="https://github.com/user-attachments/assets/5bf7f686-7872-454a-9c58-4bbb6548e735" />

- 由 RBVP 接管时，禁用「快速收藏」的收藏夹选择右键菜单：
    <img height="96" src="https://github.com/user-attachments/assets/55f90feb-5709-445d-a24b-a43ab3e33af8" />

---

- Bilibili-Evolved 本体的更改：
  - 支持组件定义多个内置插件
      <img height="128" src="https://github.com/user-attachments/assets/0900d218-29c8-4cb2-8a31-c190f8b7fa88" />


- 组件 RBVP 的更改：
  - 支持异步验证