### PR TITLE
[新增组件] 视频快照

### DIFF
--- a/registry/lib/components/video/snapshot/Plugin.vue
+++ b/registry/lib/components/video/snapshot/Plugin.vue
@@ -1,0 +1,32 @@
+<template>
+  <div class="download-cover-config download-video-config-section" style="display: flex">
+    <div class="download-video-config-title">视频快照图：</div>
+    <SwitchBox v-model="enabled" />
+  </div>
+</template>
+<script lang="ts">
+import { getComponentSettings } from '@/core/settings'
+import { UnknownOptions } from '@/components/component'
+import { SwitchBox } from '@/ui'
+
+interface Options extends UnknownOptions {
+  videoSnapshotGrid: boolean
+}
+const { options } = getComponentSettings<Options>('downloadVideo')
+
+export default Vue.extend({
+  components: {
+    SwitchBox,
+  },
+  data() {
+    return {
+      enabled: !!options.videoSnapshotGrid,
+    }
+  },
+  watch: {
+    enabled(enabled: boolean) {
+      options.videoSnapshotGrid = enabled
+    },
+  },
+})
+</script>

--- a/registry/lib/components/video/snapshot/ViewSnapshots.vue
+++ b/registry/lib/components/video/snapshot/ViewSnapshots.vue
@@ -1,0 +1,39 @@
+<template>
+  <DefaultWidget
+    :disabled="disabled"
+    name="查看预览图"
+    icon="mdi-image-outline"
+    class="view-video-snapshot-grid"
+    @click="viewSnapshotGrid()"
+  ></DefaultWidget>
+</template>
+
+<script lang="ts">
+import { DefaultWidget } from '@/ui'
+import { logError } from '@/core/utils/log'
+import { viewSnapshotGrid } from './handler'
+
+export default Vue.extend({
+  components: {
+    DefaultWidget,
+  },
+  data() {
+    return {
+      disabled: false,
+    }
+  },
+  methods: {
+    async viewSnapshotGrid() {
+      try {
+        this.disabled = true
+        const { aid, cid } = unsafeWindow
+        await viewSnapshotGrid(aid, parseInt(cid))
+      } catch (error) {
+        logError(error)
+      } finally {
+        this.disabled = false
+      }
+    },
+  },
+})
+</script>

--- a/registry/lib/components/video/snapshot/ViewSnapshots.vue
+++ b/registry/lib/components/video/snapshot/ViewSnapshots.vue
@@ -11,7 +11,7 @@
 <script lang="ts">
 import { DefaultWidget } from '@/ui'
 import { logError } from '@/core/utils/log'
-import { viewSnapshotGrid } from './handler'
+import { view } from './handler'
 
 export default Vue.extend({
   components: {
@@ -27,7 +27,7 @@ export default Vue.extend({
       try {
         this.disabled = true
         const { aid, cid } = unsafeWindow
-        await viewSnapshotGrid(aid, parseInt(cid))
+        await view(aid, parseInt(cid))
       } catch (error) {
         logError(error)
       } finally {

--- a/registry/lib/components/video/snapshot/ViewSnapshots.vue
+++ b/registry/lib/components/video/snapshot/ViewSnapshots.vue
@@ -9,9 +9,11 @@
 </template>
 
 <script lang="ts">
-import { DefaultWidget } from '@/ui'
+import { DefaultWidget, showImage } from '@/ui'
 import { logError } from '@/core/utils/log'
-import { view } from './handler'
+import { renderSnapshotGridToBlobUrl } from './handler'
+import { videoChange } from '@/core/observer'
+import { getFriendlyTitle } from '@/core/utils/title'
 
 export default Vue.extend({
   components: {
@@ -20,14 +22,24 @@ export default Vue.extend({
   data() {
     return {
       disabled: false,
+      imageBlobUrl: '',
     }
+  },
+  mounted() {
+    videoChange(() => {
+      URL.revokeObjectURL(this.imageBlobUrl)
+      this.imageBlobUrl = ''
+    })
   },
   methods: {
     async viewSnapshotGrid() {
       try {
         this.disabled = true
-        const { aid, cid } = unsafeWindow
-        await view(aid, parseInt(cid))
+        if (!this.imageBlobUrl) {
+          const { aid, cid } = unsafeWindow
+          this.imageBlobUrl = await renderSnapshotGridToBlobUrl(aid, parseInt(cid))
+        }
+        showImage(this.imageBlobUrl, `${getFriendlyTitle(true)}_snapshot.jpg`)
       } catch (error) {
         logError(error)
       } finally {

--- a/registry/lib/components/video/snapshot/handler.ts
+++ b/registry/lib/components/video/snapshot/handler.ts
@@ -2,6 +2,7 @@
 import { VideoInfo } from '@/components/video/video-info'
 import { VideoSnapshot } from '@/components/video/video-snapshot'
 import { PackageEntry } from '@/core/download'
+import { meta } from '@/core/meta'
 import { getComponentSettings } from '@/core/settings'
 import { Toast } from '@/core/toast'
 import { formatDateTime, formatDuration } from '@/core/utils/formatters'
@@ -44,7 +45,7 @@ async function createSnapshotGrid(aid: string, cid: number) {
 
   const gridCanvas = await snapshot.createGrid(options.gridColumns, options.gridRows, {
     header: infoLines,
-    footer: true,
+    footer: [`${formatDateTime(new Date())} @ Bilibili-Evolved v${meta.compilationInfo.version}`],
     timestamp: true,
     backgroundColor: options.gridBackgroundColor,
     textColor: options.gridTextColor,

--- a/registry/lib/components/video/snapshot/handler.ts
+++ b/registry/lib/components/video/snapshot/handler.ts
@@ -3,6 +3,7 @@ import { VideoInfo } from '@/components/video/video-info'
 import { VideoSnapshot } from '@/components/video/video-snapshot'
 import { getComponentSettings } from '@/core/settings'
 import { formatDateTime, formatDuration } from '@/core/utils/formatters'
+import { getFriendlyTitle } from '@/core/utils/title'
 import { showImage } from '@/ui'
 import { componentName } from '.'
 import { Options } from './options'
@@ -38,17 +39,20 @@ export async function viewSnapshotGrid(aid: string, cid: number) {
     )
   }
 
-  const canvas = await snapshot.createGrid(options.gridColumns, options.gridRows, {
+  const gridCanvas = await snapshot.createGrid(options.gridColumns, options.gridRows, {
     header: infoLines,
     footer: true,
     timestamp: true,
     backgroundColor: options.gridBackgroundColor,
     textColor: options.gridtextColor,
   })
+
   return new Promise((resolve, reject) => {
-    canvas.toBlob(blob => {
+    gridCanvas.toBlob(blob => {
       const blobURL = URL.createObjectURL(blob)
-      showImage(blobURL).then(resolve).catch(reject)
+      showImage(blobURL, `${getFriendlyTitle(true)}_snapshots.jpg`)
+        .then(resolve)
+        .catch(reject)
     }, 'image/jpeg')
   })
 }

--- a/registry/lib/components/video/snapshot/handler.ts
+++ b/registry/lib/components/video/snapshot/handler.ts
@@ -1,9 +1,36 @@
+/* eslint-disable no-irregular-whitespace */
+import { VideoInfo } from '@/components/video/video-info'
 import { VideoSnapshot } from '@/components/video/video-snapshot'
+import { formatDateTime, formatDuration } from '@/core/utils/formatters'
 import { showImage } from '@/ui'
 
 export async function viewSnapshotGrid(aid: string, cid: number) {
   const snapshot = await VideoSnapshot.byAid(aid, cid).fetchInfo(true)
-  const canvas = await snapshot.createGridWithInfo(5, 6)
+
+  const info = await new VideoInfo(aid).fetchInfo()
+  const infoLines = []
+  const page = info.pages.find(p => p.cid === cid)
+  infoLines.push(`${info.bvid}　AV${info.aid}　CID ${page.cid}`, `稿件标题：${info.title}`)
+  if (info.pages.length > 1) {
+    infoLines.push(
+      `分页：${page.pageNumber} / ${info.pages.length}　投稿时间：${formatDateTime(
+        new Date(page.ctime * 1000),
+      )}　标题：${page.title}`,
+    )
+  }
+  infoLines.push(
+    `尺寸：${page.dimension.width}x${page.dimension.height}　时长：${formatDuration(
+      page.duration,
+    )}`,
+    `UP主：${info.up.name} (UID ${info.up.uid})　发布时间：${formatDateTime(
+      new Date(info.pubdate * 1000),
+    )}`,
+  )
+  const canvas = await snapshot.createGrid(5, 6, {
+    header: infoLines,
+    footer: true,
+    timestamp: true,
+  })
   return new Promise((resolve, reject) => {
     canvas.toBlob(blob => {
       const blobURL = URL.createObjectURL(blob)

--- a/registry/lib/components/video/snapshot/handler.ts
+++ b/registry/lib/components/video/snapshot/handler.ts
@@ -47,7 +47,12 @@ async function createSnapshotGrid(aid: string, cid: number) {
     footer: true,
     timestamp: true,
     backgroundColor: options.gridBackgroundColor,
-    textColor: options.gridtextColor,
+    textColor: options.gridTextColor,
+    fontSize: options.gridTextSize,
+    paddingX: options.gridGap,
+    paddingY: options.gridGap,
+    marginX: options.gridBorder,
+    marginY: options.gridBorder,
   })
 
   return gridCanvas

--- a/registry/lib/components/video/snapshot/handler.ts
+++ b/registry/lib/components/video/snapshot/handler.ts
@@ -19,7 +19,7 @@ function getOptions() {
 async function createSnapshotGrid(aid: string, cid: number) {
   const options = getOptions()
 
-  const snapshot = await VideoSnapshot.byAid(aid, cid).fetchInfo(true)
+  const snapshot = await VideoSnapshot.byAid(aid, cid).fetchInfo()
 
   const infoLines: string[] = []
   if (options.showInfoHeader) {

--- a/registry/lib/components/video/snapshot/handler.ts
+++ b/registry/lib/components/video/snapshot/handler.ts
@@ -1,0 +1,13 @@
+import { VideoSnapshot } from '@/components/video/video-snapshot'
+import { showImage } from '@/ui'
+
+export async function viewSnapshotGrid(aid: string, cid: number) {
+  const snapshot = await VideoSnapshot.byAid(aid, cid).fetchInfo(true)
+  const canvas = await snapshot.createGridWithInfo(5, 6)
+  return new Promise((resolve, reject) => {
+    canvas.toBlob(blob => {
+      const blobURL = URL.createObjectURL(blob)
+      showImage(blobURL).then(resolve).catch(reject)
+    }, 'image/jpeg')
+  })
+}

--- a/registry/lib/components/video/snapshot/handler.ts
+++ b/registry/lib/components/video/snapshot/handler.ts
@@ -1,35 +1,49 @@
 /* eslint-disable no-irregular-whitespace */
 import { VideoInfo } from '@/components/video/video-info'
 import { VideoSnapshot } from '@/components/video/video-snapshot'
+import { getComponentSettings } from '@/core/settings'
 import { formatDateTime, formatDuration } from '@/core/utils/formatters'
 import { showImage } from '@/ui'
+import { componentName } from '.'
+import { Options } from './options'
+
+function getOptions() {
+  return getComponentSettings<Options>(componentName).options
+}
 
 export async function viewSnapshotGrid(aid: string, cid: number) {
+  const options = getOptions()
+
   const snapshot = await VideoSnapshot.byAid(aid, cid).fetchInfo(true)
 
-  const info = await new VideoInfo(aid).fetchInfo()
-  const infoLines = []
-  const page = info.pages.find(p => p.cid === cid)
-  infoLines.push(`${info.bvid}　AV${info.aid}　CID ${page.cid}`, `稿件标题：${info.title}`)
-  if (info.pages.length > 1) {
+  const infoLines: string[] = []
+  if (options.gridInfoHeader) {
+    const info = await new VideoInfo(aid).fetchInfo()
+    const page = info.pages.find(p => p.cid === cid)
+    infoLines.push(`${info.bvid}　AV${info.aid}　CID ${page.cid}`, `稿件标题：${info.title}`)
+    if (info.pages.length > 1) {
+      infoLines.push(
+        `分页：${page.pageNumber} / ${info.pages.length}　投稿时间：${formatDateTime(
+          new Date(page.ctime * 1000),
+        )}　标题：${page.title}`,
+      )
+    }
     infoLines.push(
-      `分页：${page.pageNumber} / ${info.pages.length}　投稿时间：${formatDateTime(
-        new Date(page.ctime * 1000),
-      )}　标题：${page.title}`,
+      `尺寸：${page.dimension.width}x${page.dimension.height}　时长：${formatDuration(
+        page.duration,
+      )}`,
+      `UP主：${info.up.name} (UID ${info.up.uid})　发布时间：${formatDateTime(
+        new Date(info.pubdate * 1000),
+      )}`,
     )
   }
-  infoLines.push(
-    `尺寸：${page.dimension.width}x${page.dimension.height}　时长：${formatDuration(
-      page.duration,
-    )}`,
-    `UP主：${info.up.name} (UID ${info.up.uid})　发布时间：${formatDateTime(
-      new Date(info.pubdate * 1000),
-    )}`,
-  )
-  const canvas = await snapshot.createGrid(5, 6, {
+
+  const canvas = await snapshot.createGrid(options.gridColumns, options.gridRows, {
     header: infoLines,
     footer: true,
     timestamp: true,
+    backgroundColor: options.gridBackgroundColor,
+    textColor: options.gridtextColor,
   })
   return new Promise((resolve, reject) => {
     canvas.toBlob(blob => {

--- a/registry/lib/components/video/snapshot/handler.ts
+++ b/registry/lib/components/video/snapshot/handler.ts
@@ -6,8 +6,6 @@ import { meta } from '@/core/meta'
 import { getComponentSettings } from '@/core/settings'
 import { Toast, ToastType } from '@/core/toast'
 import { formatDateTime, formatDuration } from '@/core/utils/formatters'
-import { getFriendlyTitle } from '@/core/utils/title'
-import { showImage } from '@/ui'
 import { componentName } from '.'
 import { DownloadVideoInfo } from '../download/types'
 import { Options } from './options'
@@ -72,10 +70,8 @@ async function toBlob(canvas: HTMLCanvasElement) {
   })
 }
 
-export async function view(aid: string, cid: number) {
-  return createSnapshotGrid(aid, cid)
-    .then(toBlob)
-    .then(blob => showImage(URL.createObjectURL(blob), `${getFriendlyTitle(true)}_snapshot.jpg`))
+export async function renderSnapshotGridToBlobUrl(aid: string, cid: number) {
+  return createSnapshotGrid(aid, cid).then(toBlob).then(URL.createObjectURL)
 }
 
 export async function generateDownloadAssets(infos: DownloadVideoInfo[], toast: Toast) {

--- a/registry/lib/components/video/snapshot/handler.ts
+++ b/registry/lib/components/video/snapshot/handler.ts
@@ -22,7 +22,7 @@ async function createSnapshotGrid(aid: string, cid: number) {
   const snapshot = await VideoSnapshot.byAid(aid, cid).fetchInfo(true)
 
   const infoLines: string[] = []
-  if (options.gridInfoHeader) {
+  if (options.showInfoHeader) {
     const info = await new VideoInfo(aid).fetchInfo()
     const page = info.pages.find(p => p.cid === cid)
     infoLines.push(`${info.bvid}　AV${info.aid}　CID ${page.cid}`, `稿件标题：${info.title}`)
@@ -48,8 +48,9 @@ async function createSnapshotGrid(aid: string, cid: number) {
     footer: [`${formatDateTime(new Date())} @ Bilibili-Evolved v${meta.compilationInfo.version}`],
     timestamp: true,
     backgroundColor: options.gridBackgroundColor,
-    textColor: options.gridTextColor,
-    fontSize: options.gridTextSize,
+    textColor: options.textColor,
+    fontSize: options.textSize,
+    fontFamily: options.textFont,
     paddingX: options.gridGap,
     paddingY: options.gridGap,
     marginX: options.gridBorder,

--- a/registry/lib/components/video/snapshot/handler.ts
+++ b/registry/lib/components/video/snapshot/handler.ts
@@ -4,7 +4,7 @@ import { VideoSnapshot } from '@/components/video/video-snapshot'
 import { PackageEntry } from '@/core/download'
 import { meta } from '@/core/meta'
 import { getComponentSettings } from '@/core/settings'
-import { Toast } from '@/core/toast'
+import { Toast, ToastType } from '@/core/toast'
 import { formatDateTime, formatDuration } from '@/core/utils/formatters'
 import { getFriendlyTitle } from '@/core/utils/title'
 import { showImage } from '@/ui'
@@ -90,11 +90,15 @@ export async function generateDownloadAssets(infos: DownloadVideoInfo[], toast: 
       }
     }),
   )
-  const success = results.filter(
-    it => it.status === 'fulfilled',
-  ) as PromiseFulfilledResult<PackageEntry>[]
-  const fail = results.filter(it => it.status === 'rejected') as PromiseRejectedResult[]
+  const success = results.filter(x => x.status === 'fulfilled')
+  const fail = results.filter(x => x.status === 'rejected')
   toast.message = `生成视频快照完成。成功 ${success.length} 个, 失败 ${fail.length} 个。`
-  toast.duration = 1000
-  return success.map(x => x.value)
+  if (fail.length > 0) {
+    toast.type = ToastType.Error
+    toast.clearDuration()
+  } else {
+    toast.type = ToastType.Success
+    toast.duration = 1000
+  }
+  return success.map(x => <PackageEntry>x.value)
 }

--- a/registry/lib/components/video/snapshot/handler.ts
+++ b/registry/lib/components/video/snapshot/handler.ts
@@ -1,18 +1,21 @@
 /* eslint-disable no-irregular-whitespace */
 import { VideoInfo } from '@/components/video/video-info'
 import { VideoSnapshot } from '@/components/video/video-snapshot'
+import { PackageEntry } from '@/core/download'
 import { getComponentSettings } from '@/core/settings'
+import { Toast } from '@/core/toast'
 import { formatDateTime, formatDuration } from '@/core/utils/formatters'
 import { getFriendlyTitle } from '@/core/utils/title'
 import { showImage } from '@/ui'
 import { componentName } from '.'
+import { DownloadVideoInfo } from '../download/types'
 import { Options } from './options'
 
 function getOptions() {
   return getComponentSettings<Options>(componentName).options
 }
 
-export async function viewSnapshotGrid(aid: string, cid: number) {
+async function createSnapshotGrid(aid: string, cid: number) {
   const options = getOptions()
 
   const snapshot = await VideoSnapshot.byAid(aid, cid).fetchInfo(true)
@@ -47,12 +50,44 @@ export async function viewSnapshotGrid(aid: string, cid: number) {
     textColor: options.gridtextColor,
   })
 
-  return new Promise((resolve, reject) => {
-    gridCanvas.toBlob(blob => {
-      const blobURL = URL.createObjectURL(blob)
-      showImage(blobURL, `${getFriendlyTitle(true)}_snapshots.jpg`)
-        .then(resolve)
-        .catch(reject)
+  return gridCanvas
+}
+
+async function toBlob(canvas: HTMLCanvasElement) {
+  return new Promise<Blob>((resolve, reject) => {
+    canvas.toBlob(blob => {
+      if (!blob) {
+        reject(new Error('[VideoSnapshot] 创建视频快照图 Blob 失败'))
+      } else {
+        resolve(blob)
+      }
     }, 'image/jpeg')
   })
+}
+
+export async function view(aid: string, cid: number) {
+  return createSnapshotGrid(aid, cid)
+    .then(toBlob)
+    .then(blob => showImage(URL.createObjectURL(blob), `${getFriendlyTitle(true)}_snapshot.jpg`))
+}
+
+export async function generateDownloadAssets(infos: DownloadVideoInfo[], toast: Toast) {
+  let count = 0
+  const results = await Promise.allSettled(
+    infos.map(async ({ input }) => {
+      count++
+      toast.message = `生成视频快照中... (${count}/${infos.length})`
+      return {
+        name: `${input.title}_snapshot.jpg`,
+        data: await createSnapshotGrid(input.aid, parseInt(input.cid)).then(toBlob),
+      }
+    }),
+  )
+  const success = results.filter(
+    it => it.status === 'fulfilled',
+  ) as PromiseFulfilledResult<PackageEntry>[]
+  const fail = results.filter(it => it.status === 'rejected') as PromiseRejectedResult[]
+  toast.message = `生成视频快照完成。成功 ${success.length} 个, 失败 ${fail.length} 个。`
+  toast.duration = 1000
+  return success.map(x => x.value)
 }

--- a/registry/lib/components/video/snapshot/index.ts
+++ b/registry/lib/components/video/snapshot/index.ts
@@ -1,6 +1,10 @@
 import { defineComponentMetadata } from '@/components/define'
 import { hasVideo } from '@/core/spin-query'
+import { Toast } from '@/core/toast'
 import { videoAndBangumiUrls } from '@/core/utils/urls'
+import { PluginMinimalData } from '@/plugins/plugin'
+import { DownloadVideoAssets } from '../download/types'
+import { generateDownloadAssets } from './handler'
 import { options } from './options'
 
 export const componentName = 'videoSnapshot'
@@ -17,6 +21,29 @@ const author = [
   },
 ]
 
+const pluginSetup: PluginMinimalData['setup'] = ({ addData }) => {
+  addData('downloadVideo.assets', async (assets: DownloadVideoAssets[]) => {
+    assets.push({
+      name: componentName,
+      displayName,
+      getAssets: async (
+        infos,
+        instance: {
+          enabled: boolean
+        },
+      ) => {
+        const { enabled } = instance
+        if (!enabled) {
+          return []
+        }
+        const toast = Toast.info('生成视频快照中...', displayName)
+        return generateDownloadAssets(infos, toast)
+      },
+      component: () => import('./Plugin.vue').then(m => m.default),
+    })
+  })
+}
+
 export const component = defineComponentMetadata({
   name: componentName,
   displayName,
@@ -30,8 +57,9 @@ export const component = defineComponentMetadata({
     condition: hasVideo,
     component: () => import('./ViewSnapshots.vue').then(m => m.default),
   },
-  // TODO videoSnapshot plugin
-  // plugin: {
-  //   displayName: `下载视频 - ${title}支持`,
-  // },
+  plugin: {
+    displayName: `下载视频 - ${displayName}支持`,
+    author,
+    setup: pluginSetup,
+  },
 })

--- a/registry/lib/components/video/snapshot/index.ts
+++ b/registry/lib/components/video/snapshot/index.ts
@@ -1,6 +1,7 @@
 import { defineComponentMetadata } from '@/components/define'
 import { hasVideo } from '@/core/spin-query'
 import { videoAndBangumiUrls } from '@/core/utils/urls'
+import { options } from './options'
 
 export const componentName = 'videoSnapshot'
 export const displayName = '视频快照'
@@ -9,6 +10,10 @@ const author = [
   {
     name: 'WakelessSloth56',
     link: 'https://github.com/WakelessSloth56',
+  },
+  {
+    name: 'LainIO24',
+    link: 'https://github.com/LainIO24',
   },
 ]
 
@@ -20,7 +25,7 @@ export const component = defineComponentMetadata({
   tags: [componentsTags.video],
   entry: none,
   urlInclude: videoAndBangumiUrls,
-  // options, // TODO videoSnapshot options
+  options,
   widget: {
     condition: hasVideo,
     component: () => import('./ViewSnapshots.vue').then(m => m.default),

--- a/registry/lib/components/video/snapshot/index.ts
+++ b/registry/lib/components/video/snapshot/index.ts
@@ -1,0 +1,32 @@
+import { defineComponentMetadata } from '@/components/define'
+import { hasVideo } from '@/core/spin-query'
+import { videoAndBangumiUrls } from '@/core/utils/urls'
+
+export const componentName = 'videoSnapshot'
+export const displayName = '视频快照'
+
+const author = [
+  {
+    name: 'WakelessSloth56',
+    link: 'https://github.com/WakelessSloth56',
+  },
+]
+
+export const component = defineComponentMetadata({
+  name: componentName,
+  displayName,
+  description: '查看视频多个时间点的快照预览图',
+  author,
+  tags: [componentsTags.video],
+  entry: none,
+  urlInclude: videoAndBangumiUrls,
+  // options, // TODO videoSnapshot options
+  widget: {
+    condition: hasVideo,
+    component: () => import('./ViewSnapshots.vue').then(m => m.default),
+  },
+  // TODO videoSnapshot plugin
+  // plugin: {
+  //   displayName: `下载视频 - ${title}支持`,
+  // },
+})

--- a/registry/lib/components/video/snapshot/options.ts
+++ b/registry/lib/components/video/snapshot/options.ts
@@ -9,15 +9,27 @@ export const options = defineOptionsMetadata({
     displayName: '快照图网格列数', //
     defaultValue: 5,
   },
+  gridGap: {
+    displayName: '快照图网格间隔（像素）', //
+    defaultValue: 4,
+  },
+  gridBorder: {
+    displayName: '快照图边框（像素）', //
+    defaultValue: 12,
+  },
   gridBackgroundColor: {
     displayName: '快照图背景颜色',
     color: true,
     defaultValue: '#000000',
   },
-  gridtextColor: {
+  gridTextColor: {
     displayName: '快照图文字颜色',
     color: true,
     defaultValue: '#ffffff',
+  },
+  gridTextSize: {
+    displayName: '快照图文字大小（像素）',
+    defaultValue: 32,
   },
   gridInfoHeader: {
     displayName: '快照图呈现视频信息',

--- a/registry/lib/components/video/snapshot/options.ts
+++ b/registry/lib/components/video/snapshot/options.ts
@@ -2,19 +2,19 @@ import { defineOptionsMetadata, OptionsOfMetadata } from '@/components/define'
 
 export const options = defineOptionsMetadata({
   gridRows: {
-    displayName: '快照图网格行数', //
+    displayName: '快照图网格行数',
     defaultValue: 6,
   },
   gridColumns: {
-    displayName: '快照图网格列数', //
+    displayName: '快照图网格列数',
     defaultValue: 5,
   },
   gridGap: {
-    displayName: '快照图网格间隔（像素）', //
+    displayName: '快照图网格间隔（像素）',
     defaultValue: 4,
   },
   gridBorder: {
-    displayName: '快照图边框（像素）', //
+    displayName: '快照图边框（像素）',
     defaultValue: 12,
   },
   gridBackgroundColor: {
@@ -22,16 +22,20 @@ export const options = defineOptionsMetadata({
     color: true,
     defaultValue: '#000000',
   },
-  gridTextColor: {
+  textColor: {
     displayName: '快照图文字颜色',
     color: true,
     defaultValue: '#ffffff',
   },
-  gridTextSize: {
+  textSize: {
     displayName: '快照图文字大小（像素）',
     defaultValue: 32,
   },
-  gridInfoHeader: {
+  textFont: {
+    displayName: '快照图文字字体',
+    defaultValue: 'sans-serif',
+  },
+  showInfoHeader: {
     displayName: '快照图呈现视频信息',
     defaultValue: true,
   },

--- a/registry/lib/components/video/snapshot/options.ts
+++ b/registry/lib/components/video/snapshot/options.ts
@@ -1,0 +1,28 @@
+import { defineOptionsMetadata, OptionsOfMetadata } from '@/components/define'
+
+export const options = defineOptionsMetadata({
+  gridRows: {
+    displayName: '快照图网格行数', //
+    defaultValue: 6,
+  },
+  gridColumns: {
+    displayName: '快照图网格列数', //
+    defaultValue: 5,
+  },
+  gridBackgroundColor: {
+    displayName: '快照图背景颜色',
+    color: true,
+    defaultValue: '#000000',
+  },
+  gridtextColor: {
+    displayName: '快照图文字颜色',
+    color: true,
+    defaultValue: '#ffffff',
+  },
+  gridInfoHeader: {
+    displayName: '快照图呈现视频信息',
+    defaultValue: true,
+  },
+})
+
+export type Options = OptionsOfMetadata<typeof options>

--- a/src/components/api.ts
+++ b/src/components/api.ts
@@ -1,36 +1,37 @@
 import * as builtInComponents from './built-in-components'
 import * as component from './component'
-import * as userComponent from './user-component'
-import * as styledComponent from './styled-component'
 import * as define from './define'
 import * as description from './description'
 import * as feedsApis from './feeds/api'
 import BangumiCard from './feeds/BangumiCard.vue'
-import UpInfo from './feeds/UpInfo.vue'
-import VideoCard from './feeds/VideoCard.vue'
 import ColumnCard from './feeds/ColumnCard.vue'
 import * as disableProfilePopup from './feeds/disable-profile-popup'
 import * as notify from './feeds/notify'
+import UpInfo from './feeds/UpInfo.vue'
+import VideoCard from './feeds/VideoCard.vue'
+import MachineTranslator from './i18n/machine-translator/MachineTranslator.vue'
+import LaunchBar from './launch-bar/LaunchBar.vue'
+import * as liveControlBar from './live/live-control-bar'
+import * as liveSocket from './live/live-socket'
+import * as styledComponent from './styled-component'
+import * as switchOptions from './switch-options'
+import * as userComponent from './user-component'
+import * as categoriesData from './utils/categories/data'
+import * as categoriesUpdater from './utils/categories/updater'
+import * as commentApis from './utils/comment-apis'
 import * as assUtils from './video/ass-utils'
-import * as xmlUtils from './video/xml-utils'
 import * as playerAgent from './video/player-agent'
 import * as playerLight from './video/player-light'
 import * as videoActions from './video/video-actions'
-import * as videoDanmaku from './video/video-danmaku'
-import * as videoInfo from './video/video-info'
-import * as videoQuality from './video/video-quality'
 import * as videoContextMenu from './video/video-context-menu'
 import * as videoControlBar from './video/video-control-bar'
 import * as videoCover from './video/video-cover'
+import * as videoDanmaku from './video/video-danmaku'
+import * as videoInfo from './video/video-info'
+import * as videoQuality from './video/video-quality'
+import * as videoSnapshot from './video/video-snapshot'
 import * as watchlater from './video/watchlater'
-import * as liveControlBar from './live/live-control-bar'
-import * as liveSocket from './live/live-socket'
-import * as commentApis from './utils/comment-apis'
-import * as categoriesUpdater from './utils/categories/updater'
-import * as categoriesData from './utils/categories/data'
-import MachineTranslator from './i18n/machine-translator/MachineTranslator.vue'
-import * as switchOptions from './switch-options'
-import LaunchBar from './launch-bar/LaunchBar.vue'
+import * as xmlUtils from './video/xml-utils'
 
 export const componentApis = {
   builtInComponents,
@@ -63,6 +64,7 @@ export const componentApis = {
     videoContextMenu,
     videoControlBar,
     videoCover,
+    videoSnapshot,
     watchlater,
     xmlUtils,
   },

--- a/src/components/video/video-info.ts
+++ b/src/components/video/video-info.ts
@@ -13,6 +13,8 @@ export interface VideoPageInfo {
   title: string
   pageNumber: number
   duration: number
+  ctime: number
+  dimension: { width: number; height: number }
 }
 
 export interface VideoSeasonEpisodeInfo {
@@ -45,6 +47,8 @@ const normalizeVideoPage = (page: any): VideoPageInfo => ({
   title: page.title ?? page.part,
   pageNumber: page.pageNumber ?? page.page,
   duration: page.duration ?? 0,
+  dimension: page.dimension,
+  ctime: page.ctime,
 })
 
 const normalizeVideoSeasonEpisode = (episode: any): VideoSeasonEpisodeInfo => {

--- a/src/components/video/video-snapshot.ts
+++ b/src/components/video/video-snapshot.ts
@@ -275,8 +275,10 @@ function createGrid(
   ctx.fillRect(0, 0, w, h)
 
   // 顶栏
-  ctx.drawImage(headerCanvas, x0, y0)
-  y0 += headerCanvas.height
+  if (header && header.length > 0) {
+    ctx.drawImage(headerCanvas, x0, y0)
+    y0 += headerCanvas.height
+  }
 
   // 底栏
   if (footer) {

--- a/src/components/video/video-snapshot.ts
+++ b/src/components/video/video-snapshot.ts
@@ -1,0 +1,173 @@
+/* spellchecker:words pvdata */
+import { bilibiliApi, getJsonWithCredentials } from '@/core/ajax'
+
+/**
+ * 解析二进制格式的 pvdata
+ * @author WakelessSloth56
+ * @returns 每个快照图对应的视频时间点，以秒为单位
+ */
+const parsePVData = async (data: ArrayBuffer) => {
+  const view = new DataView(data)
+  const result: number[] = []
+  // i=2 跳过第一个值，第一个值恒为0，不算在视频时间里
+  for (let i = 2; i < data.byteLength; i += 2) {
+    result.push(view.getUint16(i, false))
+  }
+  return result
+}
+
+export interface SnapshotSprite {
+  time: number
+  spriteSheet: string
+  col: number
+  row: number
+  x: number
+  y: number
+  width: number
+  height: number
+  canvas?: HTMLCanvasElement
+}
+
+/**
+ * @author WakelessSloth56
+ */
+function parseSpriteData(
+  spriteSheet: string,
+  times: number[],
+  cols: number,
+  rows: number,
+  width: number,
+  height: number,
+) {
+  const s: SnapshotSprite[] = []
+  for (let row = 0; row < rows; row++) {
+    for (let col = 0; col < cols; col++) {
+      const i = row * cols + col
+      if (i >= times.length) {
+        return s
+      }
+      const x = col * width
+      const y = row * height
+      s.push({
+        time: times[i],
+        spriteSheet,
+        x,
+        y,
+        width,
+        height,
+        col,
+        row,
+        canvas: undefined,
+      })
+    }
+  }
+  return s
+}
+
+/**
+ * 分割视频快照精灵图
+ * @author WakelessSloth56
+ * @param pvData 每个快照图的时间点 {@link parsePVData}
+ * @param spriteUrls 精灵图的URL
+ * @param cols 精灵图的列数
+ * @param rows 精灵图的行数
+ * @param width 快照图片的宽度
+ * @param height 快照图片的长度
+ */
+async function splitSnapshots(
+  pvData: number[],
+  spriteUrls: string[],
+  cols: number,
+  rows: number,
+  width: number,
+  height: number,
+  toCanvas = true,
+) {
+  const spriteSheets = lodash.zip(spriteUrls, lodash.chunk(pvData, cols * rows))
+  const sprites = spriteSheets.map(([url, times]) => {
+    const data = parseSpriteData(url, times, cols, rows, width, height)
+    if (toCanvas) {
+      return new Promise((resolve: (img: CanvasImageSource) => void, reject) => {
+        const img = new Image()
+        img.crossOrigin = 'anonymous'
+        img.onload = () => resolve(img)
+        img.onerror = reject
+        img.src = url
+      }).then(img => {
+        data.forEach(d => {
+          const canvas = document.createElement('canvas')
+          canvas.width = d.width
+          canvas.height = d.height
+          const ctx = canvas.getContext('2d')
+          ctx.drawImage(img, d.x, d.y, d.width, d.width, 0, 0, d.width, d.width)
+          d.canvas = canvas
+        })
+        return data
+      })
+    }
+    return new Promise((resolve: (value: SnapshotSprite[]) => void) => {
+      resolve(data)
+    })
+  })
+  return Promise.all(sprites).then(x => x.flat().sort((a, b) => a.time - b.time))
+}
+
+/**
+ * @author WakelessSloth56
+ */
+export class VideoSnapshot {
+  aid?: string
+  bvid?: string
+  cid: number
+  times: number[]
+  snapshots: SnapshotSprite[]
+  spriteSheets: string[]
+  spriteColumns: number
+  spriteRows: number
+  spriteWidth: number
+  spriteHeight: number
+
+  private constructor(aid: string, bvid: string, cid: number) {
+    this.aid = aid
+    this.bvid = bvid
+    this.cid = cid
+  }
+
+  public static byAid(aid: string, cid: number) {
+    return new VideoSnapshot(aid, null, cid)
+  }
+
+  public static byBvid(bvid: string, cid: number) {
+    return new VideoSnapshot(null, bvid, cid)
+  }
+
+  async fetchInfo(toCanvas = false): Promise<VideoSnapshot> {
+    let url = 'https://api.bilibili.com/x/player/videoshot?'
+    if (this.aid) {
+      url += `aid=${this.aid}`
+    } else if (this.bvid) {
+      url += `bvid=${this.bvid}`
+    }
+    url += `&cid=${this.cid}`
+    const data = await bilibiliApi(getJsonWithCredentials(url))
+    const pvData = await fetch(data.pvdata, {})
+      .then(res => res.arrayBuffer())
+      .then(b => parsePVData(b))
+    this.times = pvData
+    this.spriteSheets = data.image
+    this.spriteColumns = data.img_x_len
+    this.spriteRows = data.img_y_len
+    this.spriteWidth = data.img_x_size
+    this.spriteHeight = data.img_y_size
+    this.snapshots = await splitSnapshots(
+      this.times,
+      this.spriteSheets,
+      this.spriteColumns,
+      this.spriteRows,
+      this.spriteWidth,
+      this.spriteHeight,
+      toCanvas,
+    )
+    return this
+  }
+}

--- a/src/components/video/video-snapshot.ts
+++ b/src/components/video/video-snapshot.ts
@@ -1,5 +1,6 @@
 /* spellchecker:words pvdata */
 import { bilibiliApi, getJsonWithCredentials } from '@/core/ajax'
+import { formatDuration } from '@/core/utils/formatters'
 
 /**
  * 解析二进制格式的 pvdata
@@ -15,6 +16,8 @@ const parsePVData = async (data: ArrayBuffer) => {
   }
   return result
 }
+
+// =========================================================================== /
 
 export interface SnapshotSprite {
   time: number
@@ -113,9 +116,140 @@ async function splitSnapshots(
 }
 
 /**
+ * 根据时间均匀的取样快照图到指定的数量
+ * @author WakelessSloth56
+ * @param count 需要的快照图数量
+ */
+function sampleByTime<T extends { time: number }>(snapshots: T[], count: number): T[] {
+  if (snapshots.length <= count) {
+    return snapshots
+  }
+
+  const times = snapshots.map(x => x.time)
+  const minTime = times[0]
+  const maxTime = times[times.length - 1]
+  const duration = maxTime - minTime
+
+  const result = []
+  const timeStep = duration / (count - 1)
+
+  for (let i = 0; i < count; i++) {
+    const targetTime = minTime + i * timeStep
+    const closest = snapshots.reduce((prev, curr) => {
+      const prevDiff = Math.abs(prev.time - targetTime)
+      const currDiff = Math.abs(curr.time - targetTime)
+      return currDiff < prevDiff ? curr : prev
+    })
+    result.push(closest)
+  }
+
+  return [...new Set(result)]
+}
+
+// =========================================================================== /
+
+export interface DrawOptions {
+  fontSize?: number
+  font?: string
+  textColor?: string
+  backgroundColor?: string
+  paddingX?: number
+  paddingY?: number
+  marginX?: number
+  marginY?: number
+}
+
+/**
+ * 在快照图上绘制对应的时间点
+ * @author WakelessSloth56
+ */
+function drawTimestamp(snapshot: SnapshotSprite, options: DrawOptions = {}) {
+  const timeStr = formatDuration(snapshot.time)
+  const ctx = snapshot.canvas.getContext('2d')
+
+  const {
+    paddingX = 8,
+    paddingY = 4,
+    marginX = 6,
+    marginY = 3,
+    fontSize = 22,
+    font = 'monospace',
+    textColor = '#ffffff',
+    backgroundColor = '#00000033',
+  } = options
+
+  ctx.font = `${fontSize}px '${font}'`
+  const textW = ctx.measureText(timeStr).width
+
+  const bgW = textW + paddingX * 2
+  const bgH = fontSize + paddingY * 2
+
+  const x = snapshot.canvas.width - bgW - marginX
+  const y = snapshot.canvas.height - bgH - marginY
+
+  ctx.fillStyle = backgroundColor
+  ctx.fillRect(x, y, bgW, bgH)
+
+  ctx.fillStyle = textColor
+  ctx.textBaseline = 'top'
+  ctx.fillText(timeStr, x + paddingX, y + paddingY)
+}
+
+/**
+ * @author WakelessSloth56
+ */
+function createGrid(
+  snapshots: SnapshotSprite[],
+  cols: number,
+  rows: number,
+  spriteWidth: number,
+  spriteHeight: number,
+  options: DrawOptions = {},
+) {
+  const {
+    paddingX = 4,
+    paddingY = 4,
+    marginX = 12,
+    marginY = 12,
+    backgroundColor = '#000000',
+  } = options
+
+  const canvas = document.createElement('canvas')
+  const ctx = canvas.getContext('2d')
+
+  const w = cols * spriteWidth + (cols - 1) * paddingX + marginX * 2
+  const h = rows * spriteHeight + (rows - 1) * paddingY + marginY * 2
+  const x0 = marginX
+  const y0 = marginY
+
+  canvas.width = w
+  canvas.height = h
+
+  ctx.fillStyle = backgroundColor
+  ctx.fillRect(0, 0, w, h)
+
+  for (let row = 0; row < rows; row++) {
+    for (let col = 0; col < cols; col++) {
+      const i = row * cols + col
+      if (i >= snapshots.length) {
+        return canvas
+      }
+      const x = col * (spriteWidth + paddingX) + x0
+      const y = row * (spriteHeight + paddingY) + y0
+      drawTimestamp(snapshots[i])
+      ctx.drawImage(snapshots[i].canvas, x, y)
+    }
+  }
+  return canvas
+}
+
+// =========================================================================== /
+
+/**
  * @author WakelessSloth56
  */
 export class VideoSnapshot {
+  private ready = false
   aid?: string
   bvid?: string
   cid: number
@@ -168,6 +302,25 @@ export class VideoSnapshot {
       this.spriteHeight,
       toCanvas,
     )
+    this.ready = true
+    console.debug(this)
     return this
+  }
+
+  async createGridWithInfo(cols = 5, rows = 6, options: DrawOptions = {}) {
+    if (!this.ready || !this.snapshots[0].canvas) {
+      throw new Error('[VideoSnapshot] snapshots not ready')
+    }
+
+    const canvas = createGrid(
+      sampleByTime(this.snapshots, cols * rows),
+      cols,
+      rows,
+      this.spriteWidth,
+      this.spriteHeight,
+      options,
+    )
+
+    return canvas
   }
 }

--- a/src/components/video/video-snapshot.ts
+++ b/src/components/video/video-snapshot.ts
@@ -21,7 +21,7 @@ const parsePVData = async (data: ArrayBuffer) => {
 
 export interface SnapshotTile {
   time: number
-  col: number
+  column: number
   row: number
   x: number
   y: number
@@ -38,8 +38,12 @@ export interface SnapshotTileWithCanvas extends SnapshotTile {
 export interface SnapshotAtlas {
   index: number
   url: string
+  width: number
+  height: number
+  columns: number
+  rows: number
+  tiles: SnapshotTile[]
   image?: CanvasImageSource
-  tiles?: SnapshotTile[]
 }
 
 /**
@@ -48,19 +52,19 @@ export interface SnapshotAtlas {
 function parseTiles(
   atlas: SnapshotAtlas,
   times: number[],
-  cols: number,
+  columns: number,
   rows: number,
   width: number,
   height: number,
 ) {
   const s: SnapshotTile[] = []
   for (let row = 0; row < rows; row++) {
-    for (let col = 0; col < cols; col++) {
-      const i = row * cols + col
+    for (let column = 0; column < columns; column++) {
+      const i = row * columns + column
       if (i >= times.length) {
         return s
       }
-      const x = col * width
+      const x = column * width
       const y = row * height
       s.push({
         atlas,
@@ -69,7 +73,7 @@ function parseTiles(
         y,
         width,
         height,
-        col,
+        column,
         row,
       })
     }
@@ -83,20 +87,31 @@ function parseTiles(
 async function parseAtlases(
   allTimes: number[],
   atlasUrls: string[],
-  cols: number,
+  columns: number,
   rows: number,
-  width: number,
-  height: number,
+  tileWidth: number,
+  tileHeight: number,
 ) {
-  const spriteSheets = lodash.zip(atlasUrls, lodash.chunk(allTimes, cols * rows))
-  return spriteSheets.map(([url, times], index) => {
-    const atlas: SnapshotAtlas = { index, url }
-    const tiles = parseTiles(atlas, times, cols, rows, width, height)
+  const atlases = lodash.zip(atlasUrls, lodash.chunk(allTimes, columns * rows))
+  return atlases.map(([url, times], index) => {
+    const atlas: SnapshotAtlas = {
+      index,
+      url,
+      rows,
+      columns,
+      width: columns * tileWidth,
+      height: rows * tileHeight,
+      tiles: [],
+    }
+    const tiles = parseTiles(atlas, times, columns, rows, tileWidth, tileHeight)
     atlas.tiles = tiles
     return atlas
   })
 }
 
+/**
+ * @author WakelessSloth56
+ */
 async function loadAtlasImage(atlas: SnapshotAtlas) {
   return new Promise((resolve: (atlas: SnapshotAtlas) => void, reject) => {
     if (atlas.image) {
@@ -148,7 +163,7 @@ async function splitTileImage(tile: SnapshotTile) {
  * @author WakelessSloth56
  * @param count 需要的快照图数量
  */
-function sample<T extends { time: number }>(snapshots: T[], count: number): T[] {
+function sampleByTime<T extends { time: number }>(snapshots: T[], count: number): T[] {
   if (snapshots.length <= count) {
     return snapshots
   }
@@ -343,8 +358,6 @@ export class VideoSnapshot {
   bvid?: string
   cid: number
   atlases: SnapshotAtlas[]
-  atlasWidth: number
-  atlasHeight: number
   atlasColumns: number
   atlasRows: number
   tileWidth: number
@@ -382,8 +395,6 @@ export class VideoSnapshot {
     this.atlasRows = data.img_y_len
     this.tileWidth = data.img_x_size
     this.tileHeight = data.img_y_size
-    this.atlasWidth = this.atlasColumns * this.tileWidth
-    this.atlasHeight = this.atlasRows * this.tileHeight
 
     this.atlases = await parseAtlases(
       allTimes,
@@ -418,11 +429,31 @@ export class VideoSnapshot {
 
   async createGrid(cols = 5, rows = 6, options: DrawOptions & GridInfoOptions = {}) {
     await this.loadAtlasImage()
-    const tiles = await Promise.all(this.sample(cols * rows).map(splitTileImage))
+    const tiles = await Promise.all(this.sampleByTime(cols * rows).map(splitTileImage))
     return createGrid(tiles, cols, rows, this.tileWidth, this.tileHeight, options)
   }
 
-  sample(count: number) {
-    return sample(this.snapshots, count)
+  sampleByTime(count: number) {
+    return sampleByTime(this.snapshots, count)
+  }
+
+  getByTime(time: number) {
+    this.checkReady()
+    for (const atlas of this.atlases) {
+      for (const tile of atlas.tiles) {
+        if (time >= tile.time) {
+          return tile
+        }
+      }
+    }
+    return null
+  }
+
+  static async loadAtlasImage(atlas: SnapshotAtlas) {
+    return loadAtlasImage(atlas)
+  }
+
+  static async loadTileImage(tile: SnapshotTile) {
+    return loadAtlasImage(tile.atlas).then(() => splitTileImage(tile))
   }
 }

--- a/src/components/video/video-snapshot.ts
+++ b/src/components/video/video-snapshot.ts
@@ -191,12 +191,12 @@ function drawTimestamp(snapshot: SnapshotSprite, options: DrawOptions = {}) {
   const {
     paddingX = 8,
     paddingY = 4,
-    marginX = 6,
-    marginY = 3,
+    marginX = 2,
+    marginY = 2,
     fontSize = 22,
     fontFamily = 'monospace',
     textColor = '#ffffff',
-    backgroundColor = '#00000033',
+    backgroundColor = 'rgba(0,0,0,0.5)',
   } = options
 
   ctx.font = `${fontSize}px ${fontFamily}`
@@ -344,7 +344,7 @@ export class VideoSnapshot {
       url += `bvid=${this.bvid}`
     }
     url += `&cid=${this.cid}`
-    const data = await bilibiliApi(getJsonWithCredentials(url))
+    const data = await bilibiliApi(getJsonWithCredentials(url), '[VideoSnapshot]', false)
     const pvData = await fetch(data.pvdata, {})
       .then(res => res.arrayBuffer())
       .then(b => parsePVData(b))

--- a/src/components/video/video-snapshot.ts
+++ b/src/components/video/video-snapshot.ts
@@ -1,6 +1,7 @@
 /* spellchecker:words pvdata */
 import { bilibiliApi, getJsonWithCredentials } from '@/core/ajax'
-import { formatDuration } from '@/core/utils/formatters'
+import { meta } from '@/core/meta'
+import { formatDateTime, formatDuration } from '@/core/utils/formatters'
 
 /**
  * 解析二进制格式的 pvdata
@@ -159,6 +160,12 @@ export interface DrawOptions {
   marginY?: number
 }
 
+export interface GridInfoOptions {
+  header?: string[]
+  footer?: boolean
+  timestamp?: boolean
+}
+
 /**
  * 在快照图上绘制对应的时间点
  * @author WakelessSloth56
@@ -204,29 +211,84 @@ function createGrid(
   rows: number,
   spriteWidth: number,
   spriteHeight: number,
-  options: DrawOptions = {},
+  options: DrawOptions & GridInfoOptions = {},
 ) {
   const {
     paddingX = 4,
     paddingY = 4,
     marginX = 12,
     marginY = 12,
+    fontSize = 22,
+    font: fontName = 'monospace',
+    textColor = '#ffffff',
     backgroundColor = '#000000',
+    header = [],
+    footer = false,
+    timestamp = true,
   } = options
+  const font = `${fontSize}px '${fontName}'`
 
   const canvas = document.createElement('canvas')
   const ctx = canvas.getContext('2d')
 
-  const w = cols * spriteWidth + (cols - 1) * paddingX + marginX * 2
-  const h = rows * spriteHeight + (rows - 1) * paddingY + marginY * 2
+  // 信息栏
+  const headerCanvas = document.createElement('canvas')
+  if (header && header.length > 0) {
+    const infoCtx = headerCanvas.getContext('2d')
+    infoCtx.font = font
+    const maxWidth = Math.max(...header.map(x => infoCtx.measureText(x).width))
+    headerCanvas.width = maxWidth
+    headerCanvas.height = header.length * (fontSize + paddingY)
+    infoCtx.font = font
+    infoCtx.fillStyle = textColor
+    infoCtx.textBaseline = 'top'
+    let y = 0
+    for (const info of header) {
+      infoCtx.fillText(info, 0, y)
+      y += fontSize + paddingY
+    }
+  } else {
+    headerCanvas.width = 0
+    headerCanvas.height = 0
+  }
+
+  const w =
+    Math.max(
+      // 防止超长标题溢出
+      headerCanvas.width,
+      cols * spriteWidth + (cols - 1) * paddingX, // 快照图宽度 + 列间距
+    ) +
+    marginX * 2 // 边框
+  const h =
+    headerCanvas.height + // 信息栏高度
+    rows * spriteHeight + // 快照图高度
+    (rows - 1) * paddingY + // 行间距
+    (footer ? fontSize + paddingY * 2 : 0) + // 底栏
+    marginY * 2 // 边框
   const x0 = marginX
-  const y0 = marginY
+  let y0 = marginY
 
   canvas.width = w
   canvas.height = h
 
   ctx.fillStyle = backgroundColor
   ctx.fillRect(0, 0, w, h)
+
+  // 顶栏
+  ctx.drawImage(headerCanvas, x0, y0)
+  y0 += headerCanvas.height
+
+  // 底栏
+  if (footer) {
+    ctx.font = font
+    ctx.fillStyle = textColor
+    ctx.textBaseline = 'bottom'
+    const generatedAt = `${formatDateTime(new Date())} @ Bilibili-Evolved v${
+      meta.compilationInfo.version
+    }`
+    // 右下角
+    ctx.fillText(generatedAt, w - marginX - ctx.measureText(generatedAt).width, h - marginY)
+  }
 
   for (let row = 0; row < rows; row++) {
     for (let col = 0; col < cols; col++) {
@@ -236,7 +298,9 @@ function createGrid(
       }
       const x = col * (spriteWidth + paddingX) + x0
       const y = row * (spriteHeight + paddingY) + y0
-      drawTimestamp(snapshots[i])
+      if (timestamp) {
+        drawTimestamp(snapshots[i])
+      }
       ctx.drawImage(snapshots[i].canvas, x, y)
     }
   }
@@ -307,7 +371,7 @@ export class VideoSnapshot {
     return this
   }
 
-  async createGridWithInfo(cols = 5, rows = 6, options: DrawOptions = {}) {
+  async createGrid(cols = 5, rows = 6, options: DrawOptions & GridInfoOptions = {}) {
     if (!this.ready || !this.snapshots[0].canvas) {
       throw new Error('[VideoSnapshot] snapshots not ready')
     }

--- a/src/components/video/video-snapshot.ts
+++ b/src/components/video/video-snapshot.ts
@@ -232,8 +232,9 @@ function createGrid(
   const ctx = canvas.getContext('2d')
 
   // 信息栏
-  const headerCanvas = document.createElement('canvas')
+  let headerCanvas: HTMLCanvasElement
   if (header && header.length > 0) {
+    headerCanvas = document.createElement('canvas')
     const infoCtx = headerCanvas.getContext('2d')
     infoCtx.font = font
     const maxWidth = Math.max(...header.map(x => infoCtx.measureText(x).width))
@@ -247,49 +248,47 @@ function createGrid(
       infoCtx.fillText(info, 0, y)
       y += fontSize + paddingY
     }
-  } else {
-    headerCanvas.width = 0
-    headerCanvas.height = 0
   }
 
-  const w =
-    Math.max(
-      // 防止超长标题溢出
-      headerCanvas.width,
-      cols * spriteWidth + (cols - 1) * paddingX, // 快照图宽度 + 列间距
-    ) +
-    marginX * 2 // 边框
-  const h =
-    headerCanvas.height + // 信息栏高度
-    rows * spriteHeight + // 快照图高度
-    (rows - 1) * paddingY + // 行间距
-    (footer ? fontSize + paddingY * 2 : 0) + // 底栏
-    marginY * 2 // 边框
-  const x0 = marginX
-  let y0 = marginY
+  const headerW = headerCanvas ? headerCanvas.width : 0
+  const headerH = headerCanvas ? headerCanvas.height : 0
 
+  const gridW = cols * spriteWidth + (cols - 1) * paddingX
+  const gridH = rows * spriteHeight + (rows - 1) * paddingY
+
+  // const footerW = gridW
+  const footerH = footer ? fontSize + paddingY * 2 : 0
+
+  const w = Math.max(headerW, gridW) + marginX * 2 // 防止超长标题溢出
+  const h = headerH + gridH + footerH + marginY * 2
   canvas.width = w
   canvas.height = h
+
+  const headerX = marginX
+  const headerY = marginY
+
+  const gridX = (w - gridW) / 2 // 图片网格居中
+  const gridY = headerY + headerH
 
   ctx.fillStyle = backgroundColor
   ctx.fillRect(0, 0, w, h)
 
   // 顶栏
-  if (header && header.length > 0) {
-    ctx.drawImage(headerCanvas, x0, y0)
-    y0 += headerCanvas.height
+  if (headerCanvas) {
+    ctx.drawImage(headerCanvas, headerX, headerY)
   }
 
   // 底栏
   if (footer) {
     ctx.font = font
     ctx.fillStyle = textColor
-    ctx.textBaseline = 'bottom'
+    ctx.textBaseline = 'top'
     const generatedAt = `${formatDateTime(new Date())} @ Bilibili-Evolved v${
       meta.compilationInfo.version
     }`
-    // 右下角
-    ctx.fillText(generatedAt, w - marginX - ctx.measureText(generatedAt).width, h - marginY)
+    const footerX = w - marginX - ctx.measureText(generatedAt).width
+    const footerY = gridY + gridH + paddingY * 2
+    ctx.fillText(generatedAt, footerX, footerY) // 右下角
   }
 
   for (let row = 0; row < rows; row++) {
@@ -298,11 +297,11 @@ function createGrid(
       if (i >= snapshots.length) {
         return canvas
       }
-      const x = col * (spriteWidth + paddingX) + x0
-      const y = row * (spriteHeight + paddingY) + y0
       if (timestamp) {
         drawTimestamp(snapshots[i])
       }
+      const x = col * (spriteWidth + paddingX) + gridX
+      const y = row * (spriteHeight + paddingY) + gridY
       ctx.drawImage(snapshots[i].canvas, x, y)
     }
   }

--- a/src/components/video/video-snapshot.ts
+++ b/src/components/video/video-snapshot.ts
@@ -19,30 +19,41 @@ const parsePVData = async (data: ArrayBuffer) => {
 
 // =========================================================================== /
 
-export interface SnapshotSprite {
+export interface SnapshotTile {
   time: number
-  spriteSheet: string
   col: number
   row: number
   x: number
   y: number
   width: number
   height: number
+  atlas: SnapshotAtlas
   canvas?: HTMLCanvasElement
+}
+
+export interface SnapshotTileWithCanvas extends SnapshotTile {
+  canvas: HTMLCanvasElement
+}
+
+export interface SnapshotAtlas {
+  index: number
+  url: string
+  image?: CanvasImageSource
+  tiles?: SnapshotTile[]
 }
 
 /**
  * @author WakelessSloth56
  */
-function parseSpriteData(
-  spriteSheet: string,
+function parseTiles(
+  atlas: SnapshotAtlas,
   times: number[],
   cols: number,
   rows: number,
   width: number,
   height: number,
 ) {
-  const s: SnapshotSprite[] = []
+  const s: SnapshotTile[] = []
   for (let row = 0; row < rows; row++) {
     for (let col = 0; col < cols; col++) {
       const i = row * cols + col
@@ -52,15 +63,14 @@ function parseSpriteData(
       const x = col * width
       const y = row * height
       s.push({
+        atlas,
         time: times[i],
-        spriteSheet,
         x,
         y,
         width,
         height,
         col,
         row,
-        canvas: undefined,
       })
     }
   }
@@ -68,51 +78,69 @@ function parseSpriteData(
 }
 
 /**
- * 分割视频快照精灵图
  * @author WakelessSloth56
- * @param pvData 每个快照图的时间点 {@link parsePVData}
- * @param spriteUrls 精灵图的URL
- * @param cols 精灵图的列数
- * @param rows 精灵图的行数
- * @param width 快照图片的宽度
- * @param height 快照图片的长度
  */
-async function splitSnapshots(
-  pvData: number[],
-  spriteUrls: string[],
+async function parseAtlases(
+  allTimes: number[],
+  atlasUrls: string[],
   cols: number,
   rows: number,
   width: number,
   height: number,
-  toCanvas = true,
 ) {
-  const spriteSheets = lodash.zip(spriteUrls, lodash.chunk(pvData, cols * rows))
-  const sprites = spriteSheets.map(([url, times]) => {
-    const data = parseSpriteData(url, times, cols, rows, width, height)
-    if (toCanvas) {
-      return new Promise((resolve: (img: CanvasImageSource) => void, reject) => {
-        const img = new Image()
-        img.crossOrigin = 'anonymous'
-        img.onload = () => resolve(img)
-        img.onerror = reject
-        img.src = url
-      }).then(img => {
-        data.forEach(d => {
-          const canvas = document.createElement('canvas')
-          canvas.width = d.width
-          canvas.height = d.height
-          const ctx = canvas.getContext('2d')
-          ctx.drawImage(img, d.x, d.y, d.width, d.width, 0, 0, d.width, d.width)
-          d.canvas = canvas
-        })
-        return data
-      })
-    }
-    return new Promise((resolve: (value: SnapshotSprite[]) => void) => {
-      resolve(data)
-    })
+  const spriteSheets = lodash.zip(atlasUrls, lodash.chunk(allTimes, cols * rows))
+  return spriteSheets.map(([url, times], index) => {
+    const atlas: SnapshotAtlas = { index, url }
+    const tiles = parseTiles(atlas, times, cols, rows, width, height)
+    atlas.tiles = tiles
+    return atlas
   })
-  return Promise.all(sprites).then(x => x.flat().sort((a, b) => a.time - b.time))
+}
+
+async function loadAtlasImage(atlas: SnapshotAtlas) {
+  return new Promise((resolve: (atlas: SnapshotAtlas) => void, reject) => {
+    if (atlas.image) {
+      resolve(atlas)
+    } else {
+      const img = new Image()
+      img.crossOrigin = 'anonymous'
+      img.onload = () => {
+        atlas.image = img
+        resolve(atlas)
+      }
+      img.onerror = reject
+      img.src = atlas.url
+    }
+  })
+}
+
+/**
+ * @author WakelessSloth56
+ */
+async function splitTileImage(tile: SnapshotTile) {
+  if (tile.canvas) {
+    return tile as SnapshotTileWithCanvas
+  }
+  if (!tile.atlas.image) {
+    throw new Error('[VideoSnapshot] snapshot atlas not loaded')
+  }
+  const canvas = document.createElement('canvas')
+  canvas.width = tile.width
+  canvas.height = tile.height
+  const ctx = canvas.getContext('2d')
+  ctx.drawImage(
+    tile.atlas.image,
+    tile.x,
+    tile.y,
+    tile.width,
+    tile.width,
+    0,
+    0,
+    tile.width,
+    tile.width,
+  )
+  tile.canvas = canvas
+  return tile as SnapshotTileWithCanvas
 }
 
 /**
@@ -120,7 +148,7 @@ async function splitSnapshots(
  * @author WakelessSloth56
  * @param count 需要的快照图数量
  */
-function sampleByTime<T extends { time: number }>(snapshots: T[], count: number): T[] {
+function sample<T extends { time: number }>(snapshots: T[], count: number): T[] {
   if (snapshots.length <= count) {
     return snapshots
   }
@@ -184,7 +212,7 @@ function drawText(ctx: CanvasText, text: string[], x: number, y0: number, lineHe
  * 在快照图上绘制对应的时间点
  * @author WakelessSloth56
  */
-function drawTimestamp(snapshot: SnapshotSprite, options: DrawOptions = {}) {
+function drawTimestamp(snapshot: SnapshotTileWithCanvas, options: DrawOptions = {}) {
   const timeStr = formatDuration(snapshot.time)
   const ctx = snapshot.canvas.getContext('2d')
 
@@ -220,11 +248,11 @@ function drawTimestamp(snapshot: SnapshotSprite, options: DrawOptions = {}) {
  * @author WakelessSloth56
  */
 function createGrid(
-  snapshots: SnapshotSprite[],
+  tiles: SnapshotTileWithCanvas[],
   cols: number,
   rows: number,
-  spriteWidth: number,
-  spriteHeight: number,
+  tileWidth: number,
+  tileHeight: number,
   options: DrawOptions & GridInfoOptions = {},
 ) {
   const {
@@ -250,8 +278,8 @@ function createGrid(
   const headerW = calcTextWidth(ctx, header)
   const headerH = headerW ? header.length * fontSize + header.length * paddingY + paddingY : 0
 
-  const gridW = cols * spriteWidth + (cols - 1) * paddingX
-  const gridH = rows * spriteHeight + (rows - 1) * paddingY
+  const gridW = cols * tileWidth + (cols - 1) * paddingX
+  const gridH = rows * tileHeight + (rows - 1) * paddingY
 
   const footerW = calcTextWidth(ctx, footer)
   const footerH = footerW ? footer.length * fontSize + footer.length * paddingY + paddingY : 0
@@ -290,15 +318,15 @@ function createGrid(
   for (let row = 0; row < rows; row++) {
     for (let col = 0; col < cols; col++) {
       const i = row * cols + col
-      if (i >= snapshots.length) {
+      if (i >= tiles.length) {
         return canvas
       }
       if (timestamp) {
-        drawTimestamp(snapshots[i])
+        drawTimestamp(tiles[i])
       }
-      const x = col * (spriteWidth + paddingX) + gridX
-      const y = row * (spriteHeight + paddingY) + gridY
-      ctx.drawImage(snapshots[i].canvas, x, y)
+      const x = col * (tileWidth + paddingX) + gridX
+      const y = row * (tileHeight + paddingY) + gridY
+      ctx.drawImage(tiles[i].canvas, x, y)
     }
   }
   return canvas
@@ -314,13 +342,13 @@ export class VideoSnapshot {
   aid?: string
   bvid?: string
   cid: number
-  times: number[]
-  snapshots: SnapshotSprite[]
-  spriteSheets: string[]
-  spriteColumns: number
-  spriteRows: number
-  spriteWidth: number
-  spriteHeight: number
+  atlases: SnapshotAtlas[]
+  atlasWidth: number
+  atlasHeight: number
+  atlasColumns: number
+  atlasRows: number
+  tileWidth: number
+  tileHeight: number
 
   private constructor(aid: string, bvid: string, cid: number) {
     this.aid = aid
@@ -336,7 +364,7 @@ export class VideoSnapshot {
     return new VideoSnapshot(null, bvid, cid)
   }
 
-  async fetchInfo(toCanvas = false): Promise<VideoSnapshot> {
+  async fetchInfo() {
     let url = 'https://api.bilibili.com/x/player/videoshot?'
     if (this.aid) {
       url += `aid=${this.aid}`
@@ -345,43 +373,56 @@ export class VideoSnapshot {
     }
     url += `&cid=${this.cid}`
     const data = await bilibiliApi(getJsonWithCredentials(url), '[VideoSnapshot]', false)
-    const pvData = await fetch(data.pvdata, {})
+
+    const allTimes = await fetch(data.pvdata, {})
       .then(res => res.arrayBuffer())
       .then(b => parsePVData(b))
-    this.times = pvData
-    this.spriteSheets = data.image
-    this.spriteColumns = data.img_x_len
-    this.spriteRows = data.img_y_len
-    this.spriteWidth = data.img_x_size
-    this.spriteHeight = data.img_y_size
-    this.snapshots = await splitSnapshots(
-      this.times,
-      this.spriteSheets,
-      this.spriteColumns,
-      this.spriteRows,
-      this.spriteWidth,
-      this.spriteHeight,
-      toCanvas,
+
+    this.atlasColumns = data.img_x_len
+    this.atlasRows = data.img_y_len
+    this.tileWidth = data.img_x_size
+    this.tileHeight = data.img_y_size
+    this.atlasWidth = this.atlasColumns * this.tileWidth
+    this.atlasHeight = this.atlasRows * this.tileHeight
+
+    this.atlases = await parseAtlases(
+      allTimes,
+      data.image,
+      this.atlasColumns,
+      this.atlasRows,
+      this.tileWidth,
+      this.tileHeight,
     )
+
     this.ready = true
     console.debug(this)
     return this
   }
 
-  async createGrid(cols = 5, rows = 6, options: DrawOptions & GridInfoOptions = {}) {
-    if (!this.ready || !this.snapshots[0].canvas) {
+  checkReady() {
+    if (!this.ready) {
       throw new Error('[VideoSnapshot] snapshots not ready')
     }
+  }
 
-    const canvas = createGrid(
-      sampleByTime(this.snapshots, cols * rows),
-      cols,
-      rows,
-      this.spriteWidth,
-      this.spriteHeight,
-      options,
-    )
+  get snapshots(): SnapshotTile[] {
+    this.checkReady()
+    return this.atlases.flatMap(x => x.tiles)
+  }
 
-    return canvas
+  async loadAtlasImage() {
+    this.checkReady()
+    await Promise.all(this.atlases.map(loadAtlasImage))
+    return this
+  }
+
+  async createGrid(cols = 5, rows = 6, options: DrawOptions & GridInfoOptions = {}) {
+    await this.loadAtlasImage()
+    const tiles = await Promise.all(this.sample(cols * rows).map(splitTileImage))
+    return createGrid(tiles, cols, rows, this.tileWidth, this.tileHeight, options)
+  }
+
+  sample(count: number) {
+    return sample(this.snapshots, count)
   }
 }

--- a/src/components/video/video-snapshot.ts
+++ b/src/components/video/video-snapshot.ts
@@ -1,7 +1,6 @@
 /* spellchecker:words pvdata */
 import { bilibiliApi, getJsonWithCredentials } from '@/core/ajax'
-import { meta } from '@/core/meta'
-import { formatDateTime, formatDuration } from '@/core/utils/formatters'
+import { formatDuration } from '@/core/utils/formatters'
 
 /**
  * 解析二进制格式的 pvdata
@@ -162,8 +161,31 @@ export interface DrawOptions {
 
 export interface GridInfoOptions {
   header?: string[]
-  footer?: boolean
+  footer?: string[]
   timestamp?: boolean
+}
+
+/**
+ * CanvasState **UNSAFE**
+ * @author WakelessSloth56
+ */
+function calcTextWidth(ctx: CanvasText, text?: string[]) {
+  if (text && text.length > 0) {
+    const w = lodash.max(text.map(s => ctx.measureText(s).width))
+    return w
+  }
+  return 0
+}
+
+/**
+ * CanvasState **UNSAFE**
+ * @author WakelessSloth56
+ */
+function drawText(ctx: CanvasText, text: string[], x: number, y0: number, lineHeight: number) {
+  for (let i = 0; i < text.length; i++) {
+    const y = i * lineHeight + y0
+    ctx.fillText(text[i], x, y)
+  }
 }
 
 /**
@@ -185,7 +207,7 @@ function drawTimestamp(snapshot: SnapshotSprite, options: DrawOptions = {}) {
     backgroundColor = '#00000033',
   } = options
 
-  ctx.font = `${fontSize}px '${font}'`
+  ctx.font = `${fontSize}px ${font}`
   const textW = ctx.measureText(timeStr).width
 
   const bgW = textW + paddingX * 2
@@ -223,43 +245,26 @@ function createGrid(
     textColor = '#ffffff',
     backgroundColor = '#000000',
     header = [],
-    footer = false,
+    footer = [],
     timestamp = true,
   } = options
-  const font = `${fontSize}px '${fontName}'`
+  const font = `${fontSize}px ${fontName}`
+  const lineHeight = fontSize + paddingY
 
   const canvas = document.createElement('canvas')
   const ctx = canvas.getContext('2d')
 
-  // 信息栏
-  let headerCanvas: HTMLCanvasElement
-  if (header && header.length > 0) {
-    headerCanvas = document.createElement('canvas')
-    const infoCtx = headerCanvas.getContext('2d')
-    infoCtx.font = font
-    const maxWidth = Math.max(...header.map(x => infoCtx.measureText(x).width))
-    headerCanvas.width = maxWidth
-    headerCanvas.height = header.length * (fontSize + paddingY) + paddingY
-    infoCtx.font = font
-    infoCtx.fillStyle = textColor
-    infoCtx.textBaseline = 'top'
-    let y = 0
-    for (const info of header) {
-      infoCtx.fillText(info, 0, y)
-      y += fontSize + paddingY
-    }
-  }
-
-  const headerW = headerCanvas ? headerCanvas.width : 0
-  const headerH = headerCanvas ? headerCanvas.height : 0
+  ctx.font = font
+  const headerW = calcTextWidth(ctx, header)
+  const headerH = headerW ? header.length * fontSize + header.length * paddingY + paddingY : 0
 
   const gridW = cols * spriteWidth + (cols - 1) * paddingX
   const gridH = rows * spriteHeight + (rows - 1) * paddingY
 
-  // const footerW = gridW
-  const footerH = footer ? fontSize + paddingY * 2 : 0
+  const footerW = calcTextWidth(ctx, footer)
+  const footerH = footerW ? footer.length * fontSize + footer.length * paddingY + paddingY : 0
 
-  const w = Math.max(headerW, gridW) + marginX * 2 // 防止超长标题溢出
+  const w = Math.max(headerW, gridW, footerW) + marginX * 2 // 防止超长标题溢出
   const h = headerH + gridH + footerH + marginY * 2
   canvas.width = w
   canvas.height = h
@@ -270,25 +275,24 @@ function createGrid(
   const gridX = (w - gridW) / 2 // 图片网格居中
   const gridY = headerY + headerH
 
+  const footerX = w - marginX
+  const footerY = gridY + gridH + paddingY * 2
+
   ctx.fillStyle = backgroundColor
   ctx.fillRect(0, 0, w, h)
 
-  // 顶栏
-  if (headerCanvas) {
-    ctx.drawImage(headerCanvas, headerX, headerY)
+  ctx.font = font
+  ctx.textBaseline = 'top'
+  ctx.fillStyle = textColor
+
+  if (headerW) {
+    ctx.textAlign = 'left'
+    drawText(ctx, header, headerX, headerY, lineHeight)
   }
 
-  // 底栏
-  if (footer) {
-    ctx.font = font
-    ctx.fillStyle = textColor
-    ctx.textBaseline = 'top'
-    const generatedAt = `${formatDateTime(new Date())} @ Bilibili-Evolved v${
-      meta.compilationInfo.version
-    }`
-    const footerX = w - marginX - ctx.measureText(generatedAt).width
-    const footerY = gridY + gridH + paddingY * 2
-    ctx.fillText(generatedAt, footerX, footerY) // 右下角
+  if (footerW) {
+    ctx.textAlign = 'right'
+    drawText(ctx, footer, footerX, footerY, lineHeight)
   }
 
   for (let row = 0; row < rows; row++) {

--- a/src/components/video/video-snapshot.ts
+++ b/src/components/video/video-snapshot.ts
@@ -238,7 +238,7 @@ function createGrid(
     infoCtx.font = font
     const maxWidth = Math.max(...header.map(x => infoCtx.measureText(x).width))
     headerCanvas.width = maxWidth
-    headerCanvas.height = header.length * (fontSize + paddingY)
+    headerCanvas.height = header.length * (fontSize + paddingY) + paddingY
     infoCtx.font = font
     infoCtx.fillStyle = textColor
     infoCtx.textBaseline = 'top'

--- a/src/components/video/video-snapshot.ts
+++ b/src/components/video/video-snapshot.ts
@@ -150,7 +150,7 @@ function sampleByTime<T extends { time: number }>(snapshots: T[], count: number)
 
 export interface DrawOptions {
   fontSize?: number
-  font?: string
+  fontFamily?: string
   textColor?: string
   backgroundColor?: string
   paddingX?: number
@@ -165,10 +165,6 @@ export interface GridInfoOptions {
   timestamp?: boolean
 }
 
-/**
- * CanvasState **UNSAFE**
- * @author WakelessSloth56
- */
 function calcTextWidth(ctx: CanvasText, text?: string[]) {
   if (text && text.length > 0) {
     const w = lodash.max(text.map(s => ctx.measureText(s).width))
@@ -177,10 +173,6 @@ function calcTextWidth(ctx: CanvasText, text?: string[]) {
   return 0
 }
 
-/**
- * CanvasState **UNSAFE**
- * @author WakelessSloth56
- */
 function drawText(ctx: CanvasText, text: string[], x: number, y0: number, lineHeight: number) {
   for (let i = 0; i < text.length; i++) {
     const y = i * lineHeight + y0
@@ -202,12 +194,12 @@ function drawTimestamp(snapshot: SnapshotSprite, options: DrawOptions = {}) {
     marginX = 6,
     marginY = 3,
     fontSize = 22,
-    font = 'monospace',
+    fontFamily = 'monospace',
     textColor = '#ffffff',
     backgroundColor = '#00000033',
   } = options
 
-  ctx.font = `${fontSize}px ${font}`
+  ctx.font = `${fontSize}px ${fontFamily}`
   const textW = ctx.measureText(timeStr).width
 
   const bgW = textW + paddingX * 2
@@ -241,7 +233,7 @@ function createGrid(
     marginX = 12,
     marginY = 12,
     fontSize = 22,
-    font: fontName = 'monospace',
+    fontFamily: fontName = 'monospace',
     textColor = '#ffffff',
     backgroundColor = '#000000',
     header = [],

--- a/src/core/ajax.ts
+++ b/src/core/ajax.ts
@@ -270,17 +270,21 @@ export interface BilibiliApiResponse {
  * 进行 bilibili API 标准响应处理
  * @param apiPromise 运行中的 API Promise
  * @param errorMessage 出错时的提示信息
+ * @param log 是否输出错误信息
  */
 export const bilibiliApi = async <T = any>(
   apiPromise: Promise<BilibiliApiResponse>,
   errorMessage?: string,
+  log = true,
 ) => {
   const json = await apiPromise
   if (json.code !== 0) {
     const error = new Error(
       `${errorMessage}: code = ${json.code}, message = ${json.message || json.msg}`,
     )
-    logError(error)
+    if (log) {
+      logError(error)
+    }
     throw error
   }
   return (json.data || json.result || {}) as T

--- a/src/ui/ImageViewer.vue
+++ b/src/ui/ImageViewer.vue
@@ -7,11 +7,23 @@
       <div class="close image-viewer-icon" title="关闭" @click="open = false">
         <VIcon :size="48" icon="mdi-close"></VIcon>
       </div>
-      <a target="_blank" class="copy-link image-viewer-icon" title="复制原链接" @click="copyLink()">
+      <a
+        v-if="!blobFilename"
+        target="_blank"
+        class="copy-link image-viewer-icon"
+        title="复制原链接"
+        @click="copyLink()"
+      >
         <VIcon v-if="copiedTimer" :size="48" icon="mdi-check"></VIcon>
         <VIcon v-else :size="48" icon="mdi-link"></VIcon>
       </a>
-      <a target="_blank" class="new-tab image-viewer-icon" title="在新标签页打开" @click="newTab()">
+      <a
+        v-if="!blobFilename"
+        target="_blank"
+        class="new-tab image-viewer-icon"
+        title="在新标签页打开"
+        @click="newTab()"
+      >
         <VIcon :size="48" icon="mdi-open-in-new"></VIcon>
       </a>
       <a
@@ -38,33 +50,16 @@ export default Vue.extend({
   components: {
     VIcon,
   },
-  props: {
-    image: {
-      type: String,
-      required: true,
-    },
-  },
   data() {
     return {
+      image: '',
       filename: '',
+      blobFilename: '',
       open: false,
       blobUrl: '',
       keyHandler: null,
       copiedTimer: 0,
     }
-  },
-  watch: {
-    async image(url: string) {
-      if (this.blobUrl) {
-        URL.revokeObjectURL(this.blobUrl)
-      }
-      if (!url) {
-        this.blobUrl = ''
-      }
-      const blob = await getBlob(url)
-      this.blobUrl = URL.createObjectURL(blob)
-      this.updateFilename()
-    },
   },
   mounted() {
     this.keyHandler = (e: KeyboardEvent) => {
@@ -111,9 +106,32 @@ export default Vue.extend({
         this.filename = ''
         return
       }
-      this.filename =
-        getFriendlyTitle(document.URL.includes('/www.bilibili.com/bangumi/')) +
-        url.substring(url.lastIndexOf('.'))
+      this.filename = this.blobFilename
+        ? this.blobFilename
+        : getFriendlyTitle(document.URL.includes('/www.bilibili.com/bangumi/')) +
+          url.substring(url.lastIndexOf('.'))
+    },
+    async setImage(url: string, blobFilename?: string) {
+      if (this.blobUrl) {
+        URL.revokeObjectURL(this.blobUrl)
+      }
+      if (!url) {
+        this.blobUrl = ''
+        this.image = ''
+      }
+      this.image = url
+      this.blobFilename = ''
+      if (url.startsWith('blob:')) {
+        this.blobUrl = url
+        if (!blobFilename) {
+          throw new Error('[ImageViewer] Blob格式图片未指定文件名')
+        }
+        this.blobFilename = blobFilename
+      } else {
+        const blob = await getBlob(url)
+        this.blobUrl = URL.createObjectURL(blob)
+      }
+      this.updateFilename()
     },
   },
 })

--- a/src/ui/image-viewer.ts
+++ b/src/ui/image-viewer.ts
@@ -1,6 +1,9 @@
 import ViewerComponent from './ImageViewer.vue'
 
-let vm: { open: boolean; image: string } & Vue
+let vm: {
+  open: boolean
+  setImage: (imageUrl: string, blobFilename?: string) => Promise<void>
+} & Vue
 export const createContainer = async () => {
   vm = new ViewerComponent({
     propsData: {
@@ -11,14 +14,19 @@ export const createContainer = async () => {
   document.body.insertAdjacentElement('beforeend', vm.$el)
   return vm
 }
-export const showImage = async (imageUrl: string) => {
+export const showImage = async (imageUrl: string, blobFilename?: string) => {
   if (!vm) {
     await createContainer()
   }
-  // 等浏览器端完成一次任务处理, 防止容器创建瞬间 open = true 导致没有过渡动画
-  setTimeout(() => {
-    vm.image = imageUrl
-    vm.open = true
+  return new Promise<typeof vm>((resolve, reject) => {
+    setTimeout(() => {
+      // 等浏览器端完成一次任务处理, 防止容器创建瞬间 open = true 导致没有过渡动画
+      vm.setImage(imageUrl, blobFilename)
+        .then(() => {
+          vm.open = true
+          resolve(vm)
+        })
+        .catch(reject)
+    })
   })
-  return vm
 }


### PR DESCRIPTION
# 视频快照 `videoSnapshot`

示例图：
<img height="360" alt="BV1EV411s7vu_snapshot" src="https://github.com/user-attachments/assets/226cfe29-b3bb-44a0-9f83-0a5371503152" />
<img height="360" alt="BV1EV411s7vu_snapshot" src="https://github.com/user-attachments/assets/a9413bf1-dc2b-4602-8887-a80d208f3900" />

## 功能

- 在侧边栏查看视频多个时间点的快照预览图，可下载
    <img height="64" src="https://github.com/user-attachments/assets/9ae8f049-6cd2-4fb6-b096-0aa8f7d0d341" />

- 支持「下载视频」组件
    <img height="128" alt="1782201583034" src="https://github.com/user-attachments/assets/001b642f-1f1d-4ae3-8d7b-99a578fdf659" />

## 配置

- 快照图网格行数
- 快照图网格列数
- 快照图网格间隔（像素）
- 快照图边框（像素）
- 快照图背景颜色
- 快照图文字颜色
- 快照图文字大小（像素）
- 快照图文字字体
- 快照图呈现视频信息：是否在图片的顶部显示视频的信息

## 操作预览：

- GIF：
    <img height="720" src="https://github.com/user-attachments/assets/c28cd68e-47de-4bf3-b186-bff857c12e08" />

---

## Bilibili-Evolved 本体的更改：

- 新增 `@/components/video/video-snapshot` `VideoSnapshot`
- `@/components/video/video-info` `VideoPageInfo`：添加每页视频的投稿时间、视频分辨率
- `@/ui/ImageViewer.vue`：支持直接使用 Blob URL 的图片并指定下载文件名 (@lainio24)
