### PR TITLE
fix(定制自动连播行为): 修复视频合集新版界面功能失效

### DIFF
--- a/registry/lib/components/video/player/custom-auto-play/handlers/BaseAutoplayHandler.ts
+++ b/registry/lib/components/video/player/custom-auto-play/handlers/BaseAutoplayHandler.ts
@@ -118,7 +118,7 @@ export abstract class BaseAutoplayHandler {
     })
   }
 
-  /** 设置番剧自动连播状态 */
+  /** 设置播放器自动连播状态（位于播放器设置浮窗内） */
   protected async setupAutoPlay_Player(enableAutoplay: boolean) {
     const selector = enableAutoplay
       ? '.bpx-player-ctrl-setting-handoff input[type="radio"][value="0"]'

--- a/registry/lib/components/video/player/custom-auto-play/handlers/PlaylistAutoplayHandler.ts
+++ b/registry/lib/components/video/player/custom-auto-play/handlers/PlaylistAutoplayHandler.ts
@@ -6,11 +6,22 @@ import { BaseAutoplayHandler } from './BaseAutoplayHandler'
 export class PlaylistAutoplayHandler extends BaseAutoplayHandler {
   type = '视频合集'
 
+  /** 是否为带自动播放切换按钮的旧版界面 */
+  private isLegacyLayout() {
+    return document.querySelector('.video-pod .auto-play .switch-btn') !== null
+  }
+
+  /** 是否为带订阅合集按钮的新版界面 */
+  private isNewLayout() {
+    return document.querySelector('.video-pod .subscribe-btn') !== null
+  }
+
   async match() {
     const videoUrl = '//www.bilibili.com/video/'
     const list = document.querySelector('.video-pod .section')
-    const btn = document.querySelector('.video-pod .auto-play .switch-btn')
-    return matchUrlPattern(videoUrl) && list != null && btn != null
+    return (
+      matchUrlPattern(videoUrl) && list !== null && (this.isLegacyLayout() || this.isNewLayout())
+    )
   }
 
   protected override getSequentialNumberString(): string {
@@ -25,6 +36,10 @@ export class PlaylistAutoplayHandler extends BaseAutoplayHandler {
   }
 
   async setupAutoPlay(enable: boolean) {
+    if (this.isNewLayout()) {
+      await this.setupAutoPlay_Player(enable)
+      return
+    }
     await this.setupAutoPlay_SwitchBtn(enable)
   }
 }


### PR DESCRIPTION
视频合集相关UI更新，自动播放按钮从合集列表右上角移动到了播放器浮窗设置内，导致原先的识别和控制方式失效，添加新版界面兼容

<img width="1038" height="835" alt="image" src="https://github.com/user-attachments/assets/a0d81fa4-e9fd-48c0-b1d1-ea9a7f83f913" />
