### PR TITLE
修复“收起评论”按钮在UP主主页动态页下的评论区未按预期吸附在页面底部的问题

### DIFF
--- a/registry/lib/components/feeds/fold-comments/fold-comment.scss
+++ b/registry/lib/components/feeds/fold-comments/fold-comment.scss
@@ -27,6 +27,9 @@
     }
   }
 }
+.space-dynamic__content {
+  overflow: visible !important;
+}
 .bili-comment-container {
   display: flex !important;
   flex-direction: column !important;


### PR DESCRIPTION
修复 https://github.com/the1812/Bilibili-Evolved/issues/5628
修复方案是调整UP主动态评论区对应元素的参数
经测试可解决当前问题且未引发其他问题