### PR TITLE
修复“收起评论”按钮在UP主主页动态页会遮挡UP主主页导航栏的问题

### DIFF
--- a/registry/lib/components/feeds/fold-comments/fold-comment.scss
+++ b/registry/lib/components/feeds/fold-comments/fold-comment.scss
@@ -13,7 +13,7 @@
     color: #99a2aa;
     cursor: pointer;
     transition: all 0.2s ease-out;
-    z-index: 110;
+    z-index: 98;
     border-radius: 4px;
     &:hover {
       color: black;


### PR DESCRIPTION
修复 https://github.com/the1812/Bilibili-Evolved/pull/5629 后续问题。
原来按钮的z-index是110，但UP主主页导航栏的z-index值被官方设定为99，所以会出现按钮能遮挡导航栏的问题。
修复方案是将该按钮的z-index值修改为98，即比导航栏刚好低一层以解决问题。
因为动态首页的顶部导航栏z-index是1000，所以即使将按钮的z-index设置成98也不会受此问题影响。
已确定修复了后续问题，再次致歉于我的测试做的不够严谨。