### PR TITLE
修复评论区初始化时过早访问全局 dqa 导致的脚本初始化失败

### DIFF
--- a/src/client/init.ts
+++ b/src/client/init.ts
@@ -20,7 +20,10 @@ export const init = async () => {
 
   const { headLoaded, raiseLifeCycleEvent, LifeCycleEventTypes } = await import('@/core/life-cycle')
   raiseLifeCycleEvent(LifeCycleEventTypes.Start)
-  const { none } = await import('@/core/utils')
+  const { none, dq, dqa } = await import('@/core/utils')
+  // dq/dqa 需要先于 core-apis 挂载, 避免其模块初始化时访问未定义的全局 (如评论区初始化)
+  window.dq = dq
+  window.dqa = dqa
   const { promiseLoadTrace } = await import('@/core/performance/promise-trace')
 
   await promiseLoadTrace('wait for <head>', async () => {
@@ -48,8 +51,6 @@ export const init = async () => {
   unsafeWindow.bilibiliEvolved = externalApis
   /** sand-boxed window, safe to use original name */
   window.coreApis = coreApis
-  window.dq = coreApis.utils.dq
-  window.dqa = coreApis.utils.dqa
   window.de = coreApis.utils.de
   window.des = coreApis.utils.des
   window.dea = coreApis.utils.dea


### PR DESCRIPTION
### 问题

在部分页面上，Bilibili Evolved 可能会在脚本初始化阶段抛出：

```text
ReferenceError: dqa is not defined
```

目前已知会影响一些 `space.bilibili.com/*` 页面，也和 #5516 中提到的首页功能失效问题表现一致。表面现象可能是夜间模式、首页相关功能或其他组件不生效，但根因更像是初始化流程中断，而不是某个具体组件的样式适配问题。

大致原因是：

```text
src/client/init.ts
  -> import('@/core/core-apis')
  -> core-apis imports componentApis
  -> componentApis imports comment-apis
  -> comment-apis registers contentLoaded(() => commentAreaManager.init())
  -> contentLoaded may run immediately when document.readyState !== 'loading'
  -> commentAreaManager.init() uses bare dqa(...)
  -> window.dqa is assigned later in src/client/init.ts
```

`src/global.d.ts` 声明了全局 `dqa`，所以 TypeScript 不会报错，但运行时 `window.dqa` 在这个时机可能还没有被赋值。

### 修改

让评论区初始化路径不要依赖尚未挂到 `window` 上的全局 `dq/dqa`，而是显式从 `@/core/utils` 导入。

涉及文件：

- `src/components/utils/comment/comment-area-manager.ts`
- `src/components/utils/comment/areas/dom.ts`
- `src/components/utils/comment/areas/v1.ts`
- `src/components/utils/comment/areas/v2.ts`

其中只修改 `comment-area-manager.ts` 可以解决当前 `io.init` 的第一处报错，但 V1/V2/DOM 评论区路径里也有裸用的 `dq/dqa`。如果页面上存在这些评论区节点，可能会继续暴露同类错误，所以这里一并改成显式导入。

### 验证

本地已通过：

```text
pnpm run lint-check
pnpm run type
pnpm run build-core
pnpm run build-features
```

`build-core` 生成的 preview bundle 中，`commentAreaManager.init()` 已从裸调用 `dqa(...)` 变为使用模块导入的 `dqa`。

Fixes #5516

## 备注

根据仓库工作流，PR 建议只包含源代码补丁，生成文件可由后续 CI 构建处理，如有不当之处烦请指出。
