### PR TITLE
显示视频投稿时间修复稍后再看页面切换视频后不显示投稿时间问题

### DIFF
--- a/registry/lib/components/video/player/show-upload-time/mediaListVideo.ts
+++ b/registry/lib/components/video/player/show-upload-time/mediaListVideo.ts
@@ -1,9 +1,10 @@
 import Vue from 'vue'
 import { ComponentMetadata } from '@/components/types'
 import { getFormatStr, Video } from './video'
-import { getVue2Data } from '@/core/utils'
+import { getVue2Data, matchUrlPattern } from '@/core/utils'
 import { getComponentSettings } from '@/core/settings'
 import { VideoInfo } from '@/components/video/video-info'
+import { watchlaterUrls } from '@/core/utils/urls'
 
 interface RecommendListUgc extends Vue {
   isFolded: boolean
@@ -108,7 +109,7 @@ export class MediaListVideo implements Video {
           const relist = recoList.$children.filter(video =>
             this.videoClasses.includes(video.$el.className),
           )
-          this.showUploadTime(relist)
+          this.showUploadTime(relist, watchlaterUrls.some(matchUrlPattern))
         },
         { deep: true, immediate: true },
       )


### PR DESCRIPTION
<!-- 可以参考下代码贡献指南: https://github.com/the1812/Bilibili-Evolved/blob/preview/CONTRIBUTING.md -->
切换视频时如果处于稍后再看页面，则传递强制更新参数以避免投稿时间不显示问题。