### PR TITLE
fix(hideBanner): 隐藏横幅后新版首页顶栏文字与图标白底不可见 (#5496)

### DIFF
--- a/registry/lib/components/style/hide/banner/banner.scss
+++ b/registry/lib/components/style/hide/banner/banner.scss
@@ -45,10 +45,10 @@ div.blur-bg,
     .header-upload-entry__text,
     .header-login-entry,
     .go-login-btn {
-      color: #18191c !important;
+      color: black !important;
       text-shadow: none !important;
       body.dark & {
-        color: #e5e5e5 !important;
+        color: #eee !important;
       }
     }
   }

--- a/registry/lib/components/style/hide/banner/banner.scss
+++ b/registry/lib/components/style/hide/banner/banner.scss
@@ -32,9 +32,9 @@ div.blur-bg,
     color: #eee !important;
   }
 }
-// 隐藏顶部横幅后, 新版首页顶栏 (.bili-header) 各入口仍停留在"横幅上"的白色文字状态, 但背景已变白,
-// 导致白底白字不可见 (需下滑才恢复). 各入口自带显式白色, 故需逐类覆盖为深色 (暗色模式保持浅色).
-// 见 issue #5496.
+// 隐藏顶部横幅后, 新版首页顶栏 (.bili-header) 各入口仍停留在"横幅上"的白色文字/图标状态,
+// 但背景已变白, 导致白底白字不可见 (需下滑才恢复). 逐类将文字与图标覆盖为深色 (暗色模式保持浅色).
+// 粉色投稿按钮 (.header-upload-entry) 本就是白字白图标配粉底, 不在覆盖范围内. 见 issue #5496.
 .bili-header {
   .left-entry,
   .right-entry {
@@ -42,7 +42,6 @@ div.blur-bg,
     .default-entry,
     .download-entry,
     .right-entry-text,
-    .header-upload-entry__text,
     .header-login-entry,
     .go-login-btn {
       color: black !important;
@@ -50,6 +49,14 @@ div.blur-bg,
       body.dark & {
         color: #eee !important;
       }
+    }
+  }
+  // 图标为 SVG 且使用 currentColor, 设 color 即可连带修正 fill: 左侧小电视 logo 与右侧入口图标
+  .left-entry .zhuzhan-icon,
+  .right-entry .right-entry-icon {
+    color: black !important;
+    body.dark & {
+      color: #eee !important;
     }
   }
 }

--- a/registry/lib/components/style/hide/banner/banner.scss
+++ b/registry/lib/components/style/hide/banner/banner.scss
@@ -32,3 +32,24 @@ div.blur-bg,
     color: #eee !important;
   }
 }
+// 隐藏顶部横幅后, 新版首页顶栏 (.bili-header) 各入口仍停留在"横幅上"的白色文字状态, 但背景已变白,
+// 导致白底白字不可见 (需下滑才恢复). 各入口自带显式白色, 故需逐类覆盖为深色 (暗色模式保持浅色).
+// 见 issue #5496.
+.bili-header {
+  .left-entry,
+  .right-entry {
+    .entry-title,
+    .default-entry,
+    .download-entry,
+    .right-entry-text,
+    .header-upload-entry__text,
+    .header-login-entry,
+    .go-login-btn {
+      color: #18191c !important;
+      text-shadow: none !important;
+      body.dark & {
+        color: #e5e5e5 !important;
+      }
+    }
+  }
+}


### PR DESCRIPTION
修复 #5496。

## 问题
开启「隐藏顶部横幅」后, 首页顶栏在白色背景上仍保持「横幅上」的白色样式, 导致白底白字/白图标不可见, 下滑后才恢复正常 (暗色模式正常)。

## 原因
`banner.scss` 现有的
```scss
.nav-link .nav-link-ul .nav-link-item .link,
.nav-user-center .user-con .item .name { ... }
```
只覆盖**旧版**导航栏结构。当前首页顶栏用的是 `.bili-header .left-entry` / `.right-entry`, 其中的入口文字、右侧入口图标 (`.right-entry-icon`) 以及左侧小电视 logo (`.zhuzhan-icon`) 在「横幅上」状态自带白色。隐藏横幅后背景变白, 这些元素仍是白色 → 白底不可见。

## 改动
仅追加针对新版顶栏的覆盖, 保留原有旧版规则不动:
- 各入口文字覆盖为顶栏常规深色, 并去掉 `text-shadow`;
- 图标 (SVG 使用 `currentColor`) 同步覆盖: 右侧入口图标与左侧小电视 logo, 设 `color` 即可连带修正 `fill`;
- 暗色模式 (`body.dark`) 下保持浅色;
- **不覆盖粉色投稿按钮** (`.header-upload-entry`): 它本就是粉底白字白图标, 若一并改深会造成白图标配黑字的不一致;
- 选择器限定在 `.bili-header .left-entry` / `.right-entry` 内的具体入口/图标类, 避免匹配无关 UI。

## 测试
- `pnpm run build-features` 构建通过, Prettier / `pnpm run type` / `pnpm run lint-check` 均通过;
- 在 `www.bilibili.com` 首页 (1680px 宽) 实测: 开启隐藏横幅后, 顶栏文字与图标 (含小电视 logo) 均为深色可见、无一处白底不可见 (逐元素测得文字 0、图标 0), 投稿按钮保持粉底白字白图标一致, 横幅正常隐藏。