### PR TITLE
支持专栏转动态(ARTICLE类型)的图片DOM回退提取、重写动态图片提取为 API 方式

### DIFF
--- a/registry/lib/components/utils/image-exporter/feed.ts
+++ b/registry/lib/components/utils/image-exporter/feed.ts
@@ -3,7 +3,7 @@ import { ComponentEntry } from '@/components/types'
 import { getBlob, getJsonWithCredentials } from '@/core/ajax'
 import { DownloadPackage } from '@/core/download'
 import { Toast } from '@/core/toast'
-import { matchUrlPattern } from '@/core/utils'
+import { matchUrlPattern, retrieveImageUrl } from '@/core/utils'
 import { formatTitle, getTitleVariablesFromDate } from '@/core/utils/title'
 import { feedsUrls } from '@/core/utils/urls'
 import { Options } from '.'
@@ -72,12 +72,6 @@ interface DynamicDetailResponse {
   }
 }
 
-const getExtensionFromUrl = (url: string): string => {
-  const cleanUrl = url.replace(/^http:/, 'https:').split('?')[0]
-  const match = cleanUrl.match(/\.([a-zA-Z0-9]+)$/)
-  return match ? `.${match[1]}` : '.jpg'
-}
-
 const fetchDynamicDetail = async (dynamicId: string): Promise<DynamicDetailResponse | null> => {
   const json = await getJsonWithCredentials(
     `https://api.bilibili.com/x/polymer/web-dynamic/v1/detail?id=${dynamicId}`,
@@ -103,13 +97,6 @@ const extractImagesFromMajor = (
   return []
 }
 
-const stripThumbnailSuffix = (url: string): string =>
-  url
-    .replace(/^http:/, 'https:')
-    .replace(/@\d+w.*$/, '')
-    .replace(/@\d+h.*$/, '')
-    .replace(/@\..*$/, '')
-
 const extractImagesFromDom = (): string[] => {
   const contentArea = document.querySelector('.opus-module-content')
   if (!contentArea) {
@@ -120,7 +107,10 @@ const extractImagesFromDom = (): string[] => {
   images.forEach((img: HTMLImageElement) => {
     const src = img.src || (img.dataset as any)?.src || ''
     if (src.includes('/new_dyn/') && !src.includes('/face/')) {
-      urls.add(stripThumbnailSuffix(src))
+      const imageInfo = retrieveImageUrl(src)
+      if (imageInfo) {
+        urls.add(imageInfo.url)
+      }
     }
   })
   return [...urls]
@@ -249,8 +239,9 @@ export const setupFeedImageExporter: ComponentEntry<Options> = async ({
             n: (index + 1).toString(),
             ...variables,
           }
+          const imageInfo = retrieveImageUrl(imageUrls[index])
           pack.add(
-            `${formatTitle(feedFormat, false, titleData)}${getExtensionFromUrl(imageUrls[index])}`,
+            `${formatTitle(feedFormat, false, titleData)}${imageInfo?.extension ?? '.jpg'}`,
             blob,
           )
         })

--- a/registry/lib/components/utils/image-exporter/feed.ts
+++ b/registry/lib/components/utils/image-exporter/feed.ts
@@ -6,7 +6,6 @@ import { Toast } from '@/core/toast'
 import { matchUrlPattern } from '@/core/utils'
 import { formatTitle, getTitleVariablesFromDate } from '@/core/utils/title'
 import { feedsUrls } from '@/core/utils/urls'
-import { getWbiSignedUrl } from '@/core/wbi'
 import { Options } from '.'
 import { useScopedConsole } from '@/core/utils/log'
 
@@ -30,6 +29,11 @@ interface DynamicDetailResponse {
             opus?: {
               summary?: { text: string }
               pics?: Array<{ url: string; width: number; height: number }>
+            }
+            article?: {
+              id: number
+              title: string
+              covers?: string[]
             }
           }
         }
@@ -55,6 +59,11 @@ interface DynamicDetailResponse {
                 summary?: { text: string }
                 pics?: Array<{ url: string; width: number; height: number }>
               }
+              article?: {
+                id: number
+                title: string
+                covers?: string[]
+              }
             }
           }
         }
@@ -70,17 +79,18 @@ const getExtensionFromUrl = (url: string): string => {
 }
 
 const fetchDynamicDetail = async (dynamicId: string): Promise<DynamicDetailResponse | null> => {
-  const signedUrl = await getWbiSignedUrl(
+  const json = await getJsonWithCredentials(
     `https://api.bilibili.com/x/polymer/web-dynamic/v1/detail?id=${dynamicId}`,
   )
-  const json = await getJsonWithCredentials(signedUrl)
   if (json.code !== 0) {
     return null
   }
   return json as DynamicDetailResponse
 }
 
-const extractImagesFromMajor = (major: DynamicDetailResponse['data']['item']['modules']['module_dynamic']['major']): string[] => {
+const extractImagesFromMajor = (
+  major: DynamicDetailResponse['data']['item']['modules']['module_dynamic']['major'],
+): string[] => {
   if (!major) {
     return []
   }
@@ -91,6 +101,29 @@ const extractImagesFromMajor = (major: DynamicDetailResponse['data']['item']['mo
     return major.opus.pics.map(p => p.url.replace(/^http:/, 'https:'))
   }
   return []
+}
+
+const stripThumbnailSuffix = (url: string): string =>
+  url
+    .replace(/^http:/, 'https:')
+    .replace(/@\d+w.*$/, '')
+    .replace(/@\d+h.*$/, '')
+    .replace(/@\..*$/, '')
+
+const extractImagesFromDom = (): string[] => {
+  const contentArea = document.querySelector('.opus-module-content')
+  if (!contentArea) {
+    return []
+  }
+  const images = contentArea.querySelectorAll('img')
+  const urls = new Set<string>()
+  images.forEach((img: HTMLImageElement) => {
+    const src = img.src || (img.dataset as any)?.src || ''
+    if (src.includes('/new_dyn/') && !src.includes('/face/')) {
+      urls.add(stripThumbnailSuffix(src))
+    }
+  })
+  return [...urls]
 }
 
 const extractImagesFromItem = (
@@ -114,6 +147,13 @@ const extractImagesFromItem = (
         titleModule,
         origItem: item.orig,
       }
+    }
+  }
+
+  if (modules.module_dynamic?.major?.type === 'MAJOR_TYPE_ARTICLE') {
+    const domUrls = extractImagesFromDom()
+    if (domUrls.length > 0) {
+      return { urls: domUrls, authorModule, titleModule }
     }
   }
 

--- a/registry/lib/components/utils/image-exporter/feed.ts
+++ b/registry/lib/components/utils/image-exporter/feed.ts
@@ -1,27 +1,125 @@
-import {
-  FeedsCard,
-  addMenuItem,
-  forEachFeedsCard,
-  RepostFeedsCard,
-  normalizeFeedsCardModules,
-} from '@/components/feeds/api'
+import { FeedsCard, addMenuItem, forEachFeedsCard } from '@/components/feeds/api'
 import { ComponentEntry } from '@/components/types'
-import { getBlob } from '@/core/ajax'
+import { getBlob, getJsonWithCredentials } from '@/core/ajax'
 import { DownloadPackage } from '@/core/download'
 import { Toast } from '@/core/toast'
-import { getVue2Data, matchUrlPattern, retrieveImageUrl } from '@/core/utils'
+import { matchUrlPattern } from '@/core/utils'
 import { formatTitle, getTitleVariablesFromDate } from '@/core/utils/title'
 import { feedsUrls } from '@/core/utils/urls'
+import { getWbiSignedUrl } from '@/core/wbi'
 import { Options } from '.'
 import { useScopedConsole } from '@/core/utils/log'
 
-const isSameImage = (imageUrl: string, otherUrl: string) => {
-  try {
-    return new URL(imageUrl).pathname === new URL(otherUrl).pathname
-  } catch {
-    return false
+interface DynamicDetailResponse {
+  code: number
+  data: {
+    item: {
+      id_str: string
+      modules: {
+        module_author: {
+          name: string
+          mid: number
+          pub_ts: number
+        }
+        module_dynamic: {
+          major?: {
+            type?: string
+            draw?: {
+              items: Array<{ src: string }>
+            }
+            opus?: {
+              summary?: { text: string }
+              pics?: Array<{ url: string; width: number; height: number }>
+            }
+          }
+        }
+        module_title?: {
+          text: string
+        }
+      }
+      orig?: {
+        id_str: string
+        modules: {
+          module_author: {
+            name: string
+            mid: number
+            pub_ts: number
+          }
+          module_dynamic: {
+            major?: {
+              type?: string
+              draw?: {
+                items: Array<{ src: string }>
+              }
+              opus?: {
+                summary?: { text: string }
+                pics?: Array<{ url: string; width: number; height: number }>
+              }
+            }
+          }
+        }
+      }
+    }
   }
 }
+
+const getExtensionFromUrl = (url: string): string => {
+  const cleanUrl = url.replace(/^http:/, 'https:').split('?')[0]
+  const match = cleanUrl.match(/\.([a-zA-Z0-9]+)$/)
+  return match ? `.${match[1]}` : '.jpg'
+}
+
+const fetchDynamicDetail = async (dynamicId: string): Promise<DynamicDetailResponse | null> => {
+  const signedUrl = await getWbiSignedUrl(
+    `https://api.bilibili.com/x/polymer/web-dynamic/v1/detail?id=${dynamicId}`,
+  )
+  const json = await getJsonWithCredentials(signedUrl)
+  if (json.code !== 0) {
+    return null
+  }
+  return json as DynamicDetailResponse
+}
+
+const extractImagesFromMajor = (major: DynamicDetailResponse['data']['item']['modules']['module_dynamic']['major']): string[] => {
+  if (!major) {
+    return []
+  }
+  if (major.draw?.items) {
+    return major.draw.items.map(p => p.src.replace(/^http:/, 'https:'))
+  }
+  if (major.opus?.pics) {
+    return major.opus.pics.map(p => p.url.replace(/^http:/, 'https:'))
+  }
+  return []
+}
+
+const extractImagesFromItem = (
+  item: DynamicDetailResponse['data']['item'],
+): { urls: string[]; authorModule: any; titleModule: any; origItem?: any } => {
+  const { modules } = item
+  const authorModule = modules.module_author ?? {}
+  const titleModule = modules.module_title ?? {}
+
+  const urls = extractImagesFromMajor(modules.module_dynamic?.major)
+  if (urls.length > 0) {
+    return { urls, authorModule, titleModule }
+  }
+
+  if (item.orig) {
+    const origUrls = extractImagesFromMajor(item.orig.modules?.module_dynamic?.major)
+    if (origUrls.length > 0) {
+      return {
+        urls: origUrls,
+        authorModule: item.orig.modules.module_author ?? authorModule,
+        titleModule,
+        origItem: item.orig,
+      }
+    }
+  }
+
+  return { urls: [], authorModule, titleModule }
+}
+
 export const setupFeedImageExporter: ComponentEntry<Options> = async ({
   settings: { options },
 }) => {
@@ -34,43 +132,49 @@ export const setupFeedImageExporter: ComponentEntry<Options> = async ({
       className: 'image-export',
       text: '导出图片',
       action: async () => {
-        const imageUrls: { url: string; extension: string }[] = []
         const console = useScopedConsole('导出图片')
-        dqa(
-          card.element,
-          '.main-content .img-content, .bili-album__preview__picture__img, .bili-album .preview__picture__img, .bili-dyn-gallery__image img, .bili-album__watch__track__item img, .bili-dyn-pic__img .b-img__inner',
-        ).forEach((img: HTMLImageElement | HTMLDivElement) => {
-          const urlData = retrieveImageUrl(img)
-          if (urlData && !imageUrls.some(({ url }) => isSameImage(url, urlData.url))) {
-            imageUrls.push(urlData)
-          }
-        })
+        const toast = Toast.info('获取动态数据中...', '导出图片')
+
+        const detail = await fetchDynamicDetail(card.id)
+        if (!detail) {
+          toast.close()
+          Toast.info('获取动态数据失败.', '导出图片')
+          return
+        }
+
+        const {
+          urls: imageUrls,
+          authorModule,
+          titleModule,
+          origItem,
+        } = extractImagesFromItem(detail.data.item)
+
         if (imageUrls.length === 0) {
+          toast.close()
           Toast.info('此条动态没有检测到任何图片.', '导出图片')
           return
         }
+
         console.log({ imageUrls })
-        const toast = Toast.info('下载中...', '导出图片')
+        toast.message = '下载中...'
         let downloadedCount = 0
 
-        const vueData = getVue2Data(card.element)
-        const modules = normalizeFeedsCardModules(vueData.data.modules)
-
-        const titleModule = modules.module_title ?? {}
-        const authorModule = modules.module_author ?? {}
-        const repostAuthorModule = lodash.get(vueData, 'data.orig.modules.module_author', {})
         const date = getTitleVariablesFromDate(new Date(authorModule.pub_ts * 1000))
-        const repostDate = getTitleVariablesFromDate(
-          new Date((repostAuthorModule.pub_ts ?? authorModule.pub_ts) * 1000),
-        )
+        const origAuthorModule = origItem?.modules?.module_author ?? authorModule
+        const origDate = getTitleVariablesFromDate(new Date(origAuthorModule.pub_ts * 1000))
+
         const variables = {
           id: card.id,
-          title: titleModule.text,
-          user: card.username,
-          userID: authorModule.mid?.toString(),
-          originalUser: (card as RepostFeedsCard).repostUsername ?? card.username,
-          originalUserID: repostAuthorModule.mid?.toString() ?? authorModule.mid?.toString(),
-          originalID: lodash.get(vueData, 'data.orig.id_str', card.id),
+          title: titleModule.text ?? '',
+          user: authorModule.name ?? card.username,
+          userID: authorModule.mid?.toString() ?? '',
+          originalUser: origItem
+            ? origItem.modules?.module_author?.name ?? card.username
+            : card.username,
+          originalUserID: origItem
+            ? origItem.modules?.module_author?.mid?.toString() ?? ''
+            : authorModule.mid?.toString() ?? '',
+          originalID: origItem?.id_str ?? card.id,
 
           publishYear: date.year,
           publishMonth: date.month,
@@ -80,22 +184,24 @@ export const setupFeedImageExporter: ComponentEntry<Options> = async ({
           publishSecond: date.second,
           publishMillisecond: date.millisecond,
 
-          originalPublishYear: repostDate.year,
-          originalPublishMonth: repostDate.month,
-          originalPublishDay: repostDate.day,
-          originalPublishHour: repostDate.hour,
-          originalPublishMinute: repostDate.minute,
-          originalPublishSecond: repostDate.second,
-          originalPublishMillisecond: repostDate.millisecond,
+          originalPublishYear: origDate.year,
+          originalPublishMonth: origDate.month,
+          originalPublishDay: origDate.day,
+          originalPublishHour: origDate.hour,
+          originalPublishMinute: origDate.minute,
+          originalPublishSecond: origDate.second,
+          originalPublishMillisecond: origDate.millisecond,
         }
+
         const imageBlobs = await Promise.all(
-          imageUrls.map(async ({ url }) => {
+          imageUrls.map(async url => {
             const blob = await getBlob(url)
             downloadedCount++
             toast.message = `下载中... (${downloadedCount}/${imageUrls.length})`
             return blob
           }),
         )
+
         const pack = new DownloadPackage()
         const { feedFormat } = options
         imageBlobs.forEach((blob, index) => {
@@ -104,7 +210,7 @@ export const setupFeedImageExporter: ComponentEntry<Options> = async ({
             ...variables,
           }
           pack.add(
-            `${formatTitle(feedFormat, false, titleData)}${imageUrls[index].extension}`,
+            `${formatTitle(feedFormat, false, titleData)}${getExtensionFromUrl(imageUrls[index])}`,
             blob,
           )
         })

--- a/src/core/utils/index.ts
+++ b/src/core/utils/index.ts
@@ -542,16 +542,18 @@ export const isTyping = () => {
   }
   return activeElement instanceof HTMLTextAreaElement
 }
+interface RetrievedImageUrl {
+  url: string
+  extension: string
+}
+
 /**
- * 提取元素中的可能的图片信息 (src, data-src, background-image 等). 如果是经过缩放的图, 会自动去除缩放参数返回原图链接
- * @param element 元素
+ * 提取元素或URL字符串中的可能的图片信息 (src, data-src, background-image 等). 如果是经过缩放的图, 会自动去除缩放参数返回原图链接
+ * @param source 元素或图片URL字符串
  * @returns 图片的链接和扩展名
  */
-export const retrieveImageUrl = (element: HTMLElement) => {
-  if (!(element instanceof HTMLElement)) {
-    return null
-  }
-  const url = (() => {
+export const retrieveImageUrl = (source: string | HTMLElement): RetrievedImageUrl | null => {
+  const retrieveUrlFromElement = (element: HTMLElement) => {
     if (element.hasAttribute('data-src')) {
       return element.getAttribute('data-src')
     }
@@ -575,7 +577,16 @@ export const retrieveImageUrl = (element: HTMLElement) => {
       return null
     }
     return match[1]
-  })()
+  }
+
+  const url =
+    typeof source === 'string'
+      ? source.replace(/^http:/, 'https:').split('?')[0]
+      : retrieveUrlFromElement(source)
+
+  if (!url) {
+    return null
+  }
 
   const thumbMatch = url.match(/^(.+)(\..+?)(@.+)$/)
   if (thumbMatch) {
@@ -584,10 +595,12 @@ export const retrieveImageUrl = (element: HTMLElement) => {
       extension: thumbMatch[2],
     }
   }
+
   const noThumbMatch = url.match(/^(.+)(\..+?)$/)
   if (!noThumbMatch) {
     return null
   }
+
   return {
     url: noThumbMatch[1] + noThumbMatch[2],
     extension: noThumbMatch[2],


### PR DESCRIPTION
舊版專欄相關：close #4757, close #5184
opus動態相關：close #5658, close #5669（可能更多的issue暫時沒找到，等待編輯）

从我的 [Bilibili动态预览图片下载](https://greasyfork.org/zh-CN/scripts/524897-bilibili%E5%8A%A8%E6%80%81%E9%A2%84%E8%A7%88%E5%9B%BE%E7%89%87%E4%B8%8B%E8%BD%BD) 移植而來