### PR TITLE
feat: 添加下载 AI 原声翻译音轨功能

### DIFF
--- a/registry/lib/components/video/download/DownloadVideo.vue
+++ b/registry/lib/components/video/download/DownloadVideo.vue
@@ -37,6 +37,15 @@
           @change="saveSelectedQuality()"
         />
       </div>
+      <div v-if="audioTracks && audioTracks.length > 0" class="download-video-config-item">
+        <div class="download-video-config-title">AI 原声翻译:</div>
+        <VDropdown
+          v-model="selectedAudioTrack"
+          :items="audioTrackOptions"
+          value-key="name"
+          @change="saveSelectedAudioTrack()"
+        />
+      </div>
       <template v-if="!testData.multiple && selectedQuality">
         <div v-if="testData.videoInfo" class="download-video-config-description">
           预计大小: {{ formatFileSize(testData.videoInfo.totalSize) }}
@@ -166,6 +175,8 @@ const getFallbackTestVideoInfo = () =>
     title: getFriendlyTitle(true),
   } as DownloadVideoInputItem)
 
+const DEFAULT_AUDIO_TRACK = { name: '', displayName: '原声' }
+
 export default Vue.extend({
   components: {
     VPopup,
@@ -199,6 +210,8 @@ export default Vue.extend({
       assets,
       qualities: [],
       selectedQuality: undefined,
+      audioTracks: [],
+      selectedAudioTrack: undefined,
       inputs: [],
       selectedInput: undefined,
       apis: [],
@@ -220,12 +233,19 @@ export default Vue.extend({
       }
       return this.qualities
     },
+    audioTrackOptions() {
+      const options = this.audioTracks.map(t => ({ name: t.id, displayName: t.name }))
+      if (options.length > 0) {
+        options.unshift(DEFAULT_AUDIO_TRACK)
+      }
+      return options
+    },
     canStartDownload() {
       if (this.busy || !this.open) {
         return false
       }
       const isAnySelectionEmpty = Object.entries(this)
-        .filter(([key]) => key.startsWith('selected'))
+        .filter(([key]) => key.startsWith('selected') && key !== 'selectedAudioTrack')
         .some(([, value]) => !value)
       if (isAnySelectionEmpty) {
         return false
@@ -289,6 +309,11 @@ export default Vue.extend({
       basicConfig.quality = quality.value
       this.updateTestVideoInfo()
     },
+    saveSelectedAudioTrack() {
+      // 避免冗余请求：这里不再使用引用对比，依赖 VDropdown 的 value-key="name" 属性
+      // 它能够正确阻止触发不需要的 change 事件
+      this.updateTestVideoInfo()
+    },
     async getVideoItems() {
       const input = this.selectedInput as DownloadVideoInput
       const videoItems = await input.getInputs(this.$refs.inputOptions)
@@ -307,6 +332,8 @@ export default Vue.extend({
       try {
         const videoInfo = await api.downloadVideoInfo(testItem)
         this.qualities = videoInfo.qualities
+        this.audioTracks = videoInfo.audioTracks || []
+
         const isSelectedQualityOutdated =
           !this.selectedQuality ||
           !videoInfo.qualities.some(q => q.value === this.selectedQuality.value)
@@ -319,8 +346,22 @@ export default Vue.extend({
             }
           }
         }
+
+        const isSelectedAudioTrackOutdated =
+          !this.selectedAudioTrack ||
+          (this.selectedAudioTrack.name !== '' &&
+            !this.audioTracks.some(t => t.id === this.selectedAudioTrack.name))
+
+        if (isSelectedAudioTrackOutdated) {
+          if (this.audioTracks.length > 0) {
+            this.selectedAudioTrack = DEFAULT_AUDIO_TRACK
+          } else {
+            this.selectedAudioTrack = undefined
+          }
+        }
         // 填充 quality 后要再请求一次得到对应 quality 的统计数据
         testItem.quality = this.selectedQuality
+        testItem.audioTrack = this.selectedAudioTrack?.name
         const qualityVideoInfo = await api.downloadVideoInfo(testItem)
         this.testData.videoInfo = qualityVideoInfo
         console.log('[qualityVideoInfo]', qualityVideoInfo)
@@ -341,6 +382,7 @@ export default Vue.extend({
         }
         videoInputs.forEach(item => {
           item.quality = this.selectedQuality
+          item.audioTrack = this.selectedAudioTrack?.name
         })
         const videoInfos = await Promise.all(videoInputs.map(i => api.downloadVideoInfo(i)))
         if (videoInfos.length === 0 || lodash.sumBy(videoInfos, it => it.fragments.length) === 0) {

--- a/registry/lib/components/video/download/DownloadVideo.vue
+++ b/registry/lib/components/video/download/DownloadVideo.vue
@@ -37,12 +37,11 @@
           @change="saveSelectedQuality()"
         />
       </div>
-      <div v-if="audioTracks && audioTracks.length > 0" class="download-video-config-item">
-        <div class="download-video-config-title">AI 原声翻译:</div>
+      <div v-if="audioLanguages && audioLanguages.length > 0" class="download-video-config-item">
+        <div class="download-video-config-title">选择音轨:</div>
         <VDropdown
           v-model="selectedAudioTrack"
           :items="audioTrackOptions"
-          value-key="name"
           @change="saveSelectedAudioTrack()"
         />
       </div>
@@ -210,7 +209,7 @@ export default Vue.extend({
       assets,
       qualities: [],
       selectedQuality: undefined,
-      audioTracks: [],
+      audioLanguages: [],
       selectedAudioTrack: undefined,
       inputs: [],
       selectedInput: undefined,
@@ -234,7 +233,10 @@ export default Vue.extend({
       return this.qualities
     },
     audioTrackOptions() {
-      const options = this.audioTracks.map(t => ({ name: t.id, displayName: t.name }))
+      const options = this.audioLanguages.map(item => ({
+        name: item.language,
+        displayName: item.title,
+      }))
       if (options.length > 0) {
         options.unshift(DEFAULT_AUDIO_TRACK)
       }
@@ -310,8 +312,6 @@ export default Vue.extend({
       this.updateTestVideoInfo()
     },
     saveSelectedAudioTrack() {
-      // 避免冗余请求：这里不再使用引用对比，依赖 VDropdown 的 value-key="name" 属性
-      // 它能够正确阻止触发不需要的 change 事件
       this.updateTestVideoInfo()
     },
     async getVideoItems() {
@@ -332,7 +332,7 @@ export default Vue.extend({
       try {
         const videoInfo = await api.downloadVideoInfo(testItem)
         this.qualities = videoInfo.qualities
-        this.audioTracks = videoInfo.audioTracks || []
+        this.audioLanguages = videoInfo.audioLanguages || []
 
         const isSelectedQualityOutdated =
           !this.selectedQuality ||
@@ -350,10 +350,10 @@ export default Vue.extend({
         const isSelectedAudioTrackOutdated =
           !this.selectedAudioTrack ||
           (this.selectedAudioTrack.name !== '' &&
-            !this.audioTracks.some(t => t.id === this.selectedAudioTrack.name))
+            !this.audioLanguages.some(item => item.language === this.selectedAudioTrack.name))
 
         if (isSelectedAudioTrackOutdated) {
-          if (this.audioTracks.length > 0) {
+          if (this.audioLanguages.length > 0) {
             this.selectedAudioTrack = DEFAULT_AUDIO_TRACK
           } else {
             this.selectedAudioTrack = undefined
@@ -361,7 +361,7 @@ export default Vue.extend({
         }
         // 填充 quality 后要再请求一次得到对应 quality 的统计数据
         testItem.quality = this.selectedQuality
-        testItem.audioTrack = this.selectedAudioTrack?.name
+        testItem.audioLanguage = this.selectedAudioTrack?.name
         const qualityVideoInfo = await api.downloadVideoInfo(testItem)
         this.testData.videoInfo = qualityVideoInfo
         console.log('[qualityVideoInfo]', qualityVideoInfo)
@@ -382,7 +382,7 @@ export default Vue.extend({
         }
         videoInputs.forEach(item => {
           item.quality = this.selectedQuality
-          item.audioTrack = this.selectedAudioTrack?.name
+          item.audioLanguage = this.selectedAudioTrack?.name
         })
         const videoInfos = await Promise.all(videoInputs.map(i => api.downloadVideoInfo(i)))
         if (videoInfos.length === 0 || lodash.sumBy(videoInfos, it => it.fragments.length) === 0) {

--- a/registry/lib/components/video/download/apis/dash.ts
+++ b/registry/lib/components/video/download/apis/dash.ts
@@ -8,7 +8,7 @@ import { Options } from '..'
 import { compareQuality } from '../error'
 import {
   DownloadVideoApi,
-  DownloadVideoAudioTrack,
+  DownloadVideoAudioLanguage,
   DownloadVideoFragment,
   DownloadVideoInfo,
   DownloadVideoInputItem,
@@ -116,18 +116,17 @@ const downloadDash = async (
     audio: () => true,
     ...filters,
   }
-  const { aid, cid, quality, audioTrack } = input
+  const { aid, cid, quality, audioLanguage } = input
   const params: Record<string, string | number> = {
     avid: aid,
     cid,
     qn: quality?.value ?? '',
-    otype: 'json',
     fourk: 1,
     fnver: 0,
     fnval: 4048,
   }
-  if (audioTrack) {
-    params.cur_language = audioTrack
+  if (audioLanguage) {
+    params.cur_language = audioLanguage
   }
   const isBanugmi = bangumiUrls.some(url => matchUrlPattern(url))
   const api = isBanugmi ? bangumiApi(formData(params)) : videoApi(formData(params))
@@ -223,11 +222,11 @@ const downloadDash = async (
   })()
   const currentCodec = fragments.find(x => x.type === 'video')?.codec
   const currentBandWidth = fragments.reduce((p, c) => p + c.bandWidth, 0)
-  let audioTracks: DownloadVideoAudioTrack[] | undefined
+  let audioLanguages: DownloadVideoAudioLanguage[] | undefined
   if (data.language?.items?.length) {
-    audioTracks = data.language.items.map((item: any) => ({
-      id: item.lang,
-      name: item.title,
+    audioLanguages = data.language.items.map((item: any) => ({
+      language: item.lang,
+      title: item.title,
     }))
   }
   const info = new DownloadVideoInfo({
@@ -238,7 +237,7 @@ const downloadDash = async (
     currentQuality,
     currentCodec,
     currentBandWidth,
-    audioTracks,
+    audioLanguages,
   })
   compareQuality(input, info)
   return info

--- a/registry/lib/components/video/download/apis/dash.ts
+++ b/registry/lib/components/video/download/apis/dash.ts
@@ -8,6 +8,7 @@ import { Options } from '..'
 import { compareQuality } from '../error'
 import {
   DownloadVideoApi,
+  DownloadVideoAudioTrack,
   DownloadVideoFragment,
   DownloadVideoInfo,
   DownloadVideoInputItem,
@@ -115,8 +116,8 @@ const downloadDash = async (
     audio: () => true,
     ...filters,
   }
-  const { aid, cid, quality } = input
-  const params = {
+  const { aid, cid, quality, audioTrack } = input
+  const params: Record<string, string | number> = {
     avid: aid,
     cid,
     qn: quality?.value ?? '',
@@ -124,6 +125,9 @@ const downloadDash = async (
     fourk: 1,
     fnver: 0,
     fnval: 4048,
+  }
+  if (audioTrack) {
+    params.cur_language = audioTrack
   }
   const isBanugmi = bangumiUrls.some(url => matchUrlPattern(url))
   const api = isBanugmi ? bangumiApi(formData(params)) : videoApi(formData(params))
@@ -219,6 +223,13 @@ const downloadDash = async (
   })()
   const currentCodec = fragments.find(x => x.type === 'video')?.codec
   const currentBandWidth = fragments.reduce((p, c) => p + c.bandWidth, 0)
+  let audioTracks: DownloadVideoAudioTrack[] | undefined
+  if (data.language?.items?.length) {
+    audioTracks = data.language.items.map((item: any) => ({
+      id: item.lang,
+      name: item.title,
+    }))
+  }
   const info = new DownloadVideoInfo({
     input,
     jsonData: data,
@@ -227,6 +238,7 @@ const downloadDash = async (
     currentQuality,
     currentCodec,
     currentBandWidth,
+    audioTracks,
   })
   compareQuality(input, info)
   return info

--- a/registry/lib/components/video/download/apis/dash.ts
+++ b/registry/lib/components/video/download/apis/dash.ts
@@ -121,6 +121,7 @@ const downloadDash = async (
     avid: aid,
     cid,
     qn: quality?.value ?? '',
+    otype: 'json',
     fourk: 1,
     fnver: 0,
     fnval: 4048,

--- a/registry/lib/components/video/download/types.ts
+++ b/registry/lib/components/video/download/types.ts
@@ -19,6 +19,12 @@ export interface DownloadVideoInputItem {
   quality?: VideoQuality
   /** 是否允许画质回退, 当实际画质和期望画质不符时此项将决定是否抛出异常 */
   allowQualityDrop?: boolean
+  /** 请求的音轨语言 */
+  audioTrack?: string
+}
+export interface DownloadVideoAudioTrack {
+  id: string
+  name: string
 }
 /** 页面数据提供者 */
 export interface DownloadVideoInput<InputParameter = any> extends VueInstanceInput, WithName {
@@ -50,6 +56,7 @@ export class DownloadVideoInfo {
   public currentQuality: VideoQuality
   public currentCodec?: string
   public currentBandWidth?: number
+  public audioTracks?: DownloadVideoAudioTrack[]
   public jsonData: any
   constructor(
     parameters: Omit<DownloadVideoInfo, 'totalSize' | 'totalLength' | 'titledFragments'>,

--- a/registry/lib/components/video/download/types.ts
+++ b/registry/lib/components/video/download/types.ts
@@ -20,11 +20,11 @@ export interface DownloadVideoInputItem {
   /** 是否允许画质回退, 当实际画质和期望画质不符时此项将决定是否抛出异常 */
   allowQualityDrop?: boolean
   /** 请求的音轨语言 */
-  audioTrack?: string
+  audioLanguage?: string
 }
-export interface DownloadVideoAudioTrack {
-  id: string
-  name: string
+export interface DownloadVideoAudioLanguage {
+  language: string
+  title: string
 }
 /** 页面数据提供者 */
 export interface DownloadVideoInput<InputParameter = any> extends VueInstanceInput, WithName {
@@ -56,7 +56,7 @@ export class DownloadVideoInfo {
   public currentQuality: VideoQuality
   public currentCodec?: string
   public currentBandWidth?: number
-  public audioTracks?: DownloadVideoAudioTrack[]
+  public audioLanguages?: DownloadVideoAudioLanguage[]
   public jsonData: any
   constructor(
     parameters: Omit<DownloadVideoInfo, 'totalSize' | 'totalLength' | 'titledFragments'>,

--- a/src/ui/VDropdown.vue
+++ b/src/ui/VDropdown.vue
@@ -87,11 +87,8 @@ export default Vue.extend({
     },
     keyMapper: {
       type: Function,
-      default: (item: any) => item.name,
-    },
-    valueKey: {
-      type: String,
-      default: '',
+      default: (item: any) =>
+        item !== null && typeof item === 'object' && 'name' in item ? item.name : item,
     },
     round: {
       type: Boolean,
@@ -123,8 +120,8 @@ export default Vue.extend({
   methods: {
     selectItem(item: any) {
       let isChanged = false
-      if (this.valueKey && item && this.value) {
-        isChanged = item[this.valueKey] !== this.value[this.valueKey]
+      if (item && this.value && this.keyMapper) {
+        isChanged = this.keyMapper(item) !== this.keyMapper(this.value)
       } else {
         isChanged = item !== this.value
       }

--- a/src/ui/VDropdown.vue
+++ b/src/ui/VDropdown.vue
@@ -89,6 +89,10 @@ export default Vue.extend({
       type: Function,
       default: (item: any) => item.name,
     },
+    valueKey: {
+      type: String,
+      default: '',
+    },
     round: {
       type: Boolean,
       default: false,
@@ -118,7 +122,14 @@ export default Vue.extend({
   },
   methods: {
     selectItem(item: any) {
-      if (item !== this.value) {
+      let isChanged = false
+      if (this.valueKey && item && this.value) {
+        isChanged = item[this.valueKey] !== this.value[this.valueKey]
+      } else {
+        isChanged = item !== this.value
+      }
+
+      if (isChanged) {
         this.$emit('change', item)
       }
       this.popupOpen = false


### PR DESCRIPTION
感谢开发者大大这么久的更新~插件超级好用的一直在用！现在顺便给视频下载功能加上了“音轨选择”的支持，现在可以下载「AI 原声翻译」的音轨了。

平时碰到带多音轨（比如 AI 翻译）的视频，默认只能下到原声，这个改动主要是为了把其他音轨也暴露出来供大家选择。

### 改动
- **底层 API 扩展**：更新了视频下载的数据结构，在 `DownloadVideoInfo` 和 DASH 接口中增加了对 `audioTracks` 的解析。请求时如果有指定音轨，会带上 `cur_language` 参数。
- **UI 适配**：在视频下载界面的画质下方加了个音轨选项卡。如果接口返回了多音轨，下拉框就会显示出来，默认会选中「原声」。
- **组件优化**：稍微改了下基础组件 `VDropdown.vue`，给它加了个 `valueKey` 的 props。主要是为了避免下拉框里的对象引用变化时触发一些不必要的冗余 `change` 事件（也会导致重复请求）。

### 自查
- [x] 目标分支是 `preview-features`
- [x] 没有包含 `dist/` 或其他编译生成的文件
- [x] 本地已通过 `pnpm run type`
- [x] 本地已通过 `pnpm run lint-check`
- [x] 未修改或提交 `doc/features/` 下的自动生成文档

在本地环境测试过下载带 AI 翻译的视频，音轨能正常切换并下载成功，麻烦各位大佬帮忙 review 下，看看有没有什么需要优化的地方。

<img width="400" height="1031" alt="PixPin_2026-07-13_23-26-26" src="https://github.com/user-attachments/assets/2fddaf87-b1a1-4360-9835-d6560969c322" />
