### PR TITLE
将 JSZip 替换为 fflate

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,8 +78,8 @@
   "dependencies": {
     "@popperjs/core": "^2.6.0",
     "color": "^3.1.2",
+    "fflate": "^0.8.3",
     "fuse.js": "^6.4.6",
-    "jszip": "^3.7.1",
     "lodash": "^4.17.21",
     "marked": "^1.2.5",
     "protobufjs": "^6.11.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,12 +19,12 @@ importers:
       color:
         specifier: ^3.1.2
         version: 3.2.1
+      fflate:
+        specifier: ^0.8.3
+        version: 0.8.3
       fuse.js:
         specifier: ^6.4.6
         version: 6.6.2
-      jszip:
-        specifier: ^3.7.1
-        version: 3.10.1
       lodash:
         specifier: ^4.17.21
         version: 4.17.21
@@ -1948,9 +1948,6 @@ packages:
   core-js-compat@3.40.0:
     resolution: {integrity: sha512-0XEDpr5y5mijvw8Lbc6E5AkjrHfp7eEoPlu36SWeAbcL8fn1G1ANe8DBlo2XoNN89oVpxWwOjYIPVzR4ZvsKCQ==}
 
-  core-util-is@1.0.3:
-    resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
-
   cosmiconfig@7.1.0:
     resolution: {integrity: sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==}
     engines: {node: '>=10'}
@@ -2337,6 +2334,9 @@ packages:
   fastq@1.19.0:
     resolution: {integrity: sha512-7SFSRCNjBQIZH/xZR3iy5iQYR8aGBE0h3VG6/cwlbrpdciNYBMotQav8c1XI3HjHH+NikUpP53nPdlZSdWmFzA==}
 
+  fflate@0.8.3:
+    resolution: {integrity: sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==}
+
   file-entry-cache@6.0.1:
     resolution: {integrity: sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==}
     engines: {node: ^10.12.0 || >=12.0.0}
@@ -2537,9 +2537,6 @@ packages:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
 
-  immediate@3.0.6:
-    resolution: {integrity: sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==}
-
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
@@ -2698,9 +2695,6 @@ packages:
     resolution: {integrity: sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==}
     engines: {node: '>=8'}
 
-  isarray@1.0.0:
-    resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
-
   isarray@2.0.5:
     resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
 
@@ -2762,9 +2756,6 @@ packages:
   jsonfile@3.0.1:
     resolution: {integrity: sha512-oBko6ZHlubVB5mRFkur5vgYR1UyqX+S6Y/oCfLhqNdcc2fYFlDpIoNc7AfKS1KOGcnNAkvsr0grLck9ANM815w==}
 
-  jszip@3.10.1:
-    resolution: {integrity: sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==}
-
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
@@ -2779,9 +2770,6 @@ packages:
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
-
-  lie@3.3.0:
-    resolution: {integrity: sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==}
 
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
@@ -3020,9 +3008,6 @@ packages:
 
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
-
-  pako@1.0.11:
-    resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
 
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
@@ -3327,9 +3312,6 @@ packages:
     engines: {node: '>=10.13.0'}
     hasBin: true
 
-  process-nextick-args@2.0.1:
-    resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
-
   progress@2.0.3:
     resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
     engines: {node: '>=0.4.0'}
@@ -3364,9 +3346,6 @@ packages:
   rc@1.2.8:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
     hasBin: true
-
-  readable-stream@2.3.8:
-    resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
 
   readdirp@3.6.0:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
@@ -3521,9 +3500,6 @@ packages:
     resolution: {integrity: sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==}
     engines: {node: '>= 0.4'}
 
-  setimmediate@1.0.5:
-    resolution: {integrity: sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==}
-
   shallow-clone@3.0.1:
     resolution: {integrity: sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==}
     engines: {node: '>=8'}
@@ -3618,9 +3594,6 @@ packages:
   string.prototype.trimstart@1.0.8:
     resolution: {integrity: sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==}
     engines: {node: '>= 0.4'}
-
-  string_decoder@1.1.1:
-    resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
 
   strip-ansi@3.0.1:
     resolution: {integrity: sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==}
@@ -5843,8 +5816,6 @@ snapshots:
     dependencies:
       browserslist: 4.24.4
 
-  core-util-is@1.0.3: {}
-
   cosmiconfig@7.1.0:
     dependencies:
       '@types/parse-json': 4.0.2
@@ -6345,6 +6316,8 @@ snapshots:
     dependencies:
       reusify: 1.0.4
 
+  fflate@0.8.3: {}
+
   file-entry-cache@6.0.1:
     dependencies:
       flat-cache: 3.2.0
@@ -6547,8 +6520,6 @@ snapshots:
 
   ignore@5.3.2: {}
 
-  immediate@3.0.6: {}
-
   import-fresh@3.3.1:
     dependencies:
       parent-module: 1.0.1
@@ -6705,8 +6676,6 @@ snapshots:
     dependencies:
       is-docker: 2.2.1
 
-  isarray@1.0.0: {}
-
   isarray@2.0.5: {}
 
   isexe@2.0.0: {}
@@ -6756,13 +6725,6 @@ snapshots:
     optionalDependencies:
       graceful-fs: 4.2.11
 
-  jszip@3.10.1:
-    dependencies:
-      lie: 3.3.0
-      pako: 1.0.11
-      readable-stream: 2.3.8
-      setimmediate: 1.0.5
-
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
@@ -6775,10 +6737,6 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
       type-check: 0.4.0
-
-  lie@3.3.0:
-    dependencies:
-      immediate: 3.0.6
 
   lines-and-columns@1.2.4: {}
 
@@ -7006,8 +6964,6 @@ snapshots:
   p-try@2.2.0: {}
 
   package-json-from-dist@1.0.1: {}
-
-  pako@1.0.11: {}
 
   parent-module@1.0.1:
     dependencies:
@@ -7311,8 +7267,6 @@ snapshots:
 
   prettier@2.8.8: {}
 
-  process-nextick-args@2.0.1: {}
-
   progress@2.0.3: {}
 
   protobufjs@6.11.4:
@@ -7356,16 +7310,6 @@ snapshots:
       ini: 1.3.8
       minimist: 1.2.8
       strip-json-comments: 2.0.1
-
-  readable-stream@2.3.8:
-    dependencies:
-      core-util-is: 1.0.3
-      inherits: 2.0.4
-      isarray: 1.0.0
-      process-nextick-args: 2.0.1
-      safe-buffer: 5.1.2
-      string_decoder: 1.1.1
-      util-deprecate: 1.0.2
 
   readdirp@3.6.0:
     dependencies:
@@ -7566,8 +7510,6 @@ snapshots:
       es-errors: 1.3.0
       es-object-atoms: 1.1.1
 
-  setimmediate@1.0.5: {}
-
   shallow-clone@3.0.1:
     dependencies:
       kind-of: 6.0.3
@@ -7681,10 +7623,6 @@ snapshots:
       call-bind: 1.0.8
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
-
-  string_decoder@1.1.1:
-    dependencies:
-      safe-buffer: 5.1.2
 
   strip-ansi@3.0.1:
     dependencies:

--- a/registry/lib/components/video/player/screenshot/VideoScreenshotContainer.vue
+++ b/registry/lib/components/video/player/screenshot/VideoScreenshotContainer.vue
@@ -47,7 +47,7 @@ export default Vue.extend({
       const pack = new DownloadPackage()
       this.screenshots.forEach((it: Screenshot) => {
         pack.add(it.filename, it.blob, {
-          date: new Date(it.timeStamp),
+          mtime: new Date(it.timeStamp),
         })
       })
       await pack.emit(`${getFriendlyTitle()}.zip`)

--- a/src/components/settings-panel/sub-pages/manage-panel/ManagePanel.vue
+++ b/src/components/settings-panel/sub-pages/manage-panel/ManagePanel.vue
@@ -165,7 +165,15 @@ export default Vue.extend({
       if (codeFile.name.endsWith('.zip')) {
         const fflate = await FflateLibrary
         const buffer = new Uint8Array(await codeFile.arrayBuffer())
-        const files = fflate.unzipSync(buffer)
+        const files = await new Promise<Record<string, Uint8Array>>((resolve, reject) => {
+          fflate.unzip(buffer, (err, data) => {
+            if (err) {
+              reject(err)
+            } else {
+              resolve(data)
+            }
+          })
+        })
         const fileNames = Object.keys(files)
         if (fileNames.length === 0) {
           Toast.info('不能打开空文件', `添加${this.config.title}`)

--- a/src/components/settings-panel/sub-pages/manage-panel/ManagePanel.vue
+++ b/src/components/settings-panel/sub-pages/manage-panel/ManagePanel.vue
@@ -97,7 +97,7 @@ import { installFeature, tryParseZip } from '@/core/install-feature'
 import { pickFile } from '@/core/file-picker'
 import { Toast, ToastType } from '@/core/toast'
 import { logError } from '@/core/utils/log'
-import { JSZipLibrary } from '@/core/runtime-library'
+import { FflateLibrary } from '@/core/runtime-library'
 import { VIcon, VButton, TextBox, VEmpty, VLoading, VPopup, TextArea, SwitchBox } from '@/ui'
 import ManageItem from './ManageItem.vue'
 import OnlineRegistryButton from '../online-registry/OnlineRegistryButton.vue'
@@ -163,14 +163,15 @@ export default Vue.extend({
       const [codeFile] = codes
       let code: string
       if (codeFile.name.endsWith('.zip')) {
-        const JSZip = await JSZipLibrary
-        const zip = await JSZip.loadAsync(codeFile)
-        const files = Object.values(zip.files)
-        if (files.length === 0) {
+        const fflate = await FflateLibrary
+        const buffer = new Uint8Array(await codeFile.arrayBuffer())
+        const files = fflate.unzipSync(buffer)
+        const fileNames = Object.keys(files)
+        if (fileNames.length === 0) {
           Toast.info('不能打开空文件', `添加${this.config.title}`)
           return
         }
-        code = await files[0].async('text')
+        code = new TextDecoder().decode(files[fileNames[0]])
       } else {
         code = await codeFile.text()
       }

--- a/src/core/download.ts
+++ b/src/core/download.ts
@@ -1,6 +1,6 @@
-import { JSZipFileOptions } from 'jszip'
+import { ZipOptions } from 'fflate'
 import { DownloadPackageEmitMode } from './download-mode'
-import { JSZipLibrary } from './runtime-library'
+import { FflateLibrary } from './runtime-library'
 import { getGeneralSettings } from './settings'
 import { formatFilename } from './utils/formatters'
 import { useScopedConsole } from './utils/log'
@@ -12,8 +12,8 @@ export interface PackageEntry {
   name: string
   /** 文件内容 */
   data: Blob | string
-  /** 其他文件属性 */
-  options: JSZipFileOptions
+  /** 压缩选项 */
+  options: ZipOptions
 }
 /** 打包下载多个文件 */
 export class DownloadPackage {
@@ -29,7 +29,7 @@ export class DownloadPackage {
    * @param name 文件名
    * @param data 文件内容
    */
-  add(name: string, data: string | Blob, options: JSZipFileOptions = {}) {
+  add(name: string, data: string | Blob, options: ZipOptions = {}) {
     if (data === null || data === undefined) {
       return
     }
@@ -45,25 +45,30 @@ export class DownloadPackage {
       const { data } = this.entries[0]
       return typeof data === 'string' ? new Blob([data]) : data
     }
-    const JSZip = await JSZipLibrary
-    const zip = new JSZip()
-    const fileExists = (name: string) => zip.filter((_, file) => file.name === name).length > 0
-    this.entries.forEach(({ name, data, options }) => {
-      if (fileExists(name)) {
-        let tempName = name
+    const fflate = await FflateLibrary
+    const zippable: Record<string, [Uint8Array, ZipOptions]> = {}
+    const fileExists = (name: string) => Object.prototype.hasOwnProperty.call(zippable, name)
+    for (const { name, data, options } of this.entries) {
+      let finalName = name
+      if (fileExists(finalName)) {
+        let tempName = finalName
         while (fileExists(tempName)) {
-          const extensionIndex = name.lastIndexOf('.')
-          tempName = `${name.substring(0, extensionIndex)}.${getRandomId(8)}${name.substring(
-            extensionIndex,
-          )}`
+          const extensionIndex = finalName.lastIndexOf('.')
+          tempName = `${finalName.substring(0, extensionIndex)}.${getRandomId(
+            8,
+          )}${finalName.substring(extensionIndex)}`
         }
-        console.warn(`文件名 "${name}" 和已有文件冲突, 已临时更换为 "${tempName}"`)
-        zip.file(tempName, data, options)
-        return
+        console.warn(`文件名 "${finalName}" 和已有文件冲突, 已临时更换为 "${tempName}"`)
+        finalName = tempName
       }
-      zip.file(name, data, options)
-    })
-    return zip.generateAsync({ type: 'blob' })
+      const bytes =
+        typeof data === 'string'
+          ? new TextEncoder().encode(data)
+          : new Uint8Array(await data.arrayBuffer())
+      zippable[finalName] = [bytes, options]
+    }
+    const result = fflate.zipSync(zippable)
+    return new Blob([result])
   }
   /**
    * 触发浏览器下载, 若只有一个文件则不会打包, 而是直接下载此文件
@@ -117,7 +122,7 @@ export class DownloadPackage {
    * @param filename 文件名
    * @param data 文件内容
    */
-  static async single(filename: string, data: string | Blob, options: JSZipFileOptions = {}) {
+  static async single(filename: string, data: string | Blob, options: ZipOptions = {}) {
     const pack = new DownloadPackage()
     pack.add(filename, data, options)
     return pack.emit()

--- a/src/core/download.ts
+++ b/src/core/download.ts
@@ -65,9 +65,7 @@ export class DownloadPackage {
         typeof data === 'string'
           ? new TextEncoder().encode(data)
           : new Uint8Array(await data.arrayBuffer())
-      // 二进制媒体文件使用 store only，文本文件使用默认压缩
-      const isBinaryMedia = data instanceof Blob && /^(image|video|audio)\//.test(data.type)
-      const finalOptions = isBinaryMedia ? { ...options, level: 0 as const } : options
+      const finalOptions = { ...options, level: 0 as const }
       zippable[finalName] = [bytes, finalOptions]
     }
     const result = fflate.zipSync(zippable)

--- a/src/core/download.ts
+++ b/src/core/download.ts
@@ -65,7 +65,10 @@ export class DownloadPackage {
         typeof data === 'string'
           ? new TextEncoder().encode(data)
           : new Uint8Array(await data.arrayBuffer())
-      zippable[finalName] = [bytes, options]
+      // 二进制媒体文件使用 store only，文本文件使用默认压缩
+      const isBinaryMedia = data instanceof Blob && /^(image|video|audio)\//.test(data.type)
+      const finalOptions = isBinaryMedia ? { ...options, level: 0 as const } : options
+      zippable[finalName] = [bytes, finalOptions]
     }
     const result = fflate.zipSync(zippable)
     return new Blob([result])

--- a/src/core/download.ts
+++ b/src/core/download.ts
@@ -68,7 +68,15 @@ export class DownloadPackage {
       const finalOptions = { ...options, level: 0 as const }
       zippable[finalName] = [bytes, finalOptions]
     }
-    const result = fflate.zipSync(zippable)
+    const result = await new Promise<Uint8Array>((resolve, reject) => {
+      fflate.zip(zippable, (err, data) => {
+        if (err) {
+          reject(err)
+        } else {
+          resolve(data)
+        }
+      })
+    })
     return new Blob([result])
   }
   /**

--- a/src/core/install-feature.ts
+++ b/src/core/install-feature.ts
@@ -13,7 +13,7 @@ const isStyle = (item: FeatureType): item is UserStyle => Boolean((item as UserS
 
 /** 如果输入的功能链接是 .zip, 则尝试解压. 仅支持单个功能, 不能批量, 只是为了能方便在 GitHub 直接以 .zip 格式分享功能. */
 export const tryParseZip = async (url: string) => {
-  const { JSZipLibrary } = await import('./runtime-library')
+  const { FflateLibrary } = await import('./runtime-library')
   const { monkey } = await import('../core/ajax')
   const isZip = url.endsWith('.zip')
   const responseType = isZip ? 'blob' : 'text'
@@ -21,13 +21,14 @@ export const tryParseZip = async (url: string) => {
   if (!isZip || typeof response === 'string') {
     return response as string
   }
-  const JSZip = await JSZipLibrary
-  const zip = await JSZip.loadAsync(response)
-  const files = Object.values(zip.files)
-  if (files.length === 0) {
+  const fflate = await FflateLibrary
+  const buffer = new Uint8Array(await response.arrayBuffer())
+  const files = fflate.unzipSync(buffer)
+  const fileNames = Object.keys(files)
+  if (fileNames.length === 0) {
     throw new Error('Empty zip file')
   }
-  return files[0].async('text')
+  return new TextDecoder().decode(files[fileNames[0]])
 }
 export const installFeatureFromCode = async (
   code: string,

--- a/src/core/install-feature.ts
+++ b/src/core/install-feature.ts
@@ -23,7 +23,15 @@ export const tryParseZip = async (url: string) => {
   }
   const fflate = await FflateLibrary
   const buffer = new Uint8Array(await response.arrayBuffer())
-  const files = fflate.unzipSync(buffer)
+  const files = await new Promise<Record<string, Uint8Array>>((resolve, reject) => {
+    fflate.unzip(buffer, (err, data) => {
+      if (err) {
+        reject(err)
+      } else {
+        resolve(data)
+      }
+    })
+  })
   const fileNames = Object.keys(files)
   if (fileNames.length === 0) {
     throw new Error('Empty zip file')

--- a/src/core/runtime-library.ts
+++ b/src/core/runtime-library.ts
@@ -1,5 +1,5 @@
 import type protobufType from 'protobufjs'
-import type JSZipType from 'jszip'
+import type * as fflateType from 'fflate'
 import type SortableJSType from 'sortablejs'
 import type StreamSaverType from 'streamsaver'
 import { monkey } from './ajax'
@@ -72,9 +72,9 @@ export const protobufLibrary = new RuntimeLibrary<typeof protobufType>({
   library: meta.compilationInfo.altCdn.library.protobuf,
   getModule: window => window.protobuf,
 })
-export const JSZipLibrary = new RuntimeLibrary<typeof JSZipType>({
-  library: meta.compilationInfo.altCdn.library.jszip,
-  getModule: window => window.JSZip,
+export const FflateLibrary = new RuntimeLibrary<typeof fflateType>({
+  library: meta.compilationInfo.altCdn.library.fflate,
+  getModule: window => window.fflate,
 })
 export const SortableJSLibrary = new RuntimeLibrary<typeof SortableJSType>({
   library: meta.compilationInfo.altCdn.library.sortable,

--- a/webpack/cdn/github.ts
+++ b/webpack/cdn/github.ts
@@ -18,9 +18,9 @@ export const github: CdnConfig = {
       url: `https://${host}/protobufjs/protobuf.js/v6.10.1/dist/light/protobuf.min.js`,
       sha256: '8978daf871b02d683ecaee371861702a6f31d0a4c52925b7db2bb1655a8bc7d1',
     },
-    jszip: {
-      url: `https://${host}/Stuk/jszip/v3.7.1/dist/jszip.min.js`,
-      sha256: 'c9e4a52bac18aee4f3f90d05fbca603f5b0f5bf1ce8c45e60bb4ed3a2cb2ed86',
+    fflate: {
+      url: `https://${host}/101arrowz/fflate/v0.8.3/umd/index.js`,
+      sha256: '462ef8041fc970e3615a20a9dd2b2e3047a073b2da729ef4f02b634bba8b7b83',
     },
     sortable: {
       url: `https://${host}/SortableJS/Sortable/1.14.0/Sortable.min.js`,

--- a/webpack/cdn/github.ts
+++ b/webpack/cdn/github.ts
@@ -18,10 +18,7 @@ export const github: CdnConfig = {
       url: `https://${host}/protobufjs/protobuf.js/v6.10.1/dist/light/protobuf.min.js`,
       sha256: '8978daf871b02d683ecaee371861702a6f31d0a4c52925b7db2bb1655a8bc7d1',
     },
-    fflate: {
-      url: `https://${host}/101arrowz/fflate/v0.8.3/umd/index.js`,
-      sha256: '462ef8041fc970e3615a20a9dd2b2e3047a073b2da729ef4f02b634bba8b7b83',
-    },
+    fflate: jsDelivr.library.fflate,
     sortable: {
       url: `https://${host}/SortableJS/Sortable/1.14.0/Sortable.min.js`,
       sha256: '0ea5a6fbfbf5434b606878533cb7a66bcf700f0f08afe908335d0978fb63ad94',

--- a/webpack/cdn/jsdelivr.ts
+++ b/webpack/cdn/jsdelivr.ts
@@ -17,9 +17,9 @@ export const jsDelivr: CdnConfig = {
       url: `https://${host}/npm/protobufjs@6.10.1/dist/light/protobuf.min.js`,
       sha256: '8978daf871b02d683ecaee371861702a6f31d0a4c52925b7db2bb1655a8bc7d1',
     },
-    jszip: {
-      url: `https://${host}/npm/jszip@3.7.1/dist/jszip.min.js`,
-      sha256: 'c9e4a52bac18aee4f3f90d05fbca603f5b0f5bf1ce8c45e60bb4ed3a2cb2ed86',
+    fflate: {
+      url: `https://${host}/npm/fflate@0.8.3/umd/index.js`,
+      sha256: '462ef8041fc970e3615a20a9dd2b2e3047a073b2da729ef4f02b634bba8b7b83',
     },
     sortable: {
       url: `https://${host}/npm/sortablejs@1.14.0/Sortable.min.js`,

--- a/webpack/cdn/types.ts
+++ b/webpack/cdn/types.ts
@@ -8,7 +8,7 @@ export interface CdnConfig {
   library: {
     lodash: ExternalLibrary
     protobuf: ExternalLibrary
-    jszip: ExternalLibrary
+    fflate: ExternalLibrary
     sortable: ExternalLibrary
     streamsaver: ExternalLibrary
     ffmpeg: {


### PR DESCRIPTION
fflate 体积更小（~33KB vs ~100KB），性能更好。
- 更新 CDN 配置和运行时库加载
- 重写 DownloadPackage 使用 fflate.zipSync
- 更新 zip 解压逻辑使用 fflate.unzipSync
