### PR TITLE
fix(自定义字体): 修复新版播放器弹幕字体被自定义字体覆盖的问题

### DIFF
--- a/registry/lib/components/style/custom-font-family/set-font-family.scss
+++ b/registry/lib/components/style/custom-font-family/set-font-family.scss
@@ -27,8 +27,9 @@ $font-family-css: var(--#{$name}--options--font-family) !important;
 }
 
 @function get-danmaku-path() {
-  $main: '.bili-dm';
-  @return collect-paths(($main));
+  $legacy: '.bili-dm';
+  $new-player: '.bili-danmaku-x-dm';
+  @return collect-paths(($legacy, $new-player));
 }
 
 @function get-icon-font-path() {


### PR DESCRIPTION
修复 #5614

### 问题
新版播放器（4.9.x）的弹幕元素类名已从 `.bili-dm` 改为 `.bili-danmaku-x-dm`，导致 `custom-font-family` 组件中 `get-danmaku-path()` 的选择器失效。

表现：即使“弹幕字体覆盖”选项未勾选，弹幕字体仍被自定义字体覆盖，无法使用 B 站默认弹幕字体。

### 修改
在 `get-danmaku-path()` 中同时保留旧类名 `.bili-dm` 和新类名 `.bili-danmaku-x-dm`，兼容旧版和新版播放器。

```scss
@function get-danmaku-path() {
  $legacy: '.bili-dm';
  $new-player: '.bili-danmaku-x-dm';
  @return collect-paths(($legacy, $new-player));
}