### PR TITLE
修复自定义顶栏未隐藏原版频道下拉菜单 #5495

### DIFF
--- a/registry/lib/components/style/custom-navbar/hide-original.scss
+++ b/registry/lib/components/style/custom-navbar/hide-original.scss
@@ -43,5 +43,6 @@ body.history-page #biliMainHeader:not(.z-top-container) {
   top: var(--navbar-height) !important;
 }
 .bili-feed4 .header-channel{
+  display: none !important;
   top: 0 !important;
 }


### PR DESCRIPTION
- [x] 成功运行 `pnpm run check-pr-files`

- [x] 成功运行 `pnpm run type`

- [x] 成功运行 `pnpm run lint-check`

- [x] 启用自定义顶栏后，原版频道菜单不再出现

- [x] 关闭自定义顶栏后，B 站原版顶栏正常恢复

- [x] 刷新页面后仍然正常

- [x] 浏览器控制台没有新增错误