### PR TITLE
fix(compatibility): 为页面作用域补充 requestIdleCallback polyfill (Safari)

### DIFF
--- a/src/client/compatibility.ts
+++ b/src/client/compatibility.ts
@@ -45,4 +45,19 @@ export const compatibilityPatch = () => {
       window.clearTimeout(handle)
     }
   }
+  // 沙箱 window 的补丁不影响页面作用域, 而 B 站页面自身代码也会调用 requestIdleCallback,
+  // 在缺少原生实现的浏览器 (如 Safari) 中需要在 unsafeWindow 上同样补充
+  if (typeof unsafeWindow.requestIdleCallback === 'undefined') {
+    unsafeWindow.requestIdleCallback = (callback: IdleRequestCallback) =>
+      unsafeWindow.setTimeout(() => {
+        const start = performance.now()
+        callback({
+          didTimeout: false,
+          timeRemaining: () => Math.max(0, 50 - (performance.now() - start)),
+        })
+      }, 0)
+    unsafeWindow.cancelIdleCallback = (handle: number) => {
+      unsafeWindow.clearTimeout(handle)
+    }
+  }
 }


### PR DESCRIPTION
## 问题
Safari (27.0 实测) 页面作用域没有原生 `requestIdleCallback` (`typeof` 为 `undefined`)。`compatibility.ts` 现有的 polyfill 只补在脚本沙箱的 `window` 上, 不影响页面作用域, 而 B 站页面自身代码也会调用 `requestIdleCallback`, 在 Safari 中会因此出错, 影响页面正常渲染。

## 改动
在现有 polyfill 之后, 以同样的特性检测方式在 `unsafeWindow` 上补充 (+15 行, 单文件):

- 独立 guard: `typeof unsafeWindow.requestIdleCallback === 'undefined'`, 任何拥有原生实现的环境都不会被覆盖;
- 按规范向回调传入 `IdleDeadline` 参数 (`didTimeout` / `timeRemaining()`), 页面代码若使用该参数不会出错 (沙箱侧现有 polyfill 服务的是本脚本自身代码, 保持原样未动);
- **对 Chrome / Firefox 零影响**: 它们拥有原生实现, guard 判定不成立, 新增代码不会执行, 唯一开销是启动时一次 `typeof` 检查。

## 测试
- `pnpm run type` / `pnpm run lint-check` / `pnpm run check-pr-files` 均通过;
- Safari 27.0 (macOS) 实测: 页面作用域原生 `requestIdleCallback` 确认为 `undefined`; 注入本补丁后调用验证: 回调正常触发、`IdleDeadline` 参数符合规范、`cancelIdleCallback` 可正常取消;
- 含同等补丁的本地构建在 Safari 27 / Tampermonkey 环境日常使用约 10 天, 无异常。