### PR TITLE
[组件-直播间网页全屏自适应] 各种样式修复

### DIFF
--- a/registry/lib/components/live/chat-panel-fit/ChatPanelFitDragger.vue
+++ b/registry/lib/components/live/chat-panel-fit/ChatPanelFitDragger.vue
@@ -91,7 +91,7 @@ const startDragging = (e: PointerEvent) => {
 @import 'common';
 
 // 拖动时暂时提高 z-index, 否则预览区域会被挡住
-html.custom-width-dragging .player-full-win:not(.hide-aside-area) .player-ctnr {
+html.custom-width-dragging .player-full-win:not(.hide-aside-area) .player-and-aside-area {
   z-index: 1001 !important;
   .head-info-section {
     display: none !important;
@@ -102,13 +102,14 @@ html.custom-width-dragging .player-full-win:not(.hide-aside-area) .player-ctnr {
   @include absolute-v-center();
 }
 .chat-panel-fit-dragger {
+  z-index: 1001;
   $dragger-width: 8px;
   pointer-events: none;
   touch-action: none;
-  height: 100%;
+  height: 100vh;
   width: 0;
   position: absolute;
-  right: 0;
+  right: var(--live-chat-panel-width);
   top: 0;
   @include v-stretch();
   .player-full-win:not(.hide-aside-area) & {
@@ -151,7 +152,7 @@ html.custom-width-dragging .player-full-win:not(.hide-aside-area) .player-ctnr {
     }
   }
   &.dragging &-preview-area {
-    opacity: 1;
+    opacity: 0.8;
   }
 }
 </style>

--- a/registry/lib/components/live/chat-panel-fit/ChatPanelFitDragger.vue
+++ b/registry/lib/components/live/chat-panel-fit/ChatPanelFitDragger.vue
@@ -37,7 +37,7 @@ const startPoint = ref(0)
 const movement = ref(0)
 const previewWidth = computed(() => {
   if (options.customWidth) {
-    return options.customWidth + movement.value
+    return Math.round(options.customWidth + movement.value)
   }
   return getAutoWidth()
 })
@@ -52,12 +52,13 @@ const handlePointerMove = (e: PointerEvent) => {
     return
   }
   const currentMovement = startPoint.value - e.screenX
-  movement.value =
+  movement.value = Math.round(
     lodash.clamp(
       options.customWidth + currentMovement,
       ChatPanelFitOptionsMinWidth,
       options.maxWidth,
-    ) - options.customWidth
+    ) - options.customWidth,
+  )
 }
 const startDragging = (e: PointerEvent) => {
   isDragging.value = true
@@ -104,6 +105,7 @@ html.custom-width-dragging .player-full-win:not(.hide-aside-area) .player-and-as
 .chat-panel-fit-dragger {
   z-index: 1001;
   $dragger-width: 8px;
+  user-select: none;
   pointer-events: none;
   touch-action: none;
   height: 100vh;

--- a/registry/lib/components/live/chat-panel-fit/ChatPanelFitDragger.vue
+++ b/registry/lib/components/live/chat-panel-fit/ChatPanelFitDragger.vue
@@ -111,7 +111,7 @@ html.custom-width-dragging .player-full-win:not(.hide-aside-area) .player-and-as
   height: 100vh;
   width: 0;
   position: absolute;
-  right: var(--live-chat-panel-width);
+  left: var(--be-live-player-width);
   top: 0;
   @include v-stretch();
   .player-full-win:not(.hide-aside-area) & {

--- a/registry/lib/components/live/chat-panel-fit/chat-panel-fit.scss
+++ b/registry/lib/components/live/chat-panel-fit/chat-panel-fit.scss
@@ -33,3 +33,54 @@
     }
   }
 }
+
+// 面板错位问题修复
+html:not(.pc-app) body.player-full-win:not(.hide-aside-area) .aside-area {
+  left: auto !important;
+  right: 0 !important;
+}
+
+// 榜单标签居中 / 容器横向滚动
+.gift-rank-cntr .list-cntr {
+  .toolbox .tab-box {
+    overflow-x: auto;
+    overflow-y: hidden;
+    .sub-tab-item {
+      flex: 1;
+      width: 100%;
+      min-width: 65px;
+      .sub-tab-item-bg,
+      .sub-tab-item-text {
+        width: 100%;
+      }
+    }
+    .sub-tab-item:last-child {
+      margin-right: 0;
+    }
+  }
+
+  .list-body {
+    overflow-x: auto;
+    overflow-y: hidden;
+    .list {
+      min-width: 100%;
+      display: inline-block;
+      .gift-rank-list-item .gift-rank-list-item-content {
+        display: grid;
+        grid-template-columns: auto auto 1fr auto;
+      }
+    }
+  }
+}
+
+// 聊天工具栏错位问题修复
+.control-panel-ctnr .control-panel-icon-row {
+  display: flex;
+  overflow-x: auto;
+  overflow-y: hidden;
+  white-space: nowrap;
+  gap: 4px;
+  .icon-right-part {
+    margin-left: auto;
+  }
+}

--- a/registry/lib/components/live/chat-panel-fit/chat-panel-fit.scss
+++ b/registry/lib/components/live/chat-panel-fit/chat-panel-fit.scss
@@ -32,55 +32,79 @@
       }
     }
   }
+
+  // 房间观众榜单栏
+  .gift-rank-cntr {
+    // Top3 榜单用户名宽度自适应
+    .top3-cntr .top3 {
+      .top3-item .right .top3-name {
+        max-width: calc((var(--live-chat-panel-width, 302px) - 112px) / 3) !important;
+      }
+    }
+    // 标签居中 / 容器横向滚动
+    .list-cntr {
+      .toolbox .tab-box {
+        overflow-x: auto;
+        overflow-y: hidden;
+        .sub-tab-item {
+          flex: 1;
+          width: 100%;
+          min-width: 65px;
+          .sub-tab-item-bg,
+          .sub-tab-item-text {
+            width: 100%;
+          }
+        }
+        .sub-tab-item:last-child {
+          margin-right: 0;
+        }
+      }
+      .list-body {
+        overflow-x: auto;
+        overflow-y: hidden;
+        .list {
+          min-width: 100%;
+          display: inline-block;
+          .gift-rank-list-item .gift-rank-list-item-content {
+            display: grid;
+            grid-template-columns: auto auto 1fr auto;
+          }
+        }
+      }
+    }
+  }
+
+  // 大航海榜单栏
+  .guard-rank-cntr .rank-cntr {
+    .rank-list-cntr {
+      // Top3 榜单用户名宽度自适应
+      .rank-list-box .top3-cntr {
+        .item {
+          width: fit-content;
+          .right .uname a {
+            width: auto;
+            max-width: calc((var(--live-chat-panel-width, 302px) - 121px) / 3);
+          }
+        }
+      }
+    }
+  }
+
+  // 聊天工具栏错位问题修复
+  .control-panel-ctnr .control-panel-icon-row {
+    display: flex;
+    overflow-x: auto;
+    overflow-y: hidden;
+    white-space: nowrap;
+    gap: 4px;
+    .icon-right-part {
+      margin-left: auto;
+    }
+  }
 }
 
 // 面板错位问题修复
 html:not(.pc-app) body.player-full-win:not(.hide-aside-area) .aside-area {
   left: auto !important;
   right: 0 !important;
-}
-
-// 榜单标签居中 / 容器横向滚动
-.gift-rank-cntr .list-cntr {
-  .toolbox .tab-box {
-    overflow-x: auto;
-    overflow-y: hidden;
-    .sub-tab-item {
-      flex: 1;
-      width: 100%;
-      min-width: 65px;
-      .sub-tab-item-bg,
-      .sub-tab-item-text {
-        width: 100%;
-      }
-    }
-    .sub-tab-item:last-child {
-      margin-right: 0;
-    }
-  }
-
-  .list-body {
-    overflow-x: auto;
-    overflow-y: hidden;
-    .list {
-      min-width: 100%;
-      display: inline-block;
-      .gift-rank-list-item .gift-rank-list-item-content {
-        display: grid;
-        grid-template-columns: auto auto 1fr auto;
-      }
-    }
-  }
-}
-
-// 聊天工具栏错位问题修复
-.control-panel-ctnr .control-panel-icon-row {
-  display: flex;
-  overflow-x: auto;
-  overflow-y: hidden;
-  white-space: nowrap;
-  gap: 4px;
-  .icon-right-part {
-    margin-left: auto;
-  }
 }

--- a/registry/lib/components/live/chat-panel-fit/chat-panel-fit.scss
+++ b/registry/lib/components/live/chat-panel-fit/chat-panel-fit.scss
@@ -13,6 +13,10 @@
       }
     }
 
+    .app-content {
+      padding-top: 0 !important;
+    }
+
     .aside-area {
       container-name: aside-area;
       container-type: size;

--- a/registry/lib/components/live/chat-panel-fit/chat-panel-fit.scss
+++ b/registry/lib/components/live/chat-panel-fit/chat-panel-fit.scss
@@ -1,218 +1,220 @@
 .player-full-win:not(.hide-aside-area) {
   .live-room-app {
+    #fullscreen-container {
+      --live-player-width: calc(100vw - var(--live-chat-panel-width, 302px));
+      width: var(--live-player-width) !important;
+      min-width: var(--live-player-width) !important;
+      .player-section {
+        width: var(--live-player-width) !important;
+      }
+    }
+
     .aside-area {
       container-name: aside-area;
       container-type: size;
       width: var(--live-chat-panel-width, 302px) !important;
-    }
-    #fullscreen-container,
-    .player-section {
-      width: calc(100% - var(--live-chat-panel-width, 302px)) !important;
-    }
-    /* @container aside-area (max-width: 290px) {
-      .control-panel-icon-row-new .icon-left-part-new {
-        .super-chat,
-        .like-btn {
-          width: 32px;
-          &-icon {
-            margin-right: 0 !important;
+      --live-chat-panel-scale: calc(var(--live-chat-panel-width) / 300px);
+      .rank-list-section .rank-list-ctnr .tab-content {
+        // 房间观众榜单栏
+        .gift-rank-cntr {
+          // Top3 榜单用户名宽度自适应
+          .top3-cntr .top3 {
+            --be-count-top3-gift: 3;
+            &:has(> .top3-item:only-child) {
+              --be-count-top3-gift: 1;
+            }
+            &:has(> .top3-item:first-child:nth-last-child(2)) {
+              --be-count-top3-gift: 2;
+            }
+            .top3-item .right .top3-name {
+              max-width: calc(
+                (var(--live-chat-panel-width, 300px) - 120px) / var(--be-count-top3-gift)
+              ) !important;
+            }
           }
-          &-text {
+          // 标签居中 / 容器横向滚动
+          .list-cntr {
+            .toolbox {
+              .tab-box {
+                overflow-x: auto;
+                overflow-y: hidden;
+                .sub-tab-item {
+                  flex: 1;
+                  width: 100%;
+                  min-width: 65px;
+                  .sub-tab-item-bg,
+                  .sub-tab-item-text {
+                    width: 100%;
+                  }
+                }
+                .sub-tab-item:last-child {
+                  margin-right: 0;
+                }
+              }
+              // 宽度不足时隐藏提示文字
+              .switch-box {
+                container-type: inline-size;
+                gap: 10px;
+                @container (max-width: 260px) {
+                  justify-content: flex-end;
+                  > :first-child {
+                    display: none;
+                  }
+                }
+              }
+            }
+            .list-body {
+              overflow-x: auto;
+              overflow-y: hidden;
+              .list {
+                min-width: 100%;
+                display: inline-block;
+                .gift-rank-list-item .gift-rank-list-item-content {
+                  display: grid;
+                  grid-template-columns: auto auto 1fr auto;
+                }
+              }
+            }
+            // “我的”栏
+            .list-mine {
+              overflow-x: auto;
+              overflow-y: hidden;
+              .ranking {
+                > * {
+                  flex-shrink: 0;
+                }
+              }
+            }
+          }
+        }
+
+        // 大航海榜单栏
+        .guard-rank-cntr .rank-cntr {
+          // 宽度不足时隐藏提示文字
+          .select-virtual {
+            container-type: inline-size;
+            gap: 10px;
+            @container (max-width: 260px) {
+              justify-content: flex-end;
+              .title {
+                font-size: 0;
+                .tip-icon {
+                  font-size: 12px;
+                }
+              }
+            }
+          }
+          .rank-list-cntr {
+            // Top3 榜单用户名宽度自适应
+            .rank-list-box {
+              .top3-cntr {
+                --be-count-top3-guard: 3;
+                &:has(> .item:only-child) {
+                  --be-count-top3-guard: 1;
+                }
+                &:has(> .item:first-child:nth-last-child(2)) {
+                  --be-count-top3-guard: 2;
+                }
+                .item {
+                  width: fit-content;
+                  .right .uname > a {
+                    width: auto;
+                    max-width: calc(
+                      (var(--live-chat-panel-width, 300px) - 130px) / var(--be-count-top3-guard)
+                    );
+                  }
+                }
+              }
+              // 容器横向滚动
+              .list {
+                overflow-x: auto;
+                overflow-y: auto;
+                webcomponent-userinfo {
+                  min-width: max(100%, 260px);
+                  display: flex;
+                }
+              }
+            }
+          }
+          // “我的”栏
+          .btn-box {
+            overflow-x: auto;
+            overflow-y: hidden;
+            .guard-daily-record {
+              gap: 10px;
+              > * {
+                flex-shrink: 0;
+              }
+            }
+          }
+        }
+      }
+    }
+
+    // SC 定制按钮宽度
+    .border-box.superChat .bespoke {
+      width: 270px;
+    }
+
+    @container aside-area (max-width: 300px) {
+      .chat-history-panel {
+        // SC / 礼物 / 进场广播栏
+        .chat-overlay-layer {
+          transform-origin: left top;
+          min-width: 300px;
+          scale: var(--live-chat-panel-scale);
+        }
+      }
+
+      // 聊天 / 工具栏
+      .chat-control-panel .control-panel-ctnr {
+        // 工具栏错位问题修复
+        .control-panel-icon-row:has(.super-chat.has-ship) {
+          container-type: inline-size;
+          @container (max-width: 242px) {
+            display: flex;
+            white-space: nowrap;
+            overflow-x: auto;
+            overflow-y: hidden;
+            gap: 4px;
+          }
+        }
+        // 工具栏弹窗缩小
+        .border-box.top-left {
+          transform-origin: left bottom !important;
+          scale: var(--live-chat-panel-scale);
+        }
+        .border-box.top-right {
+          transform-origin: right bottom !important;
+          scale: var(--live-chat-panel-scale);
+        }
+        .border-box.superChat {
+          height: calc(563px * var(--live-chat-panel-scale));
+          .superchat-content {
+            display: grid;
+            justify-content: center;
+            .home-page {
+              transform-origin: center top !important;
+              scale: var(--live-chat-panel-scale);
+              .header > * {
+                flex-shrink: 0;
+                white-space: nowrap;
+              }
+            }
+          }
+        }
+        // 聊天栏
+        .chat-input-ctnr {
+          .medal-section {
             display: none !important;
           }
         }
       }
-      .chat-input-ctnr-new {
-        .medal-section {
-          display: none !important;
-        }
-        .chat-input-new:not(:has(textarea.focus)) {
-          padding-left: 12px !important;
-        }
-      }
-    } */
-  }
-
-  // 房间观众榜单栏
-  .gift-rank-cntr {
-    // Top3 榜单用户名宽度自适应
-    .top3-cntr .top3 {
-      --be-count-top3-gift: 3;
-      &:has(> .top3-item:only-child) {
-        --be-count-top3-gift: 1;
-      }
-      &:has(> .top3-item:first-child:nth-last-child(2)) {
-        --be-count-top3-gift: 2;
-      }
-      .top3-item .right .top3-name {
-        max-width: calc(
-          (var(--live-chat-panel-width, 300px) - 120px) / var(--be-count-top3-gift)
-        ) !important;
-      }
-    }
-    // 标签居中 / 容器横向滚动
-    .list-cntr {
-      .toolbox {
-        .tab-box {
-          overflow-x: auto;
-          overflow-y: hidden;
-          .sub-tab-item {
-            flex: 1;
-            width: 100%;
-            min-width: 65px;
-            .sub-tab-item-bg,
-            .sub-tab-item-text {
-              width: 100%;
-            }
-          }
-          .sub-tab-item:last-child {
-            margin-right: 0;
-          }
-        }
-        // 宽度不足时隐藏提示文字
-        .switch-box {
-          container-type: inline-size;
-          gap: 10px;
-          @container (max-width: 260px) {
-            justify-content: flex-end;
-            > :first-child {
-              display: none;
-            }
-          }
-        }
-      }
-      .list-body {
-        overflow-x: auto;
-        overflow-y: hidden;
-        .list {
-          min-width: 100%;
-          display: inline-block;
-          .gift-rank-list-item .gift-rank-list-item-content {
-            display: grid;
-            grid-template-columns: auto auto 1fr auto;
-          }
-        }
-      }
-      // “我的”栏
-      .list-mine {
-        overflow-x: auto;
-        overflow-y: hidden;
-        .ranking {
-          > * {
-            flex-shrink: 0;
-          }
-        }
-      }
-    }
-  }
-
-  // 大航海榜单栏
-  .guard-rank-cntr .rank-cntr {
-    // 宽度不足时隐藏提示文字
-    .select-virtual {
-      container-type: inline-size;
-      gap: 10px;
-      @container (max-width: 260px) {
-        justify-content: flex-end;
-        .title {
-          font-size: 0;
-          .tip-icon {
-            font-size: 12px;
-          }
-        }
-      }
-    }
-    .rank-list-cntr {
-      // Top3 榜单用户名宽度自适应
-      .rank-list-box {
-        .top3-cntr {
-          --be-count-top3-guard: 3;
-          &:has(> .item:only-child) {
-            --be-count-top3-guard: 1;
-          }
-          &:has(> .item:first-child:nth-last-child(2)) {
-            --be-count-top3-guard: 2;
-          }
-          .item {
-            width: fit-content;
-            .right .uname > a {
-              width: auto;
-              max-width: calc(
-                (var(--live-chat-panel-width, 300px) - 130px) / var(--be-count-top3-guard)
-              );
-            }
-          }
-        }
-        // 容器横向滚动
-        .list {
-          overflow-x: auto;
-          overflow-y: auto;
-          webcomponent-userinfo {
-            min-width: max(100%, 260px);
-            display: flex;
-          }
-        }
-      }
-    }
-    // “我的”栏
-    .btn-box {
-      overflow-x: auto;
-      overflow-y: hidden;
-      .guard-daily-record {
-        gap: 10px;
-        > * {
-          flex-shrink: 0;
-        }
-      }
-    }
-  }
-
-  // 聊天工具栏
-  .control-panel-ctnr {
-    // 聊天工具栏错位问题修复
-    .control-panel-icon-row:has(.super-chat.has-ship) {
-      container-type: inline-size;
-      @container (max-width: 242px) {
-        display: flex;
-        white-space: nowrap;
-        overflow-x: auto;
-        overflow-y: hidden;
-        gap: 4px;
-      }
-    }
-    // 限制聊天工具栏弹窗大小
-    @container (max-width: 300px) {
-      .border-box.top-left {
-        transform-origin: left bottom !important;
-        scale: calc(var(--live-chat-panel-width) / 300px);
-      }
-      .border-box.top-right {
-        transform-origin: right bottom !important;
-        scale: calc(var(--live-chat-panel-width) / 300px);
-      }
-      .border-box.superChat {
-        height: calc(563px * var(--live-chat-panel-width) / 300px);
-        .superchat-content {
-          display: grid;
-          justify-content: center;
-          .home-page {
-            transform-origin: center top !important;
-            scale: calc(var(--live-chat-panel-width) / 300px);
-            .header > * {
-              flex-shrink: 0;
-              white-space: nowrap;
-            }
-          }
-        }
-      }
-    }
-    .border-box.superChat .bespoke {
-      width: 270px;
     }
   }
 }
 
-// SC 主页关闭按钮
+// SC 发送页关闭按钮
 #chat-control-panel-vm .close-btn[class] {
   padding-right: 0 !important;
 }

--- a/registry/lib/components/live/chat-panel-fit/chat-panel-fit.scss
+++ b/registry/lib/components/live/chat-panel-fit/chat-panel-fit.scss
@@ -9,7 +9,7 @@
     .player-section {
       width: calc(100% - var(--live-chat-panel-width, 302px)) !important;
     }
-    @container aside-area (max-width: 290px) {
+    /* @container aside-area (max-width: 290px) {
       .control-panel-icon-row-new .icon-left-part-new {
         .super-chat,
         .like-btn {
@@ -30,7 +30,7 @@
           padding-left: 12px !important;
         }
       }
-    }
+    } */
   }
 
   // 房间观众榜单栏
@@ -46,7 +46,7 @@
       }
       .top3-item .right .top3-name {
         max-width: calc(
-          (var(--live-chat-panel-width, 300px) - 120x) / var(--be-count-top3-gift)
+          (var(--live-chat-panel-width, 300px) - 120px) / var(--be-count-top3-gift)
         ) !important;
       }
     }
@@ -167,6 +167,7 @@
     }
   }
 
+  // 聊天工具栏
   .control-panel-ctnr {
     // 聊天工具栏错位问题修复
     .control-panel-icon-row:has(.super-chat.has-ship) {
@@ -179,7 +180,41 @@
         gap: 4px;
       }
     }
+    // 限制聊天工具栏弹窗大小
+    @container (max-width: 300px) {
+      .border-box.top-left {
+        transform-origin: left bottom !important;
+        scale: calc(var(--live-chat-panel-width) / 300px);
+      }
+      .border-box.top-right {
+        transform-origin: right bottom !important;
+        scale: calc(var(--live-chat-panel-width) / 300px);
+      }
+      .border-box.superChat {
+        height: calc(563px * var(--live-chat-panel-width) / 300px);
+        .superchat-content {
+          display: grid;
+          justify-content: center;
+          .home-page {
+            transform-origin: center top !important;
+            scale: calc(var(--live-chat-panel-width) / 300px);
+            .header > * {
+              flex-shrink: 0;
+              white-space: nowrap;
+            }
+          }
+        }
+      }
+    }
+    .border-box.superChat .bespoke {
+      width: 270px;
+    }
   }
+}
+
+// SC 主页关闭按钮
+#chat-control-panel-vm .close-btn[class] {
+  padding-right: 0 !important;
 }
 
 // 面板错位问题修复

--- a/registry/lib/components/live/chat-panel-fit/chat-panel-fit.scss
+++ b/registry/lib/components/live/chat-panel-fit/chat-panel-fit.scss
@@ -37,8 +37,17 @@
   .gift-rank-cntr {
     // Top3 榜单用户名宽度自适应
     .top3-cntr .top3 {
+      --be-count-top3-gift: 3;
+      &:has(> .top3-item:only-child) {
+        --be-count-top3-gift: 1;
+      }
+      &:has(> .top3-item:first-child:nth-last-child(2)) {
+        --be-count-top3-gift: 2;
+      }
       .top3-item .right .top3-name {
-        max-width: calc((var(--live-chat-panel-width, 300px) - 112px) / 3) !important;
+        max-width: calc(
+          (var(--live-chat-panel-width, 300px) - 120x) / var(--be-count-top3-gift)
+        ) !important;
       }
     }
     // 标签居中 / 容器横向滚动
@@ -117,11 +126,20 @@
       // Top3 榜单用户名宽度自适应
       .rank-list-box {
         .top3-cntr {
+          --be-count-top3-guard: 3;
+          &:has(> .item:only-child) {
+            --be-count-top3-guard: 1;
+          }
+          &:has(> .item:first-child:nth-last-child(2)) {
+            --be-count-top3-guard: 2;
+          }
           .item {
             width: fit-content;
-            .right .uname a {
+            .right .uname > a {
               width: auto;
-              max-width: calc((var(--live-chat-panel-width, 300px) - 121px) / 3);
+              max-width: calc(
+                (var(--live-chat-panel-width, 300px) - 130px) / var(--be-count-top3-guard)
+              );
             }
           }
         }

--- a/registry/lib/components/live/chat-panel-fit/chat-panel-fit.scss
+++ b/registry/lib/components/live/chat-panel-fit/chat-panel-fit.scss
@@ -1,19 +1,23 @@
+:root {
+  --be-live-chat-panel-width: var(--live-chat-panel-width, 300px);
+  --be-live-player-width: calc(100vw - var(--be-live-chat-panel-width));
+}
+
 .player-full-win:not(.hide-aside-area) {
   .live-room-app {
     #fullscreen-container {
-      --live-player-width: calc(100vw - var(--live-chat-panel-width, 302px));
-      width: var(--live-player-width) !important;
-      min-width: var(--live-player-width) !important;
+      width: var(--be-live-player-width) !important;
+      min-width: var(--be-live-player-width) !important;
       .player-section {
-        width: var(--live-player-width) !important;
+        width: var(--be-live-player-width) !important;
       }
     }
 
     .aside-area {
       container-name: aside-area;
       container-type: size;
-      width: var(--live-chat-panel-width, 302px) !important;
-      --live-chat-panel-scale: calc(var(--live-chat-panel-width) / 300px);
+      width: var(--be-live-chat-panel-width) !important;
+      --live-chat-panel-scale: calc(var(--be-live-chat-panel-width) / 300px);
       .rank-list-section .rank-list-ctnr .tab-content {
         // 房间观众榜单栏
         .gift-rank-cntr {
@@ -28,7 +32,7 @@
             }
             .top3-item .right .top3-name {
               max-width: calc(
-                (var(--live-chat-panel-width, 300px) - 120px) / var(--be-count-top3-gift)
+                (var(--be-live-chat-panel-width) - 120px) / var(--be-count-top3-gift)
               ) !important;
             }
           }
@@ -120,7 +124,7 @@
                   .right .uname > a {
                     width: auto;
                     max-width: calc(
-                      (var(--live-chat-panel-width, 300px) - 130px) / var(--be-count-top3-guard)
+                      (var(--be-live-chat-panel-width) - 130px) / var(--be-count-top3-guard)
                     );
                   }
                 }

--- a/registry/lib/components/live/chat-panel-fit/chat-panel-fit.scss
+++ b/registry/lib/components/live/chat-panel-fit/chat-panel-fit.scss
@@ -169,7 +169,7 @@
 
   .control-panel-ctnr {
     // 聊天工具栏错位问题修复
-    .control-panel-icon-row {
+    .control-panel-icon-row:has(.super-chat.has-ship) {
       container-type: inline-size;
       @container (max-width: 242px) {
         display: flex;

--- a/registry/lib/components/live/chat-panel-fit/chat-panel-fit.scss
+++ b/registry/lib/components/live/chat-panel-fit/chat-panel-fit.scss
@@ -38,25 +38,38 @@
     // Top3 榜单用户名宽度自适应
     .top3-cntr .top3 {
       .top3-item .right .top3-name {
-        max-width: calc((var(--live-chat-panel-width, 302px) - 112px) / 3) !important;
+        max-width: calc((var(--live-chat-panel-width, 300px) - 112px) / 3) !important;
       }
     }
     // 标签居中 / 容器横向滚动
     .list-cntr {
-      .toolbox .tab-box {
-        overflow-x: auto;
-        overflow-y: hidden;
-        .sub-tab-item {
-          flex: 1;
-          width: 100%;
-          min-width: 65px;
-          .sub-tab-item-bg,
-          .sub-tab-item-text {
+      .toolbox {
+        .tab-box {
+          overflow-x: auto;
+          overflow-y: hidden;
+          .sub-tab-item {
+            flex: 1;
             width: 100%;
+            min-width: 65px;
+            .sub-tab-item-bg,
+            .sub-tab-item-text {
+              width: 100%;
+            }
+          }
+          .sub-tab-item:last-child {
+            margin-right: 0;
           }
         }
-        .sub-tab-item:last-child {
-          margin-right: 0;
+        // 宽度不足时隐藏提示文字
+        .switch-box {
+          container-type: inline-size;
+          gap: 10px;
+          @container (max-width: 260px) {
+            justify-content: flex-end;
+            > :first-child {
+              display: none;
+            }
+          }
         }
       }
       .list-body {
@@ -71,34 +84,82 @@
           }
         }
       }
-    }
-  }
-
-  // 大航海榜单栏
-  .guard-rank-cntr .rank-cntr {
-    .rank-list-cntr {
-      // Top3 榜单用户名宽度自适应
-      .rank-list-box .top3-cntr {
-        .item {
-          width: fit-content;
-          .right .uname a {
-            width: auto;
-            max-width: calc((var(--live-chat-panel-width, 302px) - 121px) / 3);
+      // “我的”栏
+      .list-mine {
+        overflow-x: auto;
+        overflow-y: hidden;
+        .ranking {
+          > * {
+            flex-shrink: 0;
           }
         }
       }
     }
   }
 
-  // 聊天工具栏错位问题修复
-  .control-panel-ctnr .control-panel-icon-row {
-    display: flex;
-    overflow-x: auto;
-    overflow-y: hidden;
-    white-space: nowrap;
-    gap: 4px;
-    .icon-right-part {
-      margin-left: auto;
+  // 大航海榜单栏
+  .guard-rank-cntr .rank-cntr {
+    // 宽度不足时隐藏提示文字
+    .select-virtual {
+      container-type: inline-size;
+      gap: 10px;
+      @container (max-width: 260px) {
+        justify-content: flex-end;
+        .title {
+          font-size: 0;
+          .tip-icon {
+            font-size: 12px;
+          }
+        }
+      }
+    }
+    .rank-list-cntr {
+      // Top3 榜单用户名宽度自适应
+      .rank-list-box {
+        .top3-cntr {
+          .item {
+            width: fit-content;
+            .right .uname a {
+              width: auto;
+              max-width: calc((var(--live-chat-panel-width, 300px) - 121px) / 3);
+            }
+          }
+        }
+        // 容器横向滚动
+        .list {
+          overflow-x: auto;
+          overflow-y: auto;
+          webcomponent-userinfo {
+            min-width: max(100%, 260px);
+            display: flex;
+          }
+        }
+      }
+    }
+    // “我的”栏
+    .btn-box {
+      overflow-x: auto;
+      overflow-y: hidden;
+      .guard-daily-record {
+        gap: 10px;
+        > * {
+          flex-shrink: 0;
+        }
+      }
+    }
+  }
+
+  .control-panel-ctnr {
+    // 聊天工具栏错位问题修复
+    .control-panel-icon-row {
+      container-type: inline-size;
+      @container (max-width: 242px) {
+        display: flex;
+        white-space: nowrap;
+        overflow-x: auto;
+        overflow-y: hidden;
+        gap: 4px;
+      }
     }
   }
 }

--- a/registry/lib/components/live/chat-panel-fit/chat-panel-fit.scss
+++ b/registry/lib/components/live/chat-panel-fit/chat-panel-fit.scss
@@ -156,7 +156,7 @@
       width: 270px;
     }
 
-    @container aside-area (max-width: 300px) {
+    @container aside-area (max-width: 299px) {
       .chat-history-panel {
         // SC / 礼物 / 进场广播栏
         .chat-overlay-layer {

--- a/registry/lib/components/live/chat-panel-fit/chat-panel-fit.scss
+++ b/registry/lib/components/live/chat-panel-fit/chat-panel-fit.scss
@@ -166,11 +166,11 @@
 
     @container aside-area (max-width: 299px) {
       // SC 气泡
-      /*.msg-bubble-setting {
+      .msg-bubble-setting {
         transform-origin: left top;
-        // min-width: 300px;
         scale: var(--live-chat-panel-scale);
-      }*/
+        left: calc(344px * var(--live-chat-panel-scale)) !important;
+      }
 
       // PK 投票栏
       .pk-multiplier-card-root {

--- a/registry/lib/components/live/chat-panel-fit/chat-panel-fit.scss
+++ b/registry/lib/components/live/chat-panel-fit/chat-panel-fit.scss
@@ -165,8 +165,22 @@
     }
 
     @container aside-area (max-width: 299px) {
+      // SC 气泡
+      /*.msg-bubble-setting {
+        transform-origin: left top;
+        // min-width: 300px;
+        scale: var(--live-chat-panel-scale);
+      }*/
+
+      // PK 投票栏
+      .pk-multiplier-card-root {
+        scale: var(--live-chat-panel-scale);
+        min-width: 300px;
+        transform-origin: left bottom;
+      }
+
       .chat-history-panel {
-        // SC / 礼物 / 进场广播栏
+        // SC 列表 / 礼物气泡 / 进场广播
         .chat-overlay-layer {
           transform-origin: left top;
           min-width: 300px;
@@ -213,6 +227,7 @@
         }
         // 聊天栏
         .chat-input-ctnr {
+          // 隐藏粉丝勋章
           .medal-section {
             display: none !important;
           }

--- a/registry/lib/components/live/chat-panel-fit/index.ts
+++ b/registry/lib/components/live/chat-panel-fit/index.ts
@@ -44,7 +44,7 @@ const load = async () => {
   window.addEventListener('customWidthReset', calcPanelWidth)
   window.addEventListener('resize', debounceCalcPanelWidth)
   const video = await sq(
-    () => dq('.live-player-ctnr video') as HTMLVideoElement,
+    () => dq('.player-ctnr video') as HTMLVideoElement,
     v => v !== null && v.readyState !== HTMLMediaElement.HAVE_NOTHING,
   )
   if (!video) {
@@ -53,14 +53,14 @@ const load = async () => {
   }
   calcPanelWidth()
 
-  const asideToggleButton = (await select('.aside-area-toggle-btn')) as HTMLElement
-  if (!asideToggleButton) {
-    console.log('未找到侧边栏按钮')
+  const aside = (await select('.aside-area')) as HTMLElement
+  if (!aside) {
+    console.log('未找到侧边栏')
     return
   }
   const { default: ChatPanelFitDragger } = await import('./ChatPanelFitDragger.vue')
   draggerInstance = mountVueComponent(ChatPanelFitDragger)
-  asideToggleButton.insertAdjacentElement('afterend', draggerInstance.$el)
+  aside.insertAdjacentElement('afterend', draggerInstance.$el)
 }
 const unload = () => {
   removeComponentListener(`${name}.targetRatio`, calcPanelWidth)


### PR DESCRIPTION
1. 面板错位问题修复 #5663
修复当面板宽度很大时，播放器宽度没有适配的问题
将拖动组件挂载到 player-ctnr 下，使预览区域能够完整显示，并为预览区域设置了透明度

2. 榜单标签居中，宽度不足时榜单标签 / 榜单列表 / “我的”栏可横向滚动
> <img width="735" height="432" alt="image" src="https://github.com/user-attachments/assets/df712091-9443-42ef-abc2-bdc694f06a68" /><img width="186" height="435" alt="image" src="https://github.com/user-attachments/assets/8458dcd6-cc64-4e96-ad4c-153c75af4b1e" /><img width="193" height="396" alt="image" src="https://github.com/user-attachments/assets/87f3058f-bbb4-43d8-b139-3edae9d41116" />

3. Top3 榜单栏用户昵称宽度自适应，宽度充足时可以完整显示用户昵称；宽度不足时省略用户昵称，防止溢出

4. 宽度不足时，隐藏榜单栏隐藏提示文字，防止排版错乱
> <img width="191" height="59" alt="image" src="https://github.com/user-attachments/assets/292a9b73-5d38-4dec-a075-011839a2d217" /><img width="179" height="138" alt="image" src="https://github.com/user-attachments/assets/4f6fe0d7-883c-4f07-bc2a-a8b47c619e54" />

5. 宽度不足时，SC 列表 / SC 气泡 / 礼物气泡 / 进场广播等比缩小

6. 宽度不足时，PK 投票栏等比缩小

7. 宽度不足时，聊天工具栏按钮可横向滚动
> <img width="187" height="53" alt="image" src="https://github.com/user-attachments/assets/91f4d718-9f79-4f1b-b917-3941d4836bf1" />

8. 宽度不足时，聊天工具栏弹窗等比缩小，移除聊天栏粉丝勋章