### PR TITLE
修改自定义顶栏生效范围，排除toy和轻剪辑

### DIFF
--- a/registry/lib/components/style/custom-navbar/urls.ts
+++ b/registry/lib/components/style/custom-navbar/urls.ts
@@ -25,5 +25,6 @@ export const urlExclude = [
   '//game.bilibili.com/',
   '//www.bilibili.com/mooc/',
   '//www.bilibili.com/bubble/publish',
-  '//www.bilibili.com/toy/toystore/index.html',
+  '//www.bilibili.com/toy/',
+  '//member.bilibili.com/editor/',
 ]


### PR DESCRIPTION
1. 修正 https://github.com/the1812/Bilibili-Evolved/commit/1484c7944b67b86b2ba4c03b32fed4dbbec909e7 并未能覆盖目前所有的toy的页面，是的，所有toy都应该关闭自定义顶栏
2. 排除 [轻剪辑体验版](https://member.bilibili.com/editor/)

===

备注，未经本地测试，但应该没有测的必要吧