### PR TITLE
[新增组件] 番剧动态稍后再看按钮

### DIFF
--- a/registry/lib/components/feeds/pgc-watchlater/WatchlaterButton.vue
+++ b/registry/lib/components/feeds/pgc-watchlater/WatchlaterButton.vue
@@ -47,7 +47,7 @@ export default {
         const vueData = getVue2Data(feedCard)
         const modules = lodash.get(vueData, 'data.modules')
         const dynamicModule = Array.isArray(modules)
-          ? modules.find(it => it.module_content)?.module_content
+          ? modules.find(it => it.module_type === 'MODULE_TYPE_CONTENT')?.module_content
           : modules?.module_dynamic
         const pgc = dynamicModule?.major?.pgc
         const epid = Number(pgc?.epid ?? 0)
@@ -56,9 +56,8 @@ export default {
           return null
         }
 
-        const bangumi = epid
-          ? await BangumiInfo.byEpisodeId(epid).fetchInfo()
-          : await BangumiInfo.bySeasonId(seasonId).fetchInfo()
+        const fetchBangumi = epid ? BangumiInfo.byEpisodeId(epid) : BangumiInfo.bySeasonId(seasonId)
+        const bangumi = await fetchBangumi.fetchInfo()
         return bangumi.episode?.aid ?? bangumi.episodes?.[0]?.aid ?? null
       } catch (e) {
         console.error('获取番剧 aid 失败:', e)

--- a/registry/lib/components/feeds/pgc-watchlater/WatchlaterButton.vue
+++ b/registry/lib/components/feeds/pgc-watchlater/WatchlaterButton.vue
@@ -44,21 +44,15 @@ export default {
           return null
         }
 
-        const vueData = getVue2Data(feedCard)
-        const modules = lodash.get(vueData, 'data.modules')
-        const dynamicModule = Array.isArray(modules)
-          ? modules.find(it => it.module_type === 'MODULE_TYPE_CONTENT')?.module_content
-          : modules?.module_dynamic
-        const pgc = dynamicModule?.major?.pgc
-        const epid = Number(pgc?.epid ?? 0)
-        const seasonId = Number(pgc?.season_id ?? 0)
-        if (!epid && !seasonId) {
+        const modules = lodash.get(getVue2Data(feedCard), 'data.modules')
+        const dynamicModule = modules?.module_dynamic
+        const epid = Number(dynamicModule?.major?.pgc?.epid ?? null)
+        if (!epid) {
           return null
         }
 
-        const fetchBangumi = epid ? BangumiInfo.byEpisodeId(epid) : BangumiInfo.bySeasonId(seasonId)
-        const bangumi = await fetchBangumi.fetchInfo()
-        return bangumi.episode?.aid ?? bangumi.episodes?.[0]?.aid ?? null
+        const bangumi = await BangumiInfo.byEpisodeId(epid).fetchInfo()
+        return bangumi.episode?.aid ?? null
       } catch (e) {
         console.error('获取番剧 aid 失败:', e)
         return null

--- a/registry/lib/components/feeds/pgc-watchlater/WatchlaterButton.vue
+++ b/registry/lib/components/feeds/pgc-watchlater/WatchlaterButton.vue
@@ -1,0 +1,123 @@
+<template>
+  <div
+    class="bili-dyn-card-pgc__mark bili-dyn-card-video__mark"
+    :class="{ active: isActive }"
+    @click.prevent.stop="handleClick"
+    @mouseleave="handleMouseLeave"
+  >
+    <div class="bili-dyn-card-pgc__mark__tip bili-dyn-card-video__mark__tip">
+      {{ tipText }}
+    </div>
+  </div>
+</template>
+
+<script>
+import { watchlaterList, toggleWatchlater } from '@/components/video/watchlater'
+
+export default {
+  data() {
+    return {
+      aid: null,
+      watchlaterList,
+      isActive: false,
+      isLoading: false,
+      feedback: '',
+    }
+  },
+
+  computed: {
+    tipText() {
+      if (this.feedback) {
+        return this.feedback
+      }
+      return this.isActive ? '移除' : '稍后再看'
+    },
+  },
+
+  methods: {
+    async getAidFromCard() {
+      try {
+        const link = this.$el.closest('a.bili-dyn-card-pgc')
+        if (!link || !link.href) {
+          return null
+        }
+
+        const response = await fetch(link.href, {
+          credentials: 'include',
+        })
+        if (!response.ok) {
+          return null
+        }
+
+        const html = await response.text()
+        const doc = new DOMParser().parseFromString(html, 'text/html')
+        const scripts = Array.from(doc.querySelectorAll('script'))
+
+        for (const script of scripts) {
+          const text = script.textContent || ''
+          const match = text.match(/"aid"\s*:\s*(\d+)/)
+          if (match) {
+            return Number(match[1])
+          }
+        }
+        return null
+      } catch (e) {
+        console.error('获取番剧 aid 失败:', e)
+        return null
+      }
+    },
+
+    async handleClick() {
+      if (this.isLoading) {
+        return
+      }
+      this.isLoading = true
+
+      try {
+        if (!this.aid) {
+          this.aid = await this.getAidFromCard()
+        }
+
+        await toggleWatchlater(this.aid, !this.isActive)
+        if (this.isActive === this.watchlaterList.includes(this.aid)) {
+          return
+        }
+
+        this.isActive = !this.isActive
+        this.feedback = this.isActive ? '已加稍后再看' : '已从稍后再看列表中移除'
+      } finally {
+        this.isLoading = false
+      }
+    },
+
+    handleMouseLeave() {
+      this.feedback = ''
+    },
+  },
+}
+</script>
+
+<style lang="scss">
+.bili-dyn-card-pgc__header {
+  .bili-dyn-card-pgc__mark {
+    opacity: 0;
+    transition: opacity 0.2s cubic-bezier(0.22, 0.58, 0.12, 0.98);
+    top: 31px !important;
+    .bili-dyn-card-pgc__mark__tip {
+      display: none !important;
+      pointer-events: none;
+    }
+  }
+  &:hover .bili-dyn-card-pgc__mark {
+    opacity: 1;
+    &:hover {
+      .bili-dyn-card-pgc__mark__tip {
+        display: block !important;
+      }
+    }
+  }
+}
+.bili-dyn-card-pgc__tag {
+  z-index: 1;
+}
+</style>

--- a/registry/lib/components/feeds/pgc-watchlater/WatchlaterButton.vue
+++ b/registry/lib/components/feeds/pgc-watchlater/WatchlaterButton.vue
@@ -13,6 +13,8 @@
 
 <script>
 import { watchlaterList, toggleWatchlater } from '@/components/video/watchlater'
+import { BangumiInfo } from '@/components/video/video-info'
+import { getVue2Data } from '@/core/utils'
 
 export default {
   data() {
@@ -37,30 +39,27 @@ export default {
   methods: {
     async getAidFromCard() {
       try {
-        const link = this.$el.closest('a.bili-dyn-card-pgc')
-        if (!link || !link.href) {
+        const feedCard = this.$el.closest('.bili-dyn-list__item, .bili-dyn-item')
+        if (!feedCard) {
           return null
         }
 
-        const response = await fetch(link.href, {
-          credentials: 'include',
-        })
-        if (!response.ok) {
+        const vueData = getVue2Data(feedCard)
+        const modules = lodash.get(vueData, 'data.modules')
+        const dynamicModule = Array.isArray(modules)
+          ? modules.find(it => it.module_content)?.module_content
+          : modules?.module_dynamic
+        const pgc = dynamicModule?.major?.pgc
+        const epid = Number(pgc?.epid ?? 0)
+        const seasonId = Number(pgc?.season_id ?? 0)
+        if (!epid && !seasonId) {
           return null
         }
 
-        const html = await response.text()
-        const doc = new DOMParser().parseFromString(html, 'text/html')
-        const scripts = Array.from(doc.querySelectorAll('script'))
-
-        for (const script of scripts) {
-          const text = script.textContent || ''
-          const match = text.match(/"aid"\s*:\s*(\d+)/)
-          if (match) {
-            return Number(match[1])
-          }
-        }
-        return null
+        const bangumi = epid
+          ? await BangumiInfo.byEpisodeId(epid).fetchInfo()
+          : await BangumiInfo.bySeasonId(seasonId).fetchInfo()
+        return bangumi.episode?.aid ?? bangumi.episodes?.[0]?.aid ?? null
       } catch (e) {
         console.error('获取番剧 aid 失败:', e)
         return null
@@ -76,6 +75,9 @@ export default {
       try {
         if (!this.aid) {
           this.aid = await this.getAidFromCard()
+        }
+        if (!this.aid) {
+          return
         }
 
         await toggleWatchlater(this.aid, !this.isActive)

--- a/registry/lib/components/feeds/pgc-watchlater/index.md
+++ b/registry/lib/components/feeds/pgc-watchlater/index.md
@@ -1,0 +1,10 @@
+为动态页的番剧卡片添加 `稍后再看` 按钮
+
+### 致谢
+
+基于 `[组件-视频快照]` 修改。
+
+原作者
+
+- [WakelessSloth56](https://github.com/WakelessSloth56)
+- [LainIO24](https://github.com/LainIO24)

--- a/registry/lib/components/feeds/pgc-watchlater/index.ts
+++ b/registry/lib/components/feeds/pgc-watchlater/index.ts
@@ -30,15 +30,13 @@ const entry = async () => {
   })
 }
 
-const author = {
-  name: 'WhiteTeal55',
-  link: 'https://github.com/WhiteTeal55',
-}
-
 export const component = defineComponentMetadata({
   name: 'pgcWatchlater',
   displayName: '番剧动态稍后再看按钮',
-  author,
+  author: {
+    name: 'WhiteTeal55',
+    link: 'https://github.com/WhiteTeal55',
+  },
   tags: [componentsTags.feeds, componentsTags.utils],
   entry,
   urlInclude: feedsUrls,

--- a/registry/lib/components/feeds/pgc-watchlater/index.ts
+++ b/registry/lib/components/feeds/pgc-watchlater/index.ts
@@ -1,0 +1,45 @@
+import { defineComponentMetadata } from '@/components/define'
+import { feedsUrls } from '@/core/utils/urls'
+import { forEachFeedsCard } from '@/components/feeds/api'
+import { urlChange } from '@/core/observer'
+import { getUID } from '@/core/utils'
+import WatchlaterButton from './WatchlaterButton.vue'
+
+const feedPgcCardSelector = 'a.bili-dyn-card-pgc'
+const feedPgcCardCoverSelector = '.bili-dyn-card-pgc__cover'
+
+const entry = async () => {
+  urlChange(() => {
+    if (!getUID()) {
+      return
+    }
+    forEachFeedsCard({
+      added: card => {
+        const videoCard: HTMLAnchorElement = card.element.querySelector(feedPgcCardSelector)
+        if (videoCard) {
+          if (videoCard.querySelector('.bili-dyn-card-pgc__mark')) {
+            return
+          }
+          const vm = new (Vue.extend(WatchlaterButton))()
+          vm.$mount()
+          const button = vm.$el
+          videoCard.querySelector(feedPgcCardCoverSelector)?.appendChild(button)
+        }
+      },
+    })
+  })
+}
+
+const author = {
+  name: 'WhiteTeal55',
+  link: 'https://github.com/WhiteTeal55',
+}
+
+export const component = defineComponentMetadata({
+  name: 'pgcWatchlater',
+  displayName: '番剧动态稍后再看按钮',
+  author,
+  tags: [componentsTags.feeds, componentsTags.utils],
+  entry,
+  urlInclude: feedsUrls,
+})

--- a/src/components/video/watchlater.ts
+++ b/src/components/video/watchlater.ts
@@ -146,7 +146,9 @@ export const toggleWatchlater = async (aid: string | number, add?: boolean | und
     return
   }
   if (add) {
-    watchlaterList.push(id)
+    if (!watchlaterList.includes(id)) {
+      watchlaterList.push(id)
+    }
   } else {
     deleteValue(watchlaterList, it => it === id)
   }


### PR DESCRIPTION
## [新增组件] 番剧动态稍后再看按钮 #5688 
#### 1. 为动态页的番剧卡片添加 `稍后再看` 按钮，交互逻辑与原生 `稍后再看` 按钮一致: 
- [x] 加载时不获取当前番剧是否已添加到稍后再看列表
- [x] 点击按钮时根据按钮当前状态发送 添加 / 移除 请求

#### 2. 本体 `src\components\video\watchlater.ts` 修复
- 修复`toggleWatchlater` 函数可能会向 `watchlaterList` 重复添加相同 aid 的问题