### PR TITLE
[组件-视频快照] fix: 修复视频快照图 CDN 跨域加载失败且报错不可见的问题

### DIFF
--- a/src/components/video/video-snapshot.ts
+++ b/src/components/video/video-snapshot.ts
@@ -1,4 +1,5 @@
 import { bilibiliApi, getJsonWithCredentials } from '@/core/ajax'
+import { Toast } from '@/core/toast'
 import { formatDuration } from '@/core/utils/formatters'
 
 /**
@@ -135,24 +136,51 @@ async function parseAtlases(
 /**
  * @author WakelessSloth56
  */
-
-async function loadImage(url: string) {
+function loadImageWithCrossOrigin(url: string, crossOrigin: boolean) {
   return new Promise<HTMLImageElement>((resolve, reject) => {
     const img = new Image()
-    img.crossOrigin = 'anonymous'
+    if (crossOrigin) {
+      img.crossOrigin = 'anonymous'
+    }
     img.onload = () => resolve(img)
-    img.onerror = reject
+    img.onerror = () =>
+      reject(
+        new Error(
+          crossOrigin
+            ? `[VideoSnapshot] 快照图跨域加载失败 (CORS 被阻止): ${url}`
+            : `[VideoSnapshot] 快照图加载失败: ${url}`,
+        ),
+      )
     img.src = url
   })
+}
+
+/**
+ * 加载快照图
+ * 优先以 CORS 模式加载 (画布才可导出), CDN 未返回
+ * Access-Control-Allow-Origin 时回退为普通加载: 图片仍可显示,
+ * 但画布会被标记为污染, 无法导出下载
+ * @param url 图片地址
+ */
+let corsToastShown = false
+async function loadImage(url: string) {
+  try {
+    return await loadImageWithCrossOrigin(url, true)
+  } catch (error) {
+    console.error(error)
+    if (!corsToastShown) {
+      corsToastShown = true
+      Toast.error('快照图 CDN 跨域加载失败, 预览可用但无法导出下载, 可重启浏览器后重试', '视频快照')
+    }
+    return loadImageWithCrossOrigin(url, false)
+  }
 }
 
 async function loadAtlasImage(atlas: SnapshotAtlas) {
   if (atlas.image) {
     return atlas
   }
-
-  const img = await loadImage(atlas.url)
-  atlas.image = img
+  atlas.image = await loadImage(atlas.url)
   return atlas
 }
 

--- a/src/components/video/video-snapshot.ts
+++ b/src/components/video/video-snapshot.ts
@@ -170,7 +170,10 @@ async function loadImage(url: string) {
     console.error(error)
     if (!corsToastShown) {
       corsToastShown = true
-      Toast.error('快照图 CDN 跨域加载失败, 预览可用但无法导出下载, 可重启浏览器后重试', '视频快照')
+      Toast.error(
+        '快照图 CDN 跨域加载失败, 预览可用但无法导出下载, 可刷新网页或重启浏览器后重试',
+        '视频快照',
+      )
     }
     return loadImageWithCrossOrigin(url, false)
   }

--- a/src/ui/CanvasViewer.vue
+++ b/src/ui/CanvasViewer.vue
@@ -27,6 +27,18 @@ import { nextTick } from 'vue'
 import VIcon from './icon/VIcon.vue'
 import VLoading from './VLoading.vue'
 
+const isTaintedCanvas = (canvas: HTMLCanvasElement) => {
+  if (!canvas.width || !canvas.height) {
+    return false
+  }
+  try {
+    canvas.getContext('2d').getImageData(0, 0, 1, 1)
+  } catch {
+    return true
+  }
+  return false
+}
+
 export default Vue.extend({
   name: 'CanvasViewer',
   components: {
@@ -82,6 +94,10 @@ export default Vue.extend({
         })
       })
     },
+    setDownloadError(message: string) {
+      this.blobStatus = 'error'
+      this.downloadMessage = message
+    },
     async setDownloadable(filename: string) {
       if (!this.canvas) {
         throw new Error('[CanvasViewer] Canvas not ready')
@@ -93,12 +109,15 @@ export default Vue.extend({
       this.blobStatus = 'wait'
       this.downloadMessage = '正在创建图片……'
       await nextTick()
+      if (isTaintedCanvas(this.canvas)) {
+        this.setDownloadError('无法下载图片：快照图 CDN 未允许跨域, 画布被污染, 无法导出下载')
+        throw new Error('[CanvasViewer] Failed to create image from tainted canvas')
+      }
       return new Promise<void>((resolve, reject) => {
         requestAnimationFrame(() => {
           this.canvas.toBlob(blob => {
             if (!blob) {
-              this.blobStatus = 'error'
-              this.downloadMessage = `无法下载图片：为Canvas创建图片失败`
+              this.setDownloadError('无法下载图片：为 Canvas 创建图片失败')
               reject(new Error('[CanvasViewer] Failed to create image from canvas'))
             } else {
               this.blobStatus = 'ready'
@@ -131,7 +150,7 @@ export default Vue.extend({
   position: fixed;
   top: 0;
   left: 0;
-  z-index: 100002;
+  z-index: 100000;
   display: flex;
   justify-content: center;
   align-items: center;

--- a/src/ui/CanvasViewer.vue
+++ b/src/ui/CanvasViewer.vue
@@ -131,7 +131,7 @@ export default Vue.extend({
   position: fixed;
   top: 0;
   left: 0;
-  z-index: 100000;
+  z-index: 100002;
   display: flex;
   justify-content: center;
   align-items: center;


### PR DESCRIPTION
#### 报错信息：
<img width="955" height="278" alt="image" src="https://github.com/user-attachments/assets/14e1f3a1-ca84-4e81-88bc-24bc36663f1c" />


#### 效果：
<img width="1919" height="918" alt="image" src="https://github.com/user-attachments/assets/1e2347cf-7df4-40f3-a5fa-1ff83e6aa9dd" />


#### 
- 快照图 CORS 加载失败时自动回退为普通加载, 预览仍可显示
- 加载失败改为携带 URL 与失败原因的明确报错
- CORS 被阻止时弹出 toast 提示可重启浏览器后重试
- CanvasViewer 下载前检测画布跨域污染, 无法导出时给出明确提示
- 提取 setDownloadError 统一下载失败提示文案