### PR TITLE
修复临时加速污染倍速切换记忆

### DIFF
--- a/registry/lib/components/video/player/common/speed/context.ts
+++ b/registry/lib/components/video/player/common/speed/context.ts
@@ -295,6 +295,16 @@ const buildSubjectPart = (elementContext: ReturnType<typeof buildElementPart>) =
     }
   })
   const menuListElementClickSpeedChange$ = menuListElementClickSpeed$.pipe(distinctUntilChanged())
+  let oldSelectedVideoSpeed: number
+  let selectedVideoSpeed: number
+
+  // 播放器的临时加速可能只修改播放按钮文字，不会触发倍速菜单点击。
+  // 只用按钮文字的变化记录历史，会把临时倍速误认为用户上次选择的倍速。
+  menuListElementClickSpeedChange$.subscribe(speed => {
+    oldSelectedVideoSpeed = selectedVideoSpeed
+    selectedVideoSpeed = speed
+  })
+
   const playbackRateChange$ = playbackRate$.pipe(distinctUntilChanged())
 
   const videoSpeedChange$ = subject(({ next }) => {
@@ -334,6 +344,7 @@ const buildSubjectPart = (elementContext: ReturnType<typeof buildElementPart>) =
     ...elementContext,
     ...subjects,
     dispose,
+    getOldActiveVideoSpeed: () => oldSelectedVideoSpeed ?? elementContext.getOldActiveVideoSpeed(),
     getOldPlaybackRate: () => oldPlaybackRate,
   }
 }


### PR DESCRIPTION
## 变更说明

修复 #5710：播放器原生“长按右箭头临时加速”时，临时倍速可能被误记为“切换倍速”的上一次速度。

倍速上下文现在只在真实倍速菜单选择发生时更新历史记录；播放器按钮文字因临时加速产生的变化不会覆盖用户最后一次选择。这样在 2 倍速与 1 倍速之间切换时，即使期间临时加速到 3 倍速，仍会回到 2 倍速。

## 验证

- `corepack pnpm run type`
- `corepack pnpm run lint-check`
- `corepack pnpm tsx dev-tools/pr-check/index.ts origin/preview-fixes...HEAD`
- `corepack pnpm tsx dev-tools/dev-server/command.ts build plugin video/player/speed production`
- `git diff --check`

Fixes #5710