### PR TITLE
[本体] fix: 指定 Toast 卡片关闭按钮颜色

### DIFF
--- a/src/core/toast/ToastCard.vue
+++ b/src/core/toast/ToastCard.vue
@@ -130,6 +130,7 @@ onMounted(() => {
     cursor: pointer;
     -webkit-tap-highlight-color: transparent;
     box-sizing: content-box;
+    color: var(--text1);
     opacity: 0.75;
     &:hover {
       opacity: 0.85;


### PR DESCRIPTION
修复在官方深色模式的视频页，Toast 卡片的进度环和关闭按钮颜色不正确的问题
修复前：
<img width="255" height="101" alt="image" src="https://github.com/user-attachments/assets/a495be0a-d073-49b6-9ac3-ccc9be148616" />

修复后：
<img width="253" height="95" alt="image" src="https://github.com/user-attachments/assets/1daa11c3-e0f7-4ec3-a6e3-90514649b0f2" />

