### PR TITLE
[组件-播放时自动关灯][播放器位置动作] fix

### DIFF
--- a/registry/lib/components/video/player/auto-light/animation.ts
+++ b/registry/lib/components/video/player/auto-light/animation.ts
@@ -9,8 +9,10 @@ const CreateAnim = (): void => {
   mstars1.id = 'mstars1'
   const mstars2 = document.createElement('div')
   mstars2.id = 'mstars2'
-  biliMainHeader.appendChild(mstars1)
-  biliMainHeader.appendChild(mstars2)
+  // bangumi 等页面的播放器位于低 z-index 的祖先堆叠上下文中, 挂在 header 上会让星星浮在播放器上方, 优先挂到播放器根容器里
+  const starsHost = document.querySelector('.bpx-docker-major') ?? biliMainHeader
+  starsHost.appendChild(mstars1)
+  starsHost.appendChild(mstars2)
 
   // 添加一段css 样式到document最后
   const style = document.createElement('style')
@@ -34,9 +36,9 @@ const CreateAnim = (): void => {
   const stars3Shadow = generate(starNumCtl * 4)
   const stars4Shadow = generate(starNumCtl * 8)
   style.innerHTML = `
-  #mstars1{z-index: 1009;position: fixed;left:0px; width:1px;height:1px;background:transparent;box-shadow:${stars1Shadow};animation:animStar 50s linear infinite}
+  #mstars1{z-index: 1009;position: fixed;left:0px;top:0px; width:1px;height:1px;background:transparent;box-shadow:${stars1Shadow};animation:animStar 50s linear infinite}
   #mstars1:after{content:' ';position:fixed;left:0px;top:0px;width:1px;height:1px;background:transparent;box-shadow:${stars2Shadow}}
-  #mstars2{z-index: 1009;position: fixed;left:0px;width:2px;height:2px;background:transparent;box-shadow:${stars3Shadow};animation:animStar 100s linear infinite}
+  #mstars2{z-index: 1009;position: fixed;left:0px;top:0px;width:2px;height:2px;background:transparent;box-shadow:${stars3Shadow};animation:animStar 100s linear infinite}
   #mstars2:after{content:' ';position:fixed;left:0px;top:0px;width:2px;height:2px;background:transparent;box-shadow:${stars4Shadow}}
   @keyframes animStar{from{transform:translateY(-200px)}to{transform:translateY(-2200px)}}
   `

--- a/registry/lib/components/video/player/auto-light/animation.ts
+++ b/registry/lib/components/video/player/auto-light/animation.ts
@@ -1,5 +1,34 @@
 // author: https://github.com/z503722728
 
+/** 动画单周期位移距离, 阴影按该周期平铺以保证循环无缝 */
+const periodHeight = 2000
+
+/** 生成单个周期的随机星点图案, 并按 periodHeight 原样重复平铺, 使动画循环首尾衔接 */
+const generateTiledShadow = (numCtrl: number) => {
+  const viewportHeight = Math.max(window.innerHeight, 1)
+  const copies = Math.ceil((viewportHeight + periodHeight) / periodHeight)
+  // 每周期星数按原实现的密度计算
+  const count = Math.floor(
+    (window.innerWidth * viewportHeight * periodHeight) /
+      (numCtrl * (viewportHeight + periodHeight)),
+  )
+  const period = []
+  for (let i = 0; i < count; i++) {
+    period.push([
+      Math.floor(Math.random() * window.innerWidth * 1.5),
+      Math.floor(Math.random() * periodHeight),
+    ])
+  }
+  const stars = []
+  for (let k = 0; k < copies; k++) {
+    const offset = k * periodHeight
+    for (const [x, y] of period) {
+      stars.push(`${x}px ${y + offset}px #FFF`)
+    }
+  }
+  return stars.join(',')
+}
+
 const CreateAnim = (): void => {
   const biliMainHeader = document.getElementById('biliMainHeader')
   if (biliMainHeader == null) {
@@ -16,31 +45,17 @@ const CreateAnim = (): void => {
 
   // 添加一段css 样式到document最后
   const style = document.createElement('style')
-  // generate random stars
-  function generate(numCtrl) {
-    let star = ''
-    const max = window.innerWidth * window.innerHeight
-    for (let i = 0; i < max / numCtrl; i++) {
-      const x = Math.floor(Math.random() * window.innerWidth * 1.5)
-      const y = Math.floor(Math.random() * (window.innerHeight + 2000))
-      star += `${x}px ${y}px #FFF,`
-    }
-    const x = Math.floor(Math.random() * window.innerWidth * 1.5)
-    const y = Math.floor(Math.random() * (window.innerHeight + 2000))
-    star += `${x}px ${y}px #FFF;`
-    return star
-  }
   const starNumCtl = 400
-  const stars1Shadow = generate(starNumCtl)
-  const stars2Shadow = generate(starNumCtl * 2)
-  const stars3Shadow = generate(starNumCtl * 4)
-  const stars4Shadow = generate(starNumCtl * 8)
+  const stars1Shadow = generateTiledShadow(starNumCtl)
+  const stars2Shadow = generateTiledShadow(starNumCtl * 2)
+  const stars3Shadow = generateTiledShadow(starNumCtl * 4)
+  const stars4Shadow = generateTiledShadow(starNumCtl * 8)
   style.innerHTML = `
   #mstars1{z-index: 1009;position: fixed;left:0px;top:0px; width:1px;height:1px;background:transparent;box-shadow:${stars1Shadow};animation:animStar 50s linear infinite}
   #mstars1:after{content:' ';position:fixed;left:0px;top:0px;width:1px;height:1px;background:transparent;box-shadow:${stars2Shadow}}
   #mstars2{z-index: 1009;position: fixed;left:0px;top:0px;width:2px;height:2px;background:transparent;box-shadow:${stars3Shadow};animation:animStar 100s linear infinite}
   #mstars2:after{content:' ';position:fixed;left:0px;top:0px;width:2px;height:2px;background:transparent;box-shadow:${stars4Shadow}}
-  @keyframes animStar{from{transform:translateY(-200px)}to{transform:translateY(-2200px)}}
+  @keyframes animStar{from{transform:translateY(0)}to{transform:translateY(-${periodHeight}px)}}
   `
   document.body.appendChild(style)
 }

--- a/registry/lib/components/video/player/auto-light/index.ts
+++ b/registry/lib/components/video/player/auto-light/index.ts
@@ -47,13 +47,12 @@ export const component = defineComponentMetadata({
       true,
     )
 
-    // 等待播放器完成初始化, 过早调用关灯 API 可能与 b 站自身的初始化竞争并触发页面自动刷新
-    // https://github.com/the1812/Bilibili-Evolved/issues/5125
-    // 就绪前的 play/pause 事件无法安全响应且状态不可信, 统一丢弃, 由 videoChange 兜底按当前状态同步
+    // 等待播放器完成初始化: 过早调用关灯 API 会与 b 站初始化竞争, 触发页面自动刷新 (#5125)
+    // 就绪前的 play/pause 事件状态不可信, 统一丢弃, 由 videoChange 兜底按当前状态同步
     await playerReady()
 
-    // 在 document 上捕获事件, 避免视频元素被替换后监听器失效，导致卡在关灯状态
-    // 限定主播放器挂载点 (#bilibili-player 为视频/番剧页, #edu-player 为课堂页), 推荐卡片预览是独立 bpx 实例, 不能误触发
+    // 在 document 上捕获事件, 避免视频元素被替换后监听器失效, 导致卡在关灯状态
+    // 限定主播放器挂载点 (#bilibili-player 为视频/番剧页, #edu-player 为课堂页)
     const onVideoEvent = (type: string, action: () => void) => {
       document.addEventListener(
         type,

--- a/registry/lib/components/video/player/auto-light/index.ts
+++ b/registry/lib/components/video/player/auto-light/index.ts
@@ -23,19 +23,6 @@ export const component = defineComponentMetadata({
       return
     }
 
-    // 等待播放器完成初始化, 过早调用关灯 API 可能与 b 站自身的初始化竞争并触发页面自动刷新
-    // https://github.com/the1812/Bilibili-Evolved/issues/5125
-    const waitPlayerReady = lodash.once(() =>
-      playerReady().catch(() => {
-        // 播放器就绪信号不可用时直接继续, 避免关灯功能完全失效
-      }),
-    )
-
-    const setLight = async (on: boolean) => {
-      await waitPlayerReady()
-      on ? lightOn() : lightOff()
-    }
-
     // 星光动画跟随灯光状态, starAnimation 选项在此统一控制
     const setStars = (isLightOff: boolean) => StarAnim(isLightOff && settings.options.starAnimation)
 
@@ -62,34 +49,34 @@ export const component = defineComponentMetadata({
 
     // 在 document 上捕获事件, 避免视频元素被替换后监听器失效，导致卡在关灯状态
     // 限定主播放器挂载点 (#bilibili-player 为视频/番剧页, #edu-player 为课堂页), 推荐卡片预览是独立 bpx 实例, 不能误触发
-    const onVideoEvent = (type: string, on: boolean) => {
+    const onVideoEvent = (type: string, action: () => void) => {
       document.addEventListener(
         type,
-        event => {
+        async event => {
           if (
             event.target instanceof Element &&
-            event.target.closest(
-              '#bilibili-player .bpx-player-video-area, #edu-player .bpx-player-video-area',
-            )
+            event.target.closest('#bilibili-player, #edu-player')
           ) {
-            setLight(on)
+            await playerReady()
+            action()
           }
         },
         true,
       )
     }
-    onVideoEvent('play', false)
-    onVideoEvent('pause', true)
-    onVideoEvent('ended', true)
+    onVideoEvent('play', lightOff)
+    onVideoEvent('pause', lightOn)
+    onVideoEvent('ended', lightOn)
 
     videoChange(async () => {
       const video = (await playerAgent.query.video.element()) as HTMLVideoElement
       // 组件加载前视频可能已经开始播放
-      waitPlayerReady().then(() => {
-        if (!video.paused && !video.ended) {
-          setLight(false)
-        }
-      })
+      // 等待播放器完成初始化, 过早调用关灯 API 可能与 b 站自身的初始化竞争并触发页面自动刷新
+      // https://github.com/the1812/Bilibili-Evolved/issues/5125
+      await playerReady()
+      if (!video.paused && !video.ended) {
+        lightOff()
+      }
     })
   },
 })

--- a/registry/lib/components/video/player/auto-light/index.ts
+++ b/registry/lib/components/video/player/auto-light/index.ts
@@ -61,11 +61,17 @@ export const component = defineComponentMetadata({
     )
 
     // 在 document 上捕获事件, 避免视频元素被替换后监听器失效，导致卡在关灯状态
+    // 限定主播放器挂载点 (#bilibili-player 为视频/番剧页, #edu-player 为课堂页), 推荐卡片预览是独立 bpx 实例, 不能误触发
     const onVideoEvent = (type: string, on: boolean) => {
       document.addEventListener(
         type,
         event => {
-          if (event.target instanceof Element && event.target.closest('.bpx-player-video-area')) {
+          if (
+            event.target instanceof Element &&
+            event.target.closest(
+              '#bilibili-player .bpx-player-video-area, #edu-player .bpx-player-video-area',
+            )
+          ) {
             setLight(on)
           }
         },

--- a/registry/lib/components/video/player/auto-light/index.ts
+++ b/registry/lib/components/video/player/auto-light/index.ts
@@ -47,17 +47,21 @@ export const component = defineComponentMetadata({
       true,
     )
 
+    // 等待播放器完成初始化, 过早调用关灯 API 可能与 b 站自身的初始化竞争并触发页面自动刷新
+    // https://github.com/the1812/Bilibili-Evolved/issues/5125
+    // 就绪前的 play/pause 事件无法安全响应且状态不可信, 统一丢弃, 由 videoChange 兜底按当前状态同步
+    await playerReady()
+
     // 在 document 上捕获事件, 避免视频元素被替换后监听器失效，导致卡在关灯状态
     // 限定主播放器挂载点 (#bilibili-player 为视频/番剧页, #edu-player 为课堂页), 推荐卡片预览是独立 bpx 实例, 不能误触发
     const onVideoEvent = (type: string, action: () => void) => {
       document.addEventListener(
         type,
-        async event => {
+        event => {
           if (
             event.target instanceof Element &&
             event.target.closest('#bilibili-player, #edu-player')
           ) {
-            await playerReady()
             action()
           }
         },
@@ -71,9 +75,6 @@ export const component = defineComponentMetadata({
     videoChange(async () => {
       const video = (await playerAgent.query.video.element()) as HTMLVideoElement
       // 组件加载前视频可能已经开始播放
-      // 等待播放器完成初始化, 过早调用关灯 API 可能与 b 站自身的初始化竞争并触发页面自动刷新
-      // https://github.com/the1812/Bilibili-Evolved/issues/5125
-      await playerReady()
       if (!video.paused && !video.ended) {
         lightOff()
       }

--- a/registry/lib/components/video/player/auto-light/index.ts
+++ b/registry/lib/components/video/player/auto-light/index.ts
@@ -2,11 +2,8 @@ import { playerAgent } from '@/components/video/player-agent'
 import { lightOn, lightOff } from '@/components/video/player-light'
 import { videoChange } from '@/core/observer'
 import { allVideoUrls } from '@/core/utils/urls'
-import type { PlayerAgent } from '@/components/video/player-agent/base'
 import { StarAnim } from './animation'
 import { defineComponentMetadata } from '@/components/define'
-
-let playerAgentInstance: PlayerAgent
 
 export const component = defineComponentMetadata({
   name: 'playerAutoLight',
@@ -20,42 +17,57 @@ export const component = defineComponentMetadata({
     },
   },
   entry: async ({ settings }) => {
-    const { isEmbeddedPlayer } = await import('@/core/utils')
+    const { isEmbeddedPlayer, playerReady } = await import('@/core/utils')
 
     if (isEmbeddedPlayer()) {
       return
     }
 
-    const makeLightOn = () => {
-      lightOn()
-      StarAnim(false)
-    }
+    // 等待播放器完成初始化, 过早调用关灯 API 可能与 b 站自身的初始化竞争并触发页面自动刷新
+    // https://github.com/the1812/Bilibili-Evolved/issues/5125
+    const waitPlayerReady = lodash.once(() =>
+      playerReady().catch(() => {
+        // 播放器就绪信号不可用时直接继续, 避免关灯功能完全失效
+      }),
+    )
 
-    const makeLightOff = () => {
-      lightOff()
-      if (settings.options.starAnimation) {
-        StarAnim(true)
+    const setLight = async (on: boolean) => {
+      await waitPlayerReady()
+      if (on) {
+        lightOn()
+        StarAnim(false)
+      } else {
+        lightOff()
+        if (settings.options.starAnimation) {
+          StarAnim(true)
+        }
       }
     }
+
+    // 在 document 上捕获事件, 避免视频元素被替换后监听器失效，导致卡在关灯状态
+    const onVideoEvent = (type: string, action: () => void) => {
+      document.addEventListener(
+        type,
+        event => {
+          if (event.target instanceof Element && event.target.closest('.bpx-player-video-area')) {
+            action()
+          }
+        },
+        true,
+      )
+    }
+    onVideoEvent('play', () => setLight(false))
+    onVideoEvent('pause', () => setLight(true))
+    onVideoEvent('ended', () => setLight(true))
 
     videoChange(async () => {
-      if (playerAgentInstance != null) {
-        const oldVideo = await playerAgentInstance.query.video.element()
-        oldVideo.removeEventListener('ended', makeLightOn)
-        oldVideo.removeEventListener('pause', makeLightOn)
-        oldVideo.removeEventListener('play', makeLightOff)
-      }
-
-      playerAgentInstance = playerAgent
-      const video = await playerAgentInstance.query.video.element()
-
-      if (playerAgentInstance.isAutoPlay()) {
-        makeLightOff()
-      }
-
-      video.addEventListener('ended', makeLightOn)
-      video.addEventListener('pause', makeLightOn)
-      video.addEventListener('play', makeLightOff)
+      const video = (await playerAgent.query.video.element()) as HTMLVideoElement
+      // 组件加载前视频可能已经开始播放
+      waitPlayerReady().then(() => {
+        if (!video.paused && !video.ended) {
+          setLight(false)
+        }
+      })
     })
   },
 })

--- a/registry/lib/components/video/player/auto-light/index.ts
+++ b/registry/lib/components/video/player/auto-light/index.ts
@@ -33,32 +33,48 @@ export const component = defineComponentMetadata({
 
     const setLight = async (on: boolean) => {
       await waitPlayerReady()
-      if (on) {
-        lightOn()
-        StarAnim(false)
-      } else {
-        lightOff()
-        if (settings.options.starAnimation) {
-          StarAnim(true)
-        }
-      }
+      on ? lightOn() : lightOff()
     }
 
+    // 星光动画跟随灯光状态, starAnimation 选项在此统一控制
+    const setStars = (isLightOff: boolean) => StarAnim(isLightOff && settings.options.starAnimation)
+
+    // 任何组件开关灯都经过 PlayerAgent.toggleLight, 监听其广播的灯光状态同步星光动画
+    window.addEventListener('playerLightChange', event => {
+      const { lightOn: isLightOn } = (event as CustomEvent<{ lightOn: boolean }>).detail
+      setStars(!isLightOn)
+    })
+
+    // 用户手动点击播放器设置中的 "关灯模式" 勾选框时同步星光动画 (该路径不经过 PlayerAgent.toggleLight)
+    document.addEventListener(
+      'change',
+      event => {
+        const checkbox = event.target
+        if (
+          checkbox instanceof HTMLInputElement &&
+          checkbox.closest('.bpx-player-ctrl-setting-lightoff')
+        ) {
+          setStars(checkbox.checked)
+        }
+      },
+      true,
+    )
+
     // 在 document 上捕获事件, 避免视频元素被替换后监听器失效，导致卡在关灯状态
-    const onVideoEvent = (type: string, action: () => void) => {
+    const onVideoEvent = (type: string, on: boolean) => {
       document.addEventListener(
         type,
         event => {
           if (event.target instanceof Element && event.target.closest('.bpx-player-video-area')) {
-            action()
+            setLight(on)
           }
         },
         true,
       )
     }
-    onVideoEvent('play', () => setLight(false))
-    onVideoEvent('pause', () => setLight(true))
-    onVideoEvent('ended', () => setLight(true))
+    onVideoEvent('play', false)
+    onVideoEvent('pause', true)
+    onVideoEvent('ended', true)
 
     videoChange(async () => {
       const video = (await playerAgent.query.video.element()) as HTMLVideoElement

--- a/registry/lib/components/video/player/intersection-actions/index.ts
+++ b/registry/lib/components/video/player/intersection-actions/index.ts
@@ -110,13 +110,15 @@ export const component = defineComponentMetadata({
         videoEl.addEventListener('play', addPlayerOutEvent)
         // videoEl.addEventListener('pause', removePlayerOutEvent);
         videoEl.addEventListener('ended', removePlayerOutEvent)
-        videoChange(async () => {
-          await playerReady()
+        videoChange(() => {
           if (!videoEl.paused && !videoEl.ended) {
             addPlayerOutEvent()
           }
         })
       }
+
+      // 就绪前不注册任何监听, 统一丢弃过期位置, 由 videoChange 兜底在就绪后按当前状态开始观察
+      await playerReady()
 
       addComponentListener(`${metadata.name}.triggerLocation`, (value: IntersectionMode) => {
         removePlayerOutEvent()

--- a/registry/lib/components/video/player/intersection-actions/index.ts
+++ b/registry/lib/components/video/player/intersection-actions/index.ts
@@ -26,6 +26,7 @@ export const component = defineComponentMetadata({
       light: boolean
     }
     Promise.resolve().then(async () => {
+      const { playerReady } = await import('@/core/utils')
       const {
         query: { video },
       } = playerAgent
@@ -106,13 +107,14 @@ export const component = defineComponentMetadata({
         )
 
       function mountPlayListener() {
+        videoEl.addEventListener('play', addPlayerOutEvent)
+        // videoEl.addEventListener('pause', removePlayerOutEvent);
+        videoEl.addEventListener('ended', removePlayerOutEvent)
         videoChange(async () => {
-          if (playerAgent.isAutoPlay()) {
+          await playerReady()
+          if (!videoEl.paused && !videoEl.ended) {
             addPlayerOutEvent()
           }
-          videoEl.addEventListener('play', addPlayerOutEvent)
-          // videoEl.addEventListener('pause', removePlayerOutEvent);
-          videoEl.addEventListener('ended', removePlayerOutEvent)
         })
       }
 

--- a/registry/lib/components/video/player/intersection-actions/index.ts
+++ b/registry/lib/components/video/player/intersection-actions/index.ts
@@ -36,16 +36,13 @@ export const component = defineComponentMetadata({
       } = playerAgent
 
       const videoEl = (await video.element()) as HTMLVideoElement
-      // const playerWrap = await video.wrap()
-      // 如果有 video-player 优先的使用该盒子
-      // 因为在稍后再看页面（medialist）视频也有 player-wrap
-      // 选择 player-wrap 会导致闪烁。
+      // 优先使用 #video-player: 稍后再看 (medialist) 页面也有 .player-wrap, 混用会导致闪烁
       const playerWrap = (document.getElementById('video-player') ??
         (dq('.player-wrap') || dq('.player-module'))) as HTMLElement
 
       let observer: IntersectionObserver
       let intersectionLock = true // Lock intersection action
-      let playerIntersecting = true // 播放器当前是否在视口内 (由 IO 回调维护)
+      let playerIntersecting = true // 播放器当前是否在视口内, 由 IO 回调维护
 
       const getToTop = (mode: string): number =>
         ({
@@ -95,8 +92,8 @@ export const component = defineComponentMetadata({
           { threshold: getToTop(mode) },
         )
 
-      // 视口外播放时, playerAutoLight 的关灯会覆盖自动开灯
-      // 同一任务内纠正可避免闪烁.
+      // 视口外播放时, playerAutoLight 的关灯会覆盖自动开灯;
+      // 关灯广播同步派发, 在同一任务内纠正开灯, 避免灯光闪烁
       window.addEventListener('playerLightChange', event => {
         const { lightOn: isLightOn } = (event as CustomEvent<{ lightOn: boolean }>).detail
         if (!isLightOn && isLightEnabled() && !videoEl.paused && !playerIntersecting) {
@@ -105,16 +102,16 @@ export const component = defineComponentMetadata({
         }
       })
 
-      await playerReady()
-
-      // 开灯模式 b 站给 left-container 加 scroll-sticky (负 top) 钉住播放器,
-      // 小窗模式还会动态写入负 top 使容器整体上移 (评论区跳动);
+      // 开灯时 left-container 有 scroll-sticky,
+      // 小窗模式还会动态写入负 top 导致评论区跳动;
       // 用重要样式一次性强制 relative + top 0
       const { addImportantStyle } = await import('@/core/style')
       addImportantStyle(
         '.left-container { position: relative !important; top: 0 !important; }',
         name,
       )
+
+      await playerReady()
 
       addComponentListener(`${metadata.name}.triggerLocation`, (value: IntersectionMode) => {
         removePlayerOutEvent()

--- a/registry/lib/components/video/player/intersection-actions/index.ts
+++ b/registry/lib/components/video/player/intersection-actions/index.ts
@@ -103,6 +103,19 @@ export const component = defineComponentMetadata({
 
       await playerReady()
 
+      // 强制 relative 让播放器随页面正常滚出, 与关灯模式几何一致
+      const leftContainer = dq('.left-container') as HTMLElement | null
+      if (leftContainer) {
+        leftContainer.style.position = 'relative'
+        // 短页面切换到小窗模式时, b 站会给 left-container 加负 top 把容器整体上移,
+        // 导致评论区瞬间跳动; 重置为 0 保持布局位置不变
+        new MutationObserver(() => {
+          if (parseFloat(leftContainer.style.top) < 0) {
+            leftContainer.style.top = '0px'
+          }
+        }).observe(leftContainer, { attributes: true, attributeFilter: ['style'] })
+      }
+
       addComponentListener(`${metadata.name}.triggerLocation`, (value: IntersectionMode) => {
         removePlayerOutEvent()
         observer = createObserver(value)

--- a/registry/lib/components/video/player/intersection-actions/index.ts
+++ b/registry/lib/components/video/player/intersection-actions/index.ts
@@ -103,18 +103,14 @@ export const component = defineComponentMetadata({
 
       await playerReady()
 
-      // 强制 relative 让播放器随页面正常滚出, 与关灯模式几何一致
-      const leftContainer = dq('.left-container') as HTMLElement | null
-      if (leftContainer) {
-        leftContainer.style.position = 'relative'
-        // 短页面切换到小窗模式时, b 站会给 left-container 加负 top 把容器整体上移,
-        // 导致评论区瞬间跳动; 重置为 0 保持布局位置不变
-        new MutationObserver(() => {
-          if (parseFloat(leftContainer.style.top) < 0) {
-            leftContainer.style.top = '0px'
-          }
-        }).observe(leftContainer, { attributes: true, attributeFilter: ['style'] })
-      }
+      // 开灯模式 b 站给 left-container 加 scroll-sticky (负 top) 钉住播放器,
+      // 小窗模式还会动态写入负 top 使容器整体上移 (评论区跳动);
+      // 用重要样式一次性强制 relative + top 0
+      const { addImportantStyle } = await import('@/core/style')
+      addImportantStyle(
+        '.left-container { position: relative !important; top: 0 !important; }',
+        'playerIntersectionActions',
+      )
 
       addComponentListener(`${metadata.name}.triggerLocation`, (value: IntersectionMode) => {
         removePlayerOutEvent()

--- a/registry/lib/components/video/player/intersection-actions/index.ts
+++ b/registry/lib/components/video/player/intersection-actions/index.ts
@@ -41,29 +41,21 @@ export const component = defineComponentMetadata({
 
       let observer: IntersectionObserver
       let intersectionLock = true // Lock intersection action
+      let playerIntersecting = true // 播放器当前是否在视口内 (由 IO 回调维护)
 
-      function getToTop(_mode: string): number {
-        switch (_mode) {
-          case IntersectionMode.Top:
-            return 1
-          case IntersectionMode.Medium:
-            return 0.5
-          case IntersectionMode.Bottom:
-            return 0
-          default:
-            return 0.5
-        }
-      }
+      const getToTop = (mode: string): number =>
+        ({
+          [IntersectionMode.Top]: 1,
+          [IntersectionMode.Medium]: 0.5,
+          [IntersectionMode.Bottom]: 0,
+        }[mode] ?? 0.5)
 
-      function addPlayerOutEvent() {
-        // window.addEventListener('scroll', onPlayerOutEvent, { passive: true });
-        observer.observe(playerWrap)
-      }
+      const addPlayerOutEvent = () => observer.observe(playerWrap)
+      const removePlayerOutEvent = () => observer.unobserve(playerWrap)
 
-      function removePlayerOutEvent() {
-        // window.removeEventListener('scroll', onPlayerOutEvent);
-        observer.unobserve(playerWrap)
-      }
+      // 自动开灯是否可用: light 选项开启且 playerAutoLight 已启用且未开自动暂停
+      const isLightEnabled = () =>
+        settings.light && getComponentSettings('playerAutoLight').enabled && !settings.pause
 
       const intersectingCall = () => {
         if (intersectionLock) {
@@ -73,51 +65,42 @@ export const component = defineComponentMetadata({
         if (settings.pause && videoEl.paused) {
           videoEl.play()
         }
-        if (
-          settings.light &&
-          getComponentSettings('playerAutoLight').enabled &&
-          !settings.pause &&
-          !videoEl.paused
-        ) {
+        if (isLightEnabled() && !videoEl.paused) {
           lightOff()
         }
       }
 
       const disIntersectingCall = () => {
-        // if video is playing, unlock intersecting action
         if (!videoEl.paused) {
           intersectionLock = false
+          if (settings.pause) {
+            videoEl.pause()
+          }
         }
-        if (settings.pause && !videoEl.paused) {
-          videoEl.pause()
-        }
-        if (settings.light && getComponentSettings('playerAutoLight').enabled && !settings.pause) {
+        if (isLightEnabled()) {
           lightOn()
         }
       }
 
-      const createObserver = (mode?: string) =>
+      const createObserver = (mode = settings.triggerLocation) =>
         new IntersectionObserver(
           ([e]) => {
+            playerIntersecting = e.isIntersecting
             e.isIntersecting ? intersectingCall() : disIntersectingCall()
           },
-          {
-            threshold: getToTop(mode || settings.triggerLocation),
-          },
+          { threshold: getToTop(mode) },
         )
 
-      function mountPlayListener() {
-        videoEl.addEventListener('play', addPlayerOutEvent)
-        // videoEl.addEventListener('pause', removePlayerOutEvent);
-        videoEl.addEventListener('ended', removePlayerOutEvent)
-        videoChange(() => {
-          if (!videoEl.paused && !videoEl.ended) {
-            addPlayerOutEvent()
-          }
-        })
-      }
+      // 视口外播放时, playerAutoLight 的关灯会覆盖自动开灯
+      // 同一任务内纠正可避免闪烁.
+      window.addEventListener('playerLightChange', event => {
+        const { lightOn: isLightOn } = (event as CustomEvent<{ lightOn: boolean }>).detail
+        if (!isLightOn && isLightEnabled() && !videoEl.paused && !playerIntersecting) {
+          intersectionLock = false
+          lightOn()
+        }
+      })
 
-      // 就绪前不注册任何监听, 统一丢弃过期位置, 由 videoChange 兜底在就绪后按当前状态开始观察
       await playerReady()
 
       addComponentListener(`${metadata.name}.triggerLocation`, (value: IntersectionMode) => {
@@ -127,7 +110,9 @@ export const component = defineComponentMetadata({
       })
 
       observer = createObserver()
-      mountPlayListener()
+      videoEl.addEventListener('play', addPlayerOutEvent)
+      videoEl.addEventListener('ended', removePlayerOutEvent)
+      videoChange(() => addPlayerOutEvent())
     })
   },
   displayName: '播放器位置动作',

--- a/registry/lib/components/video/player/intersection-actions/index.ts
+++ b/registry/lib/components/video/player/intersection-actions/index.ts
@@ -11,8 +11,12 @@ enum IntersectionMode {
   Bottom = '视频底部',
 }
 
+const name = 'playerIntersectionActions'
+const displayName = '播放器位置动作'
+
 export const component = defineComponentMetadata({
-  name: 'playerIntersectionActions',
+  name,
+  displayName,
   author: {
     name: 'Waua',
     link: 'https://github.com/FoundTheWOUT',
@@ -109,7 +113,7 @@ export const component = defineComponentMetadata({
       const { addImportantStyle } = await import('@/core/style')
       addImportantStyle(
         '.left-container { position: relative !important; top: 0 !important; }',
-        'playerIntersectionActions',
+        name,
       )
 
       addComponentListener(`${metadata.name}.triggerLocation`, (value: IntersectionMode) => {
@@ -124,7 +128,6 @@ export const component = defineComponentMetadata({
       videoChange(() => addPlayerOutEvent())
     })
   },
-  displayName: '播放器位置动作',
   options: {
     triggerLocation: {
       defaultValue: IntersectionMode.Medium,

--- a/src/components/video/player-agent/base.ts
+++ b/src/components/video/player-agent/base.ts
@@ -169,7 +169,6 @@ export abstract class PlayerAgent
         }
       })
     }
-    // 广播灯光状态, 供其他组件 (如自动关灯的星光动画) 同步
     window.dispatchEvent(
       new CustomEvent('playerLightChange', { detail: { lightOn: targetLightOn } }),
     )

--- a/src/components/video/player-agent/base.ts
+++ b/src/components/video/player-agent/base.ts
@@ -157,22 +157,23 @@ export abstract class PlayerAgent
     if (!this.nativeApi) {
       return null
     }
-    const isCurrentLightOff = this.nativeApi.getLightOff()
-    // 无指定参数, 直接 toggle
-    if (on === undefined) {
-      this.nativeApi.setLightOff(!isCurrentLightOff)
-      return !isCurrentLightOff
+    const isLightOn = !this.nativeApi.getLightOff()
+    const targetLightOn = on ?? !isLightOn
+    const changed = targetLightOn !== isLightOn
+    if (changed) {
+      this.nativeApi.setLightOff(!targetLightOn)
+      // 同步设置面板中的 "关灯模式" 勾选框 (原生 API 不会自动更新该 UI), 面板懒加载可能尚未完成
+      this.query.control.settings.lightOff().then(checkbox => {
+        if (checkbox instanceof HTMLInputElement) {
+          checkbox.checked = !targetLightOn
+        }
+      })
     }
-    // 关灯状态 && 要开灯 -> 开灯
-    if (on && isCurrentLightOff) {
-      this.nativeApi.setLightOff(false)
-      return true
-    }
-    if (!on && !isCurrentLightOff) {
-      this.nativeApi.setLightOff(true)
-      return false
-    }
-    return null
+    // 广播灯光状态, 供其他组件 (如自动关灯的星光动画) 同步
+    window.dispatchEvent(
+      new CustomEvent('playerLightChange', { detail: { lightOn: targetLightOn } }),
+    )
+    return changed ? targetLightOn : null
   }
 
   getPlayerConfig<DefaultValueType = unknown, ValueType = DefaultValueType>(


### PR DESCRIPTION
## 播放时自动关灯

- 所有开关灯动作等待播放器就绪后执行，修复过早调用关灯 API 触发页面自动刷新的问题 #5125
- 事件改为在 `document` 上捕获监听，限定主播放器挂载点，避免视频元素被替换后监听失效；兼容课堂页
- 星光动画通过 `playerLightChange` 事件同步灯光状态，兼容手动 / 其他组件的关灯模式更改
- 修复星光动画循环结尾的粒子瞬移；挂载位置改为 `.bpx-docker-major`，防止遮挡番剧页播放器和顶栏

## 播放器位置动作

- 视口外播放时通过 `playerLightChange` 纠正监听同步开灯，修复自动开灯被播放时自动关灯覆盖的问题
- 强制 `left-container` 为 `relative` 接管滚动，修复闪烁问题 #5269 #5463
- 小窗切换时重置 B 站写入的负 `top`，修复评论区瞬间跳动