### PR TITLE
fix(定制自动连播行为): 修复普通分P新版界面功能失效

### DIFF
--- a/registry/lib/components/video/player/custom-auto-play/handlers/MultipartAutoplayHandler.ts
+++ b/registry/lib/components/video/player/custom-auto-play/handlers/MultipartAutoplayHandler.ts
@@ -6,11 +6,15 @@ import { BaseAutoplayHandler } from './BaseAutoplayHandler'
 export class MultipartAutoplayHandler extends BaseAutoplayHandler {
   type = '分P视频'
 
+  /** 是否为带自动播放切换按钮的旧版界面 */
+  private isLegacyLayout() {
+    return document.querySelector('.video-pod .auto-play .switch-btn') !== null
+  }
+
   async match() {
     const videoUrl = '//www.bilibili.com/video/'
     const list = document.querySelector('.video-pod .multip')
-    const btn = document.querySelector('.video-pod .auto-play .switch-btn')
-    return matchUrlPattern(videoUrl) && list != null && btn != null
+    return matchUrlPattern(videoUrl) && list !== null
   }
 
   protected override getSequentialNumberString(): string {
@@ -25,6 +29,10 @@ export class MultipartAutoplayHandler extends BaseAutoplayHandler {
   }
 
   async setupAutoPlay(enable: boolean) {
-    await this.setupAutoPlay_SwitchBtn(enable)
+    if (this.isLegacyLayout()) {
+      await this.setupAutoPlay_SwitchBtn(enable)
+      return
+    }
+    await this.setupAutoPlay_Player(enable)
   }
 }


### PR DESCRIPTION
## 问题

新版普通分P页面仍存在 `.video-pod .multip`，但列表右上角的
`.video-pod .auto-play .switch-btn` 已被移除。

目前 `MultipartAutoplayHandler.match()` 同时要求分P列表和旧连播开关存在，
导致处理器无法匹配。修改“分P视频”选项时不会执行对应逻辑，也没有
“自动连播类型：分P视频”的日志。

## 修改

- 普通分P只通过视频页和 `.video-pod .multip` 识别
- 不再将旧 `.switch-btn` 作为匹配条件
- 旧界面仍使用 `setupAutoPlay_SwitchBtn()`
- 无旧开关的新版界面使用 `setupAutoPlay_Player()`
- 保持原有 `.video-pod__header .amt` 分P进度及最后一P判断逻辑

## 预期行为

- 非最后一P，“分P视频”设为“自动”时启用自动连播
- 最后一P，“分P视频”设为“自动”时关闭自动连播
- “禁用”和“总是”设置可以正常控制播放器播放方式
- 旧版仍有侧栏连播开关的页面保持兼容

## 检查

- [x] ESLint 检查通过
- [x] TypeScript 类型检查通过
- [x] `custom-auto-play` 组件生产构建通过