### PR TITLE
fix(navbar): fix feed crash on invisible article items

### DIFF
--- a/registry/lib/components/style/custom-navbar/feeds/tabs/next-page.ts
+++ b/registry/lib/components/style/custom-navbar/feeds/tabs/next-page.ts
@@ -9,8 +9,10 @@ import { logError } from '@/core/utils/log'
 import { setLatestID } from '@/components/feeds/notify'
 import { VLoading, VEmpty, ScrollTrigger } from '@/ui'
 
-const isBlockedRawItem = (item: any) =>
-  lodash.get(item, 'modules.module_dynamic.major.type') === 'MAJOR_TYPE_BLOCKED'
+const isUnavailableRawItem = (item: any) => {
+  const major = lodash.get(item, 'modules.module_dynamic.major')
+  return major == null || major.type === 'MAJOR_TYPE_BLOCKED'
+}
 
 /**
  * 获取用于支持顶栏动态无限滚动的Vue Mixin
@@ -60,7 +62,7 @@ export const nextPageMixin = <MappedItem extends { id: string }, RawItem>(
             throw new Error(json.message)
           }
           const jsonCards = (lodash.get(json, 'data.items', []) as RawItem[])
-            .filter(item => !isBlockedRawItem(item))
+            .filter(item => !isUnavailableRawItem(item))
             .map(jsonMapper) as MappedItem[]
 
           let concatCards = applyContentFilter(


### PR DESCRIPTION
## Summary

This commit fixes #5646 and probably #5760 that when returned article data contains invalid items, the navbar tab would crash.

## Problem

When using custom navbar, the article tab of dynamics would crash sometimes. Console reports the following:

```text
TypeError: Cannot read properties of undefined (reading 'id')
    at eval (eval at <anonymous> (eval at <anonymous> (（索引）:201:28079)), <anonymous>:32:23526)
    at Array.map (<anonymous>)
    at a.nextPage (eval at <anonymous> (eval at <anonymous> (（索引）:201:28079)), <anonymous>:19:2520)
    at async a.created (eval at <anonymous> (eval at <anonymous>
```

## Potential Cause

Following #5600 and https://github.com/the1812/Bilibili-Evolved/commit/a19f80cfbaf58b28d7ebb8ec65e78698e2896d24, after examining the data returned, some items are incompatible with current code:

<img width="725" height="427" alt="Image" src="https://github.com/user-attachments/assets/8f315c76-0b0c-4798-866f-e2320ae5498c" />

Specifically, `item 13` has the following:

```json
"visible": false,
"modules": {
  "module_dynamic": {
    "major": null
  }
}
```

This seems to correspond to a sponsor-only article. Since the returned `major` is null, this line

https://github.com/the1812/Bilibili-Evolved/blob/9535fa6cade09148b817334e1e940ab1052759c5/registry/lib/components/style/custom-navbar/feeds/tabs/ColumnFeeds.vue#L26

would return an `article` that's `undefined`, which leads the following access to `article.id` in return values throws. In the meantime, since `major` is `null`, the fix in https://github.com/the1812/Bilibili-Evolved/commit/a19f80cfbaf58b28d7ebb8ec65e78698e2896d24 failed to catch it.

It's possible that the site's API changes how invisible articles are returned.

## Fix

The fix checks if `major` is `null` before checking `major.type` is `MAJOR_TYPE_BLOCKED`, so both cases are covered. The function was renamed to `isUnavailableRawItem` to reflect the cases and is used to filter out invalid items before passing to `jsonMapper`.

## Checks

`pnpm run check-pr-files`, `pnpm run type` and `pnpm run lint-check` passed. Local test confirms that the article tab is now working properly without crashing.