### PR TITLE
[本体] fix: 修复管理面板样式被直播间样式覆盖的问题

### DIFF
--- a/src/components/settings-panel/sub-pages/manage-panel/UserItem.vue
+++ b/src/components/settings-panel/sub-pages/manage-panel/UserItem.vue
@@ -74,6 +74,8 @@ export default Vue.extend({
   grid-template: 'displayName line remove' auto 'name line remove' auto / auto 1fr auto;
   align-items: center;
   padding: 6px 0;
+  height: unset;
+  width: unset;
 
   .user-item-display-name {
     grid-area: displayName;


### PR DESCRIPTION
在带有活动样式的直播间，B站原生样式会覆盖管理面板的样式。
移除组件自身 `.manage-panel .user-item` 高度和宽度限制来修复此问题
<img width="307" height="280" alt="image" src="https://github.com/user-attachments/assets/37cd3570-3e20-4d06-9b60-beb4bb5ee263" />
<img width="432" height="881" alt="image" src="https://github.com/user-attachments/assets/aa01a868-b427-4241-8537-54be7a0a91f1" />