### PR TITLE
[组件-快捷键扩展] fix: 为弹幕开关功能添加状态提示

### DIFF
--- a/registry/lib/components/utils/keymap/actions.ts
+++ b/registry/lib/components/utils/keymap/actions.ts
@@ -190,7 +190,18 @@ export const builtInActions: Record<string, KeyBindingAction> = {
   },
   danmaku: {
     displayName: '弹幕开关',
-    run: () => playerAgent.toggleDanmaku(),
+    run: () => {
+      const result = playerAgent.toggleDanmaku()
+      if (lodash.isNil(result)) {
+        return result
+      }
+      if (result) {
+        showTip('弹幕已开启', 'mdi-comment-text')
+      } else {
+        showTip('弹幕已关闭', 'mdi-comment-text-outline')
+      }
+      return true
+    },
   },
   longJumpBackward: {
     displayName: '长倒退',


### PR DESCRIPTION
为弹幕开关功能添加状态提示 #4743 ，效果如图
<img width="279" height="115" alt="屏幕截图 2026-09-08 120703" src="https://github.com/user-attachments/assets/756aef72-727f-4b9d-9f3a-3b01634ae692" />
<img width="330" height="122" alt="屏幕截图 2026-09-08 120657" src="https://github.com/user-attachments/assets/2a1bda2e-bd84-4566-8c61-e5f588fbd6f3" />
