### PR TITLE
[组件-自定义顶栏] fix: 导航栏项目出现滚动条

### DIFF
--- a/registry/lib/components/style/custom-navbar/CustomNavbarItem.vue
+++ b/registry/lib/components/style/custom-navbar/CustomNavbarItem.vue
@@ -244,6 +244,7 @@ export default Vue.extend({
     padding: 0 10px;
     color: var(--navbar-foreground);
     user-select: none;
+    overflow: unset;
     &:hover {
       color: var(--navbar-foreground) !important;
     }


### PR DESCRIPTION
导航栏项的样式被B站原生样式覆盖
将导航栏项自身的 `overflow` 属性设置为 `unset` 以解决 #2888
<img width="313" height="82" alt="屏幕截图 2026-09-08 144735" src="https://github.com/user-attachments/assets/ee2e0462-3dd8-4116-809d-3d5e7a9322ba" />
