### PR TITLE
[组件-下载视频] feat: 支持区分合集内的多个子合集

### DIFF
--- a/registry/lib/components/video/download/inputs/EpisodesPicker.vue
+++ b/registry/lib/components/video/download/inputs/EpisodesPicker.vue
@@ -2,33 +2,17 @@
   <div class="episodes-picker download-video-config-section">
     <div class="episodes-picker-header">
       <div class="episodes-picker-title">选集:</div>
-      <div class="episodes-picker-checked-ratio">
-        {{ checkedRatio }}
-      </div>
+      <div class="episodes-picker-checked-ratio">{{ formatRatio(episodeItems) }}</div>
       <div class="episodes-picker-actions">
         <VButton
-          class="select-all"
-          title="全选"
+          v-for="action of selectActions"
+          :key="action.name"
+          :class="action.name"
+          :title="action.title"
           type="transparent"
-          @click="forEachItem(it => (it.isChecked = true))"
+          @click="applySelectAction(action, episodeItems)"
         >
-          <VIcon :size="16" icon="mdi-checkbox-multiple-marked-circle" />
-        </VButton>
-        <VButton
-          class="deselect-all"
-          title="全不选"
-          type="transparent"
-          @click="forEachItem(it => (it.isChecked = false))"
-        >
-          <VIcon :size="16" icon="mdi-checkbox-multiple-blank-circle-outline" />
-        </VButton>
-        <VButton
-          class="invert-selection"
-          title="反选"
-          type="transparent"
-          @click="forEachItem(it => (it.isChecked = !it.isChecked))"
-        >
-          <VIcon :size="16" icon="mdi-circle-slice-4" />
+          <VIcon :size="16" :icon="action.icon" />
         </VButton>
       </div>
     </div>
@@ -46,30 +30,15 @@
         >
           <VIcon class="episodes-picker-section-toggle" :size="14" icon="mdi-chevron-down" />
           <span class="episodes-picker-section-title">{{ section.title }}</span>
-          <span class="episodes-picker-section-ratio">{{ getSectionCheckedRatio(section) }}</span>
+          <span class="episodes-picker-section-ratio">{{ formatRatio(section.entries) }}</span>
           <VButton
-            class="select-section"
-            title="全选此子合集"
+            v-for="action of selectActions"
+            :key="action.name"
+            :title="action.title"
             type="transparent"
-            @click.stop="forEachSectionItem(section, it => (it.isChecked = true))"
+            @click.stop="applySelectAction(action, section.entries)"
           >
-            <VIcon :size="14" icon="mdi-checkbox-multiple-marked-circle" />
-          </VButton>
-          <VButton
-            class="deselect-section"
-            title="全不选此子合集"
-            type="transparent"
-            @click.stop="forEachSectionItem(section, it => (it.isChecked = false))"
-          >
-            <VIcon :size="14" icon="mdi-checkbox-multiple-blank-circle-outline" />
-          </VButton>
-          <VButton
-            class="invert-section"
-            title="反选此子合集"
-            type="transparent"
-            @click.stop="forEachSectionItem(section, it => (it.isChecked = !it.isChecked))"
-          >
-            <VIcon :size="14" icon="mdi-circle-slice-4" />
+            <VIcon :size="14" :icon="action.icon" />
           </VButton>
         </div>
         <transition
@@ -113,6 +82,30 @@ interface EpisodeSection {
   entries: EpisodeItem[]
 }
 
+interface SelectAction {
+  name: string
+  title: string
+  icon: string
+  /** 目标选中状态, 省略时表示反选 */
+  isChecked?: boolean
+}
+
+const selectActions: SelectAction[] = [
+  {
+    name: 'select-all',
+    title: '全选',
+    icon: 'mdi-checkbox-multiple-marked-circle',
+    isChecked: true,
+  },
+  {
+    name: 'deselect-all',
+    title: '全不选',
+    icon: 'mdi-checkbox-multiple-blank-circle-outline',
+    isChecked: false,
+  },
+  { name: 'invert-selection', title: '反选', icon: 'mdi-circle-slice-4' },
+]
+
 const buildEpisodeSections = (items: EpisodeItem[]): EpisodeSection[] => {
   const sections: EpisodeSection[] = []
   let lastSection: EpisodeSection | undefined
@@ -141,6 +134,7 @@ export default Vue.extend({
   },
   data() {
     return {
+      selectActions,
       episodeItems: [] as EpisodeItem[],
       episodeSections: [] as EpisodeSection[],
       maxCheckedItems: 32,
@@ -148,13 +142,6 @@ export default Vue.extend({
     }
   },
   computed: {
-    checkedRatio() {
-      const checked = this.episodeItems.filter(it => it.isChecked).length
-      return `(${checked}/${this.episodeItems.length})`
-    },
-    inputItems() {
-      return this.episodeItems.map(it => it.inputItem)
-    },
     checkedInputItems() {
       return this.episodeItems.filter(it => it.isChecked).map(it => it.inputItem)
     },
@@ -173,12 +160,13 @@ export default Vue.extend({
     toggleSection(section: EpisodeSection) {
       section.isCollapsed = !section.isCollapsed
     },
-    getSectionCheckedRatio(section: EpisodeSection) {
-      const { entries } = section
-      return `(${entries.filter(it => it.isChecked).length}/${entries.length})`
+    formatRatio(items: EpisodeItem[]) {
+      return `(${items.filter(it => it.isChecked).length}/${items.length})`
     },
-    forEachSectionItem(section: EpisodeSection, action: (item: EpisodeItem) => void) {
-      section.entries.forEach(action)
+    applySelectAction(action: SelectAction, items: EpisodeItem[]) {
+      items.forEach(it => {
+        it.isChecked = action.isChecked ?? !it.isChecked
+      })
     },
     shiftSelect(e: MouseEvent, item: EpisodeItem) {
       const index = this.episodeItems.indexOf(item)
@@ -203,9 +191,6 @@ export default Vue.extend({
       this.lastCheckedEpisodeIndex = index
       e.preventDefault()
     },
-    forEachItem(action: (item: EpisodeItem) => void) {
-      this.episodeItems.forEach(action)
-    },
     async getEpisodeItems() {
       if (this.episodeItems.length > 0) {
         return
@@ -219,6 +204,8 @@ export default Vue.extend({
 </script>
 <style lang="scss">
 @import 'common';
+// 折叠高度与箭头旋转共用同一节奏, 保证两者协调
+$collapse-transition: 0.25s cubic-bezier(0.4, 0, 0.2, 1);
 .episodes-picker {
   &-header {
     @include h-center();
@@ -269,7 +256,7 @@ export default Vue.extend({
       flex-shrink: 0;
       margin-right: 2px;
       opacity: 0.7;
-      transition: transform 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+      transition: transform $collapse-transition;
     }
     &.collapsed &-toggle {
       transform: rotate(-90deg);
@@ -292,9 +279,6 @@ export default Vue.extend({
       }
     }
   }
-  &-section-items {
-    overflow: hidden;
-  }
   &-empty {
     @include h-center();
     justify-content: center;
@@ -303,7 +287,8 @@ export default Vue.extend({
 }
 .episodes-picker-collapse-enter-active,
 .episodes-picker-collapse-leave-active {
-  transition: height 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+  overflow: hidden;
+  transition: height $collapse-transition;
 }
 .episodes-picker-collapse-enter,
 .episodes-picker-collapse-leave-to {

--- a/registry/lib/components/video/download/inputs/EpisodesPicker.vue
+++ b/registry/lib/components/video/download/inputs/EpisodesPicker.vue
@@ -36,22 +36,73 @@
       <div v-if="episodeItems.length === 0" class="episodes-picker-empty">
         <VEmpty />
       </div>
-      <div v-for="(item, index) of episodeItems" :key="item.key" class="episodes-picker-item">
-        <CheckBox
-          v-model="item.isChecked"
-          icon-position="left"
-          :data-aid="item.inputItem.aid"
-          :data-cid="item.inputItem.cid"
-          :data-bvid="item.inputItem.bvid"
-          @click.native="shiftSelect($event, item, index)"
+      <div v-for="(section, sectionIndex) of episodeSections" :key="sectionIndex">
+        <div
+          v-if="section.title"
+          class="episodes-picker-section"
+          :class="{ collapsed: section.isCollapsed }"
+          :title="section.title"
+          @click="toggleSection(section)"
         >
-          <span class="episode-title">
-            {{ item.title }}
-          </span>
-          <span v-if="item.durationText" class="episode-duration">
-            {{ item.durationText }}
-          </span>
-        </CheckBox>
+          <VIcon class="episodes-picker-section-toggle" :size="14" icon="mdi-chevron-down" />
+          <span class="episodes-picker-section-title">{{ section.title }}</span>
+          <span class="episodes-picker-section-ratio">{{ getSectionCheckedRatio(section) }}</span>
+          <VButton
+            class="select-section"
+            title="全选此子合集"
+            type="transparent"
+            @click.stop="setSectionChecked(section, true)"
+          >
+            <VIcon :size="14" icon="mdi-checkbox-multiple-marked-circle" />
+          </VButton>
+          <VButton
+            class="deselect-section"
+            title="全不选此子合集"
+            type="transparent"
+            @click.stop="setSectionChecked(section, false)"
+          >
+            <VIcon :size="14" icon="mdi-checkbox-multiple-blank-circle-outline" />
+          </VButton>
+          <VButton
+            class="invert-section"
+            title="反选此子合集"
+            type="transparent"
+            @click.stop="invertSectionChecked(section)"
+          >
+            <VIcon :size="14" icon="mdi-circle-slice-4" />
+          </VButton>
+        </div>
+        <transition
+          name="episodes-picker-collapse"
+          @enter="onSectionTransitionStart"
+          @leave="onSectionTransitionStart"
+          @after-enter="onSectionTransitionEnd"
+          @after-leave="onSectionTransitionEnd"
+        >
+          <div v-show="!section.isCollapsed" class="episodes-picker-section-items">
+            <div
+              v-for="entry of section.entries"
+              :key="entry.item.key"
+              class="episodes-picker-item"
+            >
+              <CheckBox
+                v-model="entry.item.isChecked"
+                icon-position="left"
+                :data-aid="entry.item.inputItem.aid"
+                :data-cid="entry.item.inputItem.cid"
+                :data-bvid="entry.item.inputItem.bvid"
+                @click.native="shiftSelect($event, entry.item, entry.index)"
+              >
+                <span class="episode-title">
+                  {{ entry.item.title }}
+                </span>
+                <span v-if="entry.item.durationText" class="episode-duration">
+                  {{ entry.item.durationText }}
+                </span>
+              </CheckBox>
+            </div>
+          </div>
+        </transition>
       </div>
     </div>
   </div>
@@ -59,6 +110,29 @@
 <script lang="ts">
 import { VButton, VIcon, CheckBox, VEmpty } from '@/ui'
 import { EpisodeItem } from './episode-item'
+
+interface EpisodeSectionEntry {
+  item: EpisodeItem
+  index: number
+}
+interface EpisodeSection {
+  title?: string
+  isCollapsed: boolean
+  entries: EpisodeSectionEntry[]
+}
+
+const buildEpisodeSections = (items: EpisodeItem[]) => {
+  const sections: EpisodeSection[] = []
+  items.forEach((item, index) => {
+    const lastSection = sections[sections.length - 1]
+    if (lastSection !== undefined && lastSection.title === item.sectionTitle) {
+      lastSection.entries.push({ item, index })
+      return
+    }
+    sections.push({ title: item.sectionTitle, isCollapsed: false, entries: [{ item, index }] })
+  })
+  return sections
+}
 
 export default Vue.extend({
   components: {
@@ -75,7 +149,8 @@ export default Vue.extend({
   },
   data() {
     return {
-      episodeItems: [],
+      episodeItems: [] as EpisodeItem[],
+      episodeSections: [] as EpisodeSection[],
       maxCheckedItems: 32,
       lastCheckedEpisodeIndex: -1,
     }
@@ -97,6 +172,30 @@ export default Vue.extend({
     this.getEpisodeItems()
   },
   methods: {
+    // 展开/折叠前固定为内容高度, 结束值由 CSS 类提供
+    onSectionTransitionStart(el: HTMLElement) {
+      el.style.height = `${el.scrollHeight}px`
+    },
+    onSectionTransitionEnd(el: HTMLElement) {
+      el.style.height = ''
+    },
+    toggleSection(section: EpisodeSection) {
+      section.isCollapsed = !section.isCollapsed
+    },
+    getSectionCheckedRatio(section: EpisodeSection) {
+      const checked = section.entries.filter(it => it.item.isChecked).length
+      return `(${checked}/${section.entries.length})`
+    },
+    setSectionChecked(section: EpisodeSection, isChecked: boolean) {
+      section.entries.forEach(it => {
+        it.item.isChecked = isChecked
+      })
+    },
+    invertSectionChecked(section: EpisodeSection) {
+      section.entries.forEach(it => {
+        it.item.isChecked = !it.item.isChecked
+      })
+    },
     shiftSelect(e: MouseEvent, item: EpisodeItem, index: number) {
       if (!e.shiftKey || this.lastCheckedEpisodeIndex === -1) {
         // console.log('set lastCheckedEpisodeIndex', index)
@@ -129,7 +228,9 @@ export default Vue.extend({
       if (this.episodeItems.length > 0) {
         return
       }
-      this.episodeItems = await this.api(this)
+      const items: EpisodeItem[] = await this.api(this)
+      this.episodeItems = items
+      this.episodeSections = buildEpisodeSections(items)
     },
   },
 })
@@ -175,10 +276,55 @@ export default Vue.extend({
       opacity: 0.5;
     }
   }
+  &-section {
+    @include h-center();
+    padding: 4px 6px;
+    background-color: #8882;
+    border-bottom: 1px solid #8882;
+    cursor: pointer;
+    user-select: none;
+    &-toggle {
+      flex-shrink: 0;
+      margin-right: 2px;
+      opacity: 0.7;
+      transition: transform 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+    }
+    &.collapsed &-toggle {
+      transform: rotate(-90deg);
+    }
+    &-title {
+      flex: 1 1 0;
+      min-width: 0;
+      @include single-line();
+      @include semi-bold();
+    }
+    &-ratio {
+      margin-left: 4px;
+      opacity: 0.5;
+    }
+    .be-button {
+      padding: 2px;
+      margin-left: 2px;
+      .be-icon {
+        transform: translateY(1px);
+      }
+    }
+  }
+  &-section-items {
+    overflow: hidden;
+  }
   &-empty {
     @include h-center();
     justify-content: center;
     padding: 4px 0;
   }
+}
+.episodes-picker-collapse-enter-active,
+.episodes-picker-collapse-leave-active {
+  transition: height 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+}
+.episodes-picker-collapse-enter,
+.episodes-picker-collapse-leave-to {
+  height: 0 !important;
 }
 </style>

--- a/registry/lib/components/video/download/inputs/EpisodesPicker.vue
+++ b/registry/lib/components/video/download/inputs/EpisodesPicker.vue
@@ -237,6 +237,15 @@ $collapse-transition: 0.25s cubic-bezier(0.4, 0, 0.2, 1);
     }
     .be-check-box {
       padding: 2px 6px;
+      // VButton 的 .content-container 也会阻止收缩, 需一并放开
+      .content-container,
+      .text-container {
+        min-width: 0;
+      }
+    }
+    .episode-title {
+      min-width: 0;
+      overflow-wrap: break-word;
     }
     .episode-duration {
       margin-right: 4px;

--- a/registry/lib/components/video/download/inputs/EpisodesPicker.vue
+++ b/registry/lib/components/video/download/inputs/EpisodesPicker.vue
@@ -51,7 +51,7 @@
             class="select-section"
             title="全选此子合集"
             type="transparent"
-            @click.stop="setSectionChecked(section, true)"
+            @click.stop="forEachSectionItem(section, it => (it.isChecked = true))"
           >
             <VIcon :size="14" icon="mdi-checkbox-multiple-marked-circle" />
           </VButton>
@@ -59,7 +59,7 @@
             class="deselect-section"
             title="全不选此子合集"
             type="transparent"
-            @click.stop="setSectionChecked(section, false)"
+            @click.stop="forEachSectionItem(section, it => (it.isChecked = false))"
           >
             <VIcon :size="14" icon="mdi-checkbox-multiple-blank-circle-outline" />
           </VButton>
@@ -67,7 +67,7 @@
             class="invert-section"
             title="反选此子合集"
             type="transparent"
-            @click.stop="invertSectionChecked(section)"
+            @click.stop="forEachSectionItem(section, it => (it.isChecked = !it.isChecked))"
           >
             <VIcon :size="14" icon="mdi-circle-slice-4" />
           </VButton>
@@ -80,24 +80,20 @@
           @after-leave="onSectionTransitionEnd"
         >
           <div v-show="!section.isCollapsed" class="episodes-picker-section-items">
-            <div
-              v-for="entry of section.entries"
-              :key="entry.item.key"
-              class="episodes-picker-item"
-            >
+            <div v-for="item of section.entries" :key="item.key" class="episodes-picker-item">
               <CheckBox
-                v-model="entry.item.isChecked"
+                v-model="item.isChecked"
                 icon-position="left"
-                :data-aid="entry.item.inputItem.aid"
-                :data-cid="entry.item.inputItem.cid"
-                :data-bvid="entry.item.inputItem.bvid"
-                @click.native="shiftSelect($event, entry.item, entry.index)"
+                :data-aid="item.inputItem.aid"
+                :data-cid="item.inputItem.cid"
+                :data-bvid="item.inputItem.bvid"
+                @click.native="shiftSelect($event, item)"
               >
                 <span class="episode-title">
-                  {{ entry.item.title }}
+                  {{ item.title }}
                 </span>
-                <span v-if="entry.item.durationText" class="episode-duration">
-                  {{ entry.item.durationText }}
+                <span v-if="item.durationText" class="episode-duration">
+                  {{ item.durationText }}
                 </span>
               </CheckBox>
             </div>
@@ -111,25 +107,21 @@
 import { VButton, VIcon, CheckBox, VEmpty } from '@/ui'
 import { EpisodeItem } from './episode-item'
 
-interface EpisodeSectionEntry {
-  item: EpisodeItem
-  index: number
-}
 interface EpisodeSection {
   title?: string
   isCollapsed: boolean
-  entries: EpisodeSectionEntry[]
+  entries: EpisodeItem[]
 }
 
-const buildEpisodeSections = (items: EpisodeItem[]) => {
+const buildEpisodeSections = (items: EpisodeItem[]): EpisodeSection[] => {
   const sections: EpisodeSection[] = []
-  items.forEach((item, index) => {
-    const lastSection = sections[sections.length - 1]
-    if (lastSection !== undefined && lastSection.title === item.sectionTitle) {
-      lastSection.entries.push({ item, index })
-      return
+  let lastSection: EpisodeSection | undefined
+  items.forEach(item => {
+    if (lastSection === undefined || lastSection.title !== item.sectionTitle) {
+      lastSection = { title: item.sectionTitle, isCollapsed: false, entries: [] }
+      sections.push(lastSection)
     }
-    sections.push({ title: item.sectionTitle, isCollapsed: false, entries: [{ item, index }] })
+    lastSection.entries.push(item)
   })
   return sections
 }
@@ -157,15 +149,14 @@ export default Vue.extend({
   },
   computed: {
     checkedRatio() {
-      const checked: number = this.episodeItems.filter((it: EpisodeItem) => it.isChecked).length
+      const checked = this.episodeItems.filter(it => it.isChecked).length
       return `(${checked}/${this.episodeItems.length})`
     },
     inputItems() {
-      return this.episodeItems.map((it: EpisodeItem) => it.inputItem)
+      return this.episodeItems.map(it => it.inputItem)
     },
     checkedInputItems() {
-      const items: EpisodeItem[] = this.episodeItems
-      return items.filter(it => it.isChecked).map(it => it.inputItem)
+      return this.episodeItems.filter(it => it.isChecked).map(it => it.inputItem)
     },
   },
   created() {
@@ -183,46 +174,37 @@ export default Vue.extend({
       section.isCollapsed = !section.isCollapsed
     },
     getSectionCheckedRatio(section: EpisodeSection) {
-      const checked = section.entries.filter(it => it.item.isChecked).length
-      return `(${checked}/${section.entries.length})`
+      const { entries } = section
+      return `(${entries.filter(it => it.isChecked).length}/${entries.length})`
     },
-    setSectionChecked(section: EpisodeSection, isChecked: boolean) {
-      section.entries.forEach(it => {
-        it.item.isChecked = isChecked
-      })
+    forEachSectionItem(section: EpisodeSection, action: (item: EpisodeItem) => void) {
+      section.entries.forEach(action)
     },
-    invertSectionChecked(section: EpisodeSection) {
-      section.entries.forEach(it => {
-        it.item.isChecked = !it.item.isChecked
-      })
-    },
-    shiftSelect(e: MouseEvent, item: EpisodeItem, index: number) {
+    shiftSelect(e: MouseEvent, item: EpisodeItem) {
+      const index = this.episodeItems.indexOf(item)
       if (!e.shiftKey || this.lastCheckedEpisodeIndex === -1) {
         // console.log('set lastCheckedEpisodeIndex', index)
         this.lastCheckedEpisodeIndex = index
         return
       }
-      if (e.shiftKey && this.lastCheckedEpisodeIndex !== -1) {
-        ;(this.episodeItems as EpisodeItem[])
-          .slice(
-            Math.min(this.lastCheckedEpisodeIndex, index) + 1,
-            Math.max(this.lastCheckedEpisodeIndex, index),
-          )
-          .forEach(it => {
-            it.isChecked = !it.isChecked
-          })
-        // console.log(
-        //   'shift toggle',
-        //   Math.min(this.lastCheckedEpisodeIndex, index) + 1,
-        //   Math.max(this.lastCheckedEpisodeIndex, index),
-        // )
-        this.lastCheckedEpisodeIndex = index
-        e.preventDefault()
-      }
+      this.episodeItems
+        .slice(
+          Math.min(this.lastCheckedEpisodeIndex, index) + 1,
+          Math.max(this.lastCheckedEpisodeIndex, index),
+        )
+        .forEach(it => {
+          it.isChecked = !it.isChecked
+        })
+      // console.log(
+      //   'shift toggle',
+      //   Math.min(this.lastCheckedEpisodeIndex, index) + 1,
+      //   Math.max(this.lastCheckedEpisodeIndex, index),
+      // )
+      this.lastCheckedEpisodeIndex = index
+      e.preventDefault()
     },
-    forEachItem(action: (item: EpisodeItem, index: number) => void) {
-      const items: EpisodeItem[] = this.episodeItems
-      items.forEach(action)
+    forEachItem(action: (item: EpisodeItem) => void) {
+      this.episodeItems.forEach(action)
     },
     async getEpisodeItems() {
       if (this.episodeItems.length > 0) {

--- a/registry/lib/components/video/download/inputs/episode-item.ts
+++ b/registry/lib/components/video/download/inputs/episode-item.ts
@@ -7,7 +7,7 @@ export interface EpisodeItem {
   isChecked: boolean
   inputItem: DownloadVideoInputItem
   durationText?: string
-  /** 所属子合集标题, 用于在选集中分组显示, 为空时不显示分组 */
+  /** 所属子合集标题, 用于选集中分组显示 */
   sectionTitle?: string
 }
 export const createEpisodesPicker = (

--- a/registry/lib/components/video/download/inputs/episode-item.ts
+++ b/registry/lib/components/video/download/inputs/episode-item.ts
@@ -7,6 +7,8 @@ export interface EpisodeItem {
   isChecked: boolean
   inputItem: DownloadVideoInputItem
   durationText?: string
+  /** 所属子合集标题, 用于在选集中分组显示, 为空时不显示分组 */
+  sectionTitle?: string
 }
 export const createEpisodesPicker = (
   fetchEpisodeItems: (instance: any) => Promise<EpisodeItem[]>,

--- a/registry/lib/components/video/download/inputs/video/batch.ts
+++ b/registry/lib/components/video/download/inputs/video/batch.ts
@@ -81,8 +81,7 @@ export const videoSeasonBatchInput: DownloadVideoInput = {
         [],
       )
       const validSections = sections.filter(
-        (section): section is { title?: string; episodes: any[] } =>
-          (section.episodes?.length ?? 0) > 0,
+        (section): section is { title?: string; episodes: any[] } => !!section.episodes?.length,
       )
       if (validSections.length === 0) {
         return []

--- a/registry/lib/components/video/download/inputs/video/batch.ts
+++ b/registry/lib/components/video/download/inputs/video/batch.ts
@@ -75,16 +75,28 @@ export const videoSeasonBatchInput: DownloadVideoInput = {
         return []
       }
       const owner = lodash.get(json, 'data.View.owner', {})
-      const sections: { episodes: any[] }[] = lodash.get(json, 'data.View.ugc_season.sections', [])
-      if (sections.length === 0) {
+      const sections: { title?: string; episodes?: any[] }[] = lodash.get(
+        json,
+        'data.View.ugc_season.sections',
+        [],
+      )
+      const validSections = sections.filter(
+        (section): section is { title?: string; episodes: any[] } =>
+          (section.episodes?.length ?? 0) > 0,
+      )
+      if (validSections.length === 0) {
         return []
       }
-      const totalEpisodesLength = lodash.sumBy(sections, it => it.episodes.length)
-      return sections.flatMap((section, sectionIndex) => {
-        const { episodes = [] } = section
+      // 存在多个子合集时才需要显示分组标题以区分
+      const showSectionTitle = validSections.length > 1
+      const totalEpisodesLength = lodash.sumBy(validSections, it => it.episodes.length)
+      return validSections.flatMap((section, sectionIndex) => {
+        const { episodes } = section
+        const sectionTitle = showSectionTitle ? section.title : undefined
         return episodes.map((episode, episodeIndex) => {
           const currentIndex =
-            episodeIndex + lodash.sumBy(sections.slice(0, sectionIndex), it => it.episodes.length)
+            episodeIndex +
+            lodash.sumBy(validSections.slice(0, sectionIndex), it => it.episodes.length)
           const key = episode.cid
           const page = currentIndex + 1
           const title = `P${page} ${episode.title}`
@@ -94,6 +106,7 @@ export const videoSeasonBatchInput: DownloadVideoInput = {
             title,
             isChecked: currentIndex < instance.maxCheckedItems,
             durationText: formatDuration(episode.arc.duration),
+            sectionTitle,
             inputItem: {
               allowQualityDrop: true,
               title: formatTitle(getGeneralSettings().batchFilenameFormat, false, {

--- a/registry/lib/components/video/download/inputs/video/batch.ts
+++ b/registry/lib/components/video/download/inputs/video/batch.ts
@@ -89,21 +89,16 @@ export const videoSeasonBatchInput: DownloadVideoInput = {
       // 存在多个子合集时才需要显示分组标题以区分
       const showSectionTitle = validSections.length > 1
       const totalEpisodesLength = lodash.sumBy(validSections, it => it.episodes.length)
-      return validSections.flatMap((section, sectionIndex) => {
-        const { episodes } = section
+      let page = 0
+      return validSections.flatMap(section => {
         const sectionTitle = showSectionTitle ? section.title : undefined
-        return episodes.map((episode, episodeIndex) => {
-          const currentIndex =
-            episodeIndex +
-            lodash.sumBy(validSections.slice(0, sectionIndex), it => it.episodes.length)
-          const key = episode.cid
-          const page = currentIndex + 1
-          const title = `P${page} ${episode.title}`
+        return section.episodes.map(episode => {
+          page += 1
           const date = getTitleVariablesFromDate(new Date(episode.arc.pubdate * 1000))
           return {
-            key,
-            title,
-            isChecked: currentIndex < instance.maxCheckedItems,
+            key: episode.cid,
+            title: `P${page} ${episode.title}`,
+            isChecked: page <= instance.maxCheckedItems,
             durationText: formatDuration(episode.arc.duration),
             sectionTitle,
             inputItem: {


### PR DESCRIPTION
#5227
效果如图，允许分别全选 / 全不选 / 反选 / 折叠子合集。
<img width="330" height="544" alt="image" src="https://github.com/user-attachments/assets/1c467e35-135c-4918-8283-72f0f75a288f" />

活动 (festival) 页右侧的栏目实际上也是子合集，刚好适配了。
<img width="1920" height="919" alt="image" src="https://github.com/user-attachments/assets/87811185-802a-4d30-bd1e-c7167d97eea8" />
