### PR TITLE
调整自定义顶栏漫画封面以使用 HTTPS

### DIFF
--- a/registry/lib/components/style/custom-navbar/manga/MangaPopup.vue
+++ b/registry/lib/components/style/custom-navbar/manga/MangaPopup.vue
@@ -77,7 +77,10 @@ defineExpose({
           :href="'https://manga.bilibili.com/detail/mc' + card.season_id"
         >
           <div class="recommend-manga-card-image">
-            <img :src="card.horizontal_cover + '@300w.jpg'" :alt="card.title" />
+            <img
+              :src="(card.horizontal_cover + '@300w.jpg').replace(/^http:/, 'https:')"
+              :alt="card.title"
+            />
           </div>
           <div class="recommend-manga-card-title" :title="card.title">{{ card.title }}</div>
         </a>
@@ -101,7 +104,10 @@ defineExpose({
           </a>
         </div>
         <div v-if="previewCard" class="hot-manga-card-preview">
-          <img :src="previewCard.vertical_cover + '@450h.jpg'" :alt="previewCard.title" />
+          <img
+            :src="(previewCard.vertical_cover + '@450h.jpg').replace(/^http:/, 'https:')"
+            :alt="previewCard.title"
+          />
         </div>
       </div>
     </div>


### PR DESCRIPTION
自定义顶栏的漫画接口有时返回 HTTP 封面地址。在 HTTPS 页面打开漫画弹窗后，Chrome 会自动升级图片请求，并提示混合内容。

此修改在生成图片 `src` 时，将开头的 `http:` 替换为 `https:`，覆盖推荐缩略图和人气漫画的悬浮预览，保留原有尺寸后缀、链接和加载逻辑。

当接口返回 HTTP 地址时：

| 图片 | 修改前的 `src` | 修改后的 `src` |
| --- | --- | --- |
| 推荐缩略图 | HTTP，后缀 `@300w.jpg` | HTTPS，后缀不变 |
| 人气漫画悬浮预览 | HTTP，后缀 `@450h.jpg` | HTTPS，后缀不变 |

复现方式：

1. 启用自定义顶栏，在动态页打开“漫画”弹窗。
2. 当接口返回 HTTP 封面时，检查图片元素的 `src`：原来仍是 HTTP，请求由浏览器升级为 HTTPS。

验证情况：

- `pnpm run check-pr-files upstream/preview-fixes...HEAD`、`pnpm run type`、`pnpm run lint-check` 通过。
- 开发服务单独编译 `style/custom-navbar` 通过。
- 在 Chrome / Tampermonkey 中加载本地组件后，原来使用 HTTP 的三张推荐图改为 HTTPS；四张推荐图及悬浮预览均成功加载。
- 使用实际 Vue 2 模板对照检查了推荐图和预览图的 HTTP 输入；已有 HTTPS、协议相对地址及原有尺寸后缀保持不变。

浏览器自测使用动态页及 Bilibili Evolved Preview `v2.11.3-preview-274-g1bfd94835` 本体。
