### PR TITLE
为动态过滤的板块开关补充键盘支持

### DIFF
--- a/registry/lib/components/feeds/filter/FilterSideCard.vue
+++ b/registry/lib/components/feeds/filter/FilterSideCard.vue
@@ -1,10 +1,17 @@
 <template>
-  <div class="filter-side-card-switch feeds-filter-switch" v-on="$listeners">
-    <label :class="{ disabled }">
+  <div class="filter-side-card-switch feeds-filter-switch">
+    <button
+      type="button"
+      class="filter-side-card-button"
+      :class="{ disabled }"
+      :aria-label="`显示${name}`"
+      :aria-pressed="disabled ? 'false' : 'true'"
+      v-on="$listeners"
+    >
       <span class="name" :class="{ disabled }">{{ name }}</span>
-      <VIcon :size="16" class="disabled" icon="mdi-cancel"></VIcon>
-      <VIcon :size="16" icon="mdi-check"></VIcon>
-    </label>
+      <VIcon :size="16" class="disabled" icon="mdi-cancel" aria-hidden="true"></VIcon>
+      <VIcon :size="16" icon="mdi-check" aria-hidden="true"></VIcon>
+    </button>
   </div>
 </template>
 <script setup lang="ts">

--- a/registry/lib/components/feeds/filter/FilterTypeSwitch.vue
+++ b/registry/lib/components/feeds/filter/FilterTypeSwitch.vue
@@ -55,7 +55,21 @@ watch(
   &:not(:last-child) {
     margin-bottom: 4px;
   }
-  label {
+  > .filter-side-card-button {
+    width: 100%;
+    box-sizing: border-box;
+    font: inherit;
+    color: inherit;
+    text-align: inherit;
+    background-color: transparent;
+
+    &:focus-visible {
+      outline: 2px solid var(--theme-color);
+      outline-offset: 2px;
+    }
+  }
+  label,
+  > .filter-side-card-button {
     cursor: pointer;
     margin: 0;
     padding: 4px 6px;


### PR DESCRIPTION
动态过滤的“板块”开关使用未关联表单控件的 `label`，Chrome 会提示标签问题，这些开关也无法通过 Tab、Enter 和空格键操作。

此修改将板块开关改为 `type="button"` 的原生按钮，保留原有点击处理和保存设置的逻辑，并补充名称、`aria-pressed` 状态和键盘焦点样式。按下状态表示对应板块显示；隐藏后仍可操作按钮以恢复显示。

`aria-pressed` 使用 `'true'` / `'false'` 字符串，避免 Vue 2 在值为布尔 `false` 时移除属性；装饰图标设为 `aria-hidden="true"`。

| 操作或状态 | 修改前 | 修改后 |
| --- | --- | --- |
| Tab 导航 | 跳过板块开关 | 可逐个聚焦，并显示焦点轮廓 |
| Enter / 空格 | 无原生键盘操作 | 切换对应板块一次 |
| 板块隐藏 | 无按下状态属性 | `aria-pressed="false"`，按钮仍可操作 |

复现方式：

1. 在动态页启用并展开“动态过滤”。
2. 使用 Tab 尝试进入“板块”中的开关。原来的标签会被跳过；修改后可以聚焦，并通过 Enter 或空格切换。

验证情况：

- `pnpm run check-pr-files upstream/preview-fixes...HEAD`、`pnpm run type`、`pnpm run lint-check` 通过。
- 开发服务单独编译 `feeds/filter` 通过。
- 在 Chrome / Tampermonkey 中加载本地组件，检查当前配置的五个板块开关：鼠标、Tab、Enter、空格及显示/隐藏状态正常。
- 检查刷新后的设置保留、侧栏与组件设置页同步、组件关闭后重新启用，以及相邻类型过滤的切换。
- 对照检查控件尺寸、浅色/深色焦点、显式 `false` 状态，以及文字/图标点击和键盘操作的单次事件处理。

浏览器自测使用动态页及 Bilibili Evolved Preview `v2.11.3-preview-274-g1bfd94835` 本体。本次修改范围为“板块”开关。
